### PR TITLE
Make symlink within ~/Applications if it exists instead of skipping

### DIFF
--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -26,8 +26,10 @@ in
 
       if [ ! -e ~/Applications -o -L ~/Applications ]; then
         ln -sfn ${cfg.build.applications}/Applications ~/Applications
+      elif [ ! -e ~/Applications/Nix\ Apps -o -L ~/Applications/Nix\ Apps ]; then
+        ln -sfn ${cfg.build.applications}/Applications ~/Applications/Nix\ Apps
       else
-        echo "warning: ~/Applications is a directory, skipping..." >&2
+        echo "warning: ~/Applications and ~/Applications/Nix Apps are directories, skipping App linking..." >&2
       fi
     '';
 


### PR DESCRIPTION
This allows you to easily browse and spotlight-search Nix apps without having to give your entire `~/Applications` over to Nix.