### PR TITLE
tmux: play nice with iTerm2

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -73,6 +73,13 @@ in
       description = "Enable vim style keybindings for copy mode, and navigation of tmux panes.";
     };
 
+    programs.tmux.iTerm2 = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Cater to iTerm2 and its tmux integration, as appropriate.";
+    };
+
     programs.tmux.tmuxOptions = mkOption {
       internal = true;
       type = types.attrsOf (types.submodule text);
@@ -100,7 +107,7 @@ in
       source-file -q /etc/tmux.conf.local
     '';
 
-    programs.tmux.tmuxOptions.login-shell.text = if stdenv.isDarwin then ''
+    programs.tmux.tmuxOptions.login-shell.text = if stdenv.isDarwin && !cfg.iTerm2 then ''
       set -g default-command "${pkgs.reattach-to-user-namespace}/bin/reattach-to-user-namespace ${config.environment.loginShell}"
     '' else ''
       set -g default-command "${config.environment.loginShell}"


### PR DESCRIPTION
**N.B. This is quick, dirty and untested. Feel free to amend as appropriate.**


That is, don't use `reattach-to-user-namespace`. iTerm2 provides [an option](https://iterm2.com/documentation-preferences.html) to allow applications in the terminal to access the clipboard, as well as deeper [shell integration utilities](https://iterm2.com/documentation-utilities.html), which obviate the need for `reattach-to-user-namespace`. What's more, iTerm2's [tmux integration](https://iterm2.com/documentation-tmux-integration.html) doesn't work with it, [nor when `aggressive-resize` is `on`](https://github.com/tmux-plugins/tmux-sensible/issues/24).


Currently, I'm avoiding the issues by including the following in [my `darwin-configuration.nix`](https://github.com/yurrriq/dotfiles/blob/ef83f1f1e56d4000ff442c26e82ece77cc88d966/darwin-configuration.nix#L366-L372).

```nix
{
  programs.tmux.tmuxConfig = ''
    set-option -g default-command ${config.environment.loginShell}
    setw -g aggressive-resize off
    set -s escape-time 0
  '';
}
```