### PR TITLE
adds emacs launchd service

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,7 @@ let
         ./modules/services/activate-system.nix
         ./modules/services/khd.nix
         ./modules/services/kwm.nix
+        ./modules/services/emacs.nix
         ./modules/services/nix-daemon.nix
         ./modules/programs/bash.nix
         ./modules/programs/fish.nix

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.emacs;
+
+in
+
+{
+  options = {
+    services.emacs = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the Emacs Daemon.";
+      };
+
+      package = mkOption {
+        type = types.path;
+        default = pkgs.emacs;
+        description = "This option specifies the emacs package to use.";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    launchd.user.agents.emacs = {
+      serviceConfig.ProgramArguments = [
+        "${cfg.package}/bin/emacs"
+        "--daemon"
+      ];
+      serviceConfig.RunAtLoad = true;
+    };
+
+  };
+}


### PR DESCRIPTION
Adds an expression (compatible w/ linux counterpart) for starting emacs daemon as a launchd service.