### PR TITLE
Adds service.emacs.exec to choose emacs binary to execute

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -24,6 +24,11 @@ in
         description = "This option specifies the emacs package to use.";
       };
 
+      exec = mkOption {
+        type = types.string;
+        default = "emacs";
+        description = "Emacs command/binary to exeucte";
+      };
     };
   };
 
@@ -31,7 +36,7 @@ in
 
     launchd.user.agents.emacs = {
       serviceConfig.ProgramArguments = [
-        "${cfg.package}/bin/emacs"
+        "${cfg.package}/bin/${cfg.exec}"
         "--daemon"
       ];
       serviceConfig.RunAtLoad = true;


### PR DESCRIPTION
The motivation of the change is that some forks (ie. Wilfred/remacs)
choose not to use the emacs binary. Whereas it is perfectly possible
to generate /bin/emacs in a drv, but I strongly believe it's cleaner
to have a service parameter.