### PR TITLE
Adds parameter for emacs package binary

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -24,6 +24,12 @@ in
         description = "This option specifies the emacs package to use.";
       };
 
+      exec = mkOption {
+        type = types.str ;
+        default = "emacs";
+        description = "Executable emacs command";
+      };
+
     };
   };
 
@@ -31,7 +37,7 @@ in
 
     launchd.user.agents.emacs = {
       serviceConfig.ProgramArguments = [
-        "${cfg.package}/bin/emacs"
+        "${cfg.package}/bin/${cfg.exec}"
         "--daemon"
       ];
       serviceConfig.RunAtLoad = true;


### PR DESCRIPTION
The motivation is that emacs binary is now well... remacs. Can alias it to emacs, but will impact readability when listing processes.