### PR TITLE
Adds mopidy service with media keys support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,7 @@ let
         ./modules/services/khd.nix
         ./modules/services/kwm.nix
         ./modules/services/emacs.nix
+        ./modules/services/mopidy.nix
         ./modules/services/nix-daemon.nix
         ./modules/services/nix-gc.nix
         ./modules/programs/bash.nix

--- a/modules/services/mopidy.nix
+++ b/modules/services/mopidy.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.mopidy;
+
+in
+
+{
+  options = {
+    services.mopidy = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the Mopidy Daemon.";
+      };
+
+      package = mkOption {
+        type = types.path;
+        default = pkgs.mopidy;
+        description = "This option specifies the mopidy package to use.";
+      };
+
+      mediakeys = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to enable the Mopidy OSX Media Keys support daemon.";
+        };
+        package = mkOption {
+          type = types.path;
+          default = pkgs.pythonPackages.osxmpdkeys;
+          description = "This option specifies the mediakeys package to use.";
+        };
+      };
+
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      launchd.user.agents.mopidy = {
+        serviceConfig.Program = "${cfg.package}/bin/mopidy";
+        serviceConfig.RunAtLoad = true;
+        serviceConfig.KeepAlive = true;
+        serviceConfig.ProcessType = "Adaptive";
+      };
+    })
+    (mkIf cfg.mediakeys.enable {
+      launchd.user.agents.mopidymediakeys = {
+        serviceConfig.Program = "${cfg.package}/bin/mpdkeys";
+        serviceConfig.RunAtLoad = true;
+        serviceConfig.KeepAlive = true;
+        serviceConfig.ProcessType = "Interactive";
+      };
+    })
+  ];
+}


### PR DESCRIPTION
Basic support for mopidy service along with media keys support service.
Currently the mopidy installation via nix is broken, therefore set the default packages to `/usr/local`.

Have a look if that's something you're ok with including :)