### PR TITLE
Preserve existing PATH in generated zshrc

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -176,7 +176,7 @@ in
 
       setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
 
-      export PATH=${config.environment.systemPath}
+      export PATH=${config.environment.systemPath}:$PATH
       ${config.system.build.setEnvironment}
       ${config.system.build.setAliases}
 


### PR DESCRIPTION
Currently sourcing the generated zshrc in my existing dotfiles breaks my `PATH`
environment variable. This change allows me to source the generated file and
preserve the existing `PATH` value.