### PR TITLE
Improve trackpad settings support

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -23,7 +23,8 @@ let
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
-  trackpad = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
+  trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
+  trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
 
 in
 
@@ -42,6 +43,7 @@ in
       ${concatStringsSep "\n" dock}
       ${concatStringsSep "\n" finder}
       ${concatStringsSep "\n" trackpad}
+      ${concatStringsSep "\n" trackpadBluetooth}
     '';
 
   };

--- a/modules/system/defaults/default.nix
+++ b/modules/system/defaults/default.nix
@@ -20,7 +20,8 @@ let
   global = defaultsToList "-g" cfg.global;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
-  trackpad = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
+  trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
+  trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
 
 in
@@ -39,6 +40,7 @@ in
       ${concatStringsSep "\n" dock}
       ${concatStringsSep "\n" finder}
       ${concatStringsSep "\n" trackpad}
+      ${concatStringsSep "\n" trackpadBluetooth}
       ${concatStringsSep "\n" LaunchServices}
     '';
 

--- a/modules/system/defaults/trackpad.nix
+++ b/modules/system/defaults/trackpad.nix
@@ -21,5 +21,13 @@ with lib;
       '';
     };
 
+    system.defaults.trackpad.TrackpadThreeFingerDrag = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable three finger drag.  The default is false.
+      '';
+    };
+
   };
 }


### PR DESCRIPTION
- Write trackpad settings to both `com.apple.AppleMultitouchTrackpad` and `com.apple.driver.AppleBluetoothMultitouch.trackpad` (seems necessary for Sierra+)
- Add `TrackpadThreeFingerDrag` setting to trackpad module