### PR TITLE
Default outputs should include "man"

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -51,7 +51,7 @@ in {
 
     environment.extraOutputsToInstall = mkOption {
       type = types.listOf types.str;
-      default = [ ];
+      default = [ "man" ];
       example = [ "doc" "info" "devdoc" ];
       description = "List of additional package outputs to be symlinked into <filename>/run/current-system/sw</filename>.";
     };


### PR DESCRIPTION
If you don't include "man", basic nix commands (e.g. nix-env) basically have broken help/usage text, since they delegate to calling man.