### PR TITLE
Don't put profiles in reverse-order in PATH

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -33,7 +33,7 @@ in {
 
     environment.systemPath = mkOption {
       type = types.loeOf types.path;
-      default = (reverseList cfg.profiles) ++ [ "/usr/local" "/usr" "" ];
+      default = cfg.profiles ++ [ "/usr/local" "/usr" "" ];
       description = "The set of paths that are added to PATH.";
       apply = x: if isList x then makeBinPath x else x;
     };


### PR DESCRIPTION
Your user-specific profile should take precedence over the system one. If I've gone out of my way to install something into my personal profile, my version should be used instead of the system's.