### PR TITLE
Add buildkite-agent module

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,6 +44,7 @@ let
         ./modules/environment
         ./modules/launchd
         ./modules/services/activate-system
+        ./modules/services/buildkite-agent.nix
         ./modules/services/chunkwm.nix
         ./modules/services/emacs.nix
         ./modules/services/khd

--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -1,0 +1,252 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.buildkite-agent;
+
+  mkHookOption = { name, description, example ? null }: {
+    inherit name;
+    value = mkOption {
+      default = null;
+      inherit description;
+      type = types.nullOr types.lines;
+    } // (if example == null then {} else { inherit example; });
+  };
+  mkHookOptions = hooks: listToAttrs (map mkHookOption hooks);
+
+  hooksDir = let
+    mkHookEntry = name: value: ''
+      cat > $out/${name} <<EOF
+      #! ${pkgs.stdenv.shell}
+      set -e
+      ${value}
+      EOF
+      chmod 755 $out/${name}
+    '';
+  in pkgs.runCommand "buildkite-agent-hooks" {} ''
+    mkdir $out
+    ${concatStringsSep "\n" (mapAttrsToList mkHookEntry (filterAttrs (n: v: v != null) cfg.hooks))}
+  '';
+
+in
+
+{
+  options = {
+    services.buildkite-agent = {
+      enable = mkEnableOption "buildkite-agent";
+
+      package = mkOption {
+        default = pkgs.buildkite-agent;
+        defaultText = "pkgs.buildkite-agent";
+        description = "Which buildkite-agent derivation to use";
+        type = types.package;
+      };
+
+      dataDir = mkOption {
+        default = "/var/lib/buildkite-agent";
+        description = "The workdir for the agent";
+        type = types.str;
+      };
+
+      runtimePackages = mkOption {
+        default = [ pkgs.bash pkgs.nix ];
+        defaultText = "[ pkgs.bash pkgs.nix ]";
+        description = "Add programs to the buildkite-agent environment";
+        type = types.listOf types.package;
+      };
+
+      tokenPath = mkOption {
+        type = types.path;
+        description = ''
+          The token from your Buildkite "Agents" page.
+
+          A run-time path to the token file, which is supposed to be provisioned
+          outside of Nix store.
+        '';
+      };
+
+      name = mkOption {
+        type = types.str;
+        default = "%hostname-%n";
+        description = ''
+          The name of the agent.
+        '';
+      };
+
+      meta-data = mkOption {
+        type = types.str;
+        default = "";
+        example = "queue=default,docker=true,ruby2=true";
+        description = ''
+          Meta data for the agent. This is a comma-separated list of
+          <code>key=value</code> pairs.
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = "debug=true";
+        description = ''
+          Extra lines to be added verbatim to the configuration file.
+        '';
+      };
+
+      openssh =
+        { privateKeyPath = mkOption {
+            type = types.path;
+            description = ''
+              Private agent key.
+
+              A run-time path to the key file, which is supposed to be provisioned
+              outside of Nix store.
+            '';
+          };
+          publicKeyPath = mkOption {
+            type = types.path;
+            description = ''
+              Public agent key.
+
+              A run-time path to the key file, which is supposed to be provisioned
+              outside of Nix store.
+            '';
+          };
+        };
+
+      hooks = mkHookOptions [
+        { name = "checkout";
+          description = ''
+            The `checkout` hook script will replace the default checkout routine of the
+            bootstrap.sh script. You can use this hook to do your own SCM checkout
+            behaviour
+          ''; }
+        { name = "command";
+          description = ''
+            The `command` hook script will replace the default implementation of running
+            the build command.
+          ''; }
+        { name = "environment";
+          description = ''
+            The `environment` hook will run before all other commands, and can be used
+            to set up secrets, data, etc. Anything exported in hooks will be available
+            to the build script.
+
+            Note: the contents of this file will be copied to the world-readable
+            Nix store.
+          '';
+          example = ''
+            export SECRET_VAR=`head -1 /run/keys/secret`
+          ''; }
+        { name = "post-artifact";
+          description = ''
+            The `post-artifact` hook will run just after artifacts are uploaded
+          ''; }
+        { name = "post-checkout";
+          description = ''
+            The `post-checkout` hook will run after the bootstrap script has checked out
+            your projects source code.
+          ''; }
+        { name = "post-command";
+          description = ''
+            The `post-command` hook will run after the bootstrap script has run your
+            build commands
+          ''; }
+        { name = "pre-artifact";
+          description = ''
+            The `pre-artifact` hook will run just before artifacts are uploaded
+          ''; }
+        { name = "pre-checkout";
+          description = ''
+            The `pre-checkout` hook will run just before your projects source code is
+            checked out from your SCM provider
+          ''; }
+        { name = "pre-command";
+          description = ''
+            The `pre-command` hook will run just before your build command runs
+          ''; }
+        { name = "pre-exit";
+          description = ''
+            The `pre-exit` hook will run just before your build job finishes
+          ''; }
+      ];
+
+      hooksPath = mkOption {
+        type = types.path;
+        default = hooksDir;
+        defaultText = "generated from services.buildkite-agent.hooks";
+        description = ''
+          Path to the directory storing the hooks.
+          Consider using <option>services.buildkite-agent.hooks.&lt;name&gt;</option>
+          instead.
+        '';
+      };
+    };
+  };
+
+  config = mkIf config.services.buildkite-agent.enable {
+    users.extraUsers.buildkite-agent =
+      { name = "buildkite-agent";
+        home = cfg.dataDir;
+        createHome = true;
+        description = "Buildkite agent user";
+        extraGroups = [ "keys" ];
+      };
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.buildkite-agent =
+      { description = "Buildkite Agent";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        path = cfg.runtimePackages ++ [ pkgs.coreutils ];
+        environment = config.networking.proxy.envVars // {
+          HOME = cfg.dataDir;
+          NIX_REMOTE = "daemon";
+        };
+
+        ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
+        ##     don't end up in the Nix store.
+        preStart = let
+          sshDir = "${cfg.dataDir}/.ssh";
+        in
+          ''
+            mkdir -m 0700 -p "${sshDir}"
+            cp -f "${toString cfg.openssh.privateKeyPath}" "${sshDir}/id_rsa"
+            cp -f "${toString cfg.openssh.publicKeyPath}"  "${sshDir}/id_rsa.pub"
+            chmod 600 "${sshDir}"/id_rsa*
+
+            cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
+            token="$(cat ${toString cfg.tokenPath})"
+            name="${cfg.name}"
+            meta-data="${cfg.meta-data}"
+            build-path="${cfg.dataDir}/builds"
+            hooks-path="${cfg.hooksPath}"
+            ${cfg.extraConfig}
+            EOF
+          '';
+
+        serviceConfig =
+          { ExecStart = "${pkgs.buildkite-agent}/bin/buildkite-agent start --config /var/lib/buildkite-agent/buildkite-agent.cfg";
+            User = "buildkite-agent";
+            RestartSec = 5;
+            Restart = "on-failure";
+            TimeoutSec = 10;
+          };
+      };
+
+    assertions = [
+      { assertion = cfg.hooksPath == hooksDir || all isNull (attrValues cfg.hooks);
+        message = ''
+          Options `services.buildkite-agent.hooksPath' and
+          `services.buildkite-agent.hooks.<name>' are mutually exclusive.
+        '';
+      }
+    ];
+  };
+  imports = [
+    (mkRenamedOptionModule [ "services" "buildkite-agent" "token" ]                [ "services" "buildkite-agent" "tokenPath" ])
+    (mkRenamedOptionModule [ "services" "buildkite-agent" "openssh" "privateKey" ] [ "services" "buildkite-agent" "openssh" "privateKeyPath" ])
+    (mkRenamedOptionModule [ "services" "buildkite-agent" "openssh" "publicKey" ]  [ "services" "buildkite-agent" "openssh" "publicKeyPath" ])
+  ];
+}

--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -33,144 +33,142 @@ in
 
 {
   options = {
-    services.buildkite-agent = {
-      enable = mkEnableOption "buildkite-agent";
+    services.buildkite-agent.enable = mkEnableOption "buildkite-agent";
 
-      package = mkOption {
-        default = pkgs.buildkite-agent;
-        defaultText = "pkgs.buildkite-agent";
-        description = "Which buildkite-agent derivation to use";
-        type = types.package;
-      };
-
-      dataDir = mkOption {
-        default = "/var/lib/buildkite-agent";
-        description = "The workdir for the agent";
-        type = types.str;
-      };
-
-      runtimePackages = mkOption {
-        default = [ pkgs.bash pkgs.nix ];
-        defaultText = "[ pkgs.bash pkgs.nix ]";
-        description = "Add programs to the buildkite-agent environment";
-        type = types.listOf types.package;
-      };
-
-      tokenPath = mkOption {
-        type = types.path;
-        description = ''
-          The token from your Buildkite "Agents" page.
-
-          A run-time path to the token file, which is supposed to be provisioned
-          outside of Nix store.
-        '';
-      };
-
-      name = mkOption {
-        type = types.str;
-        default = "%hostname-%n";
-        description = ''
-          The name of the agent.
-        '';
-      };
-
-      meta-data = mkOption {
-        type = types.str;
-        default = "";
-        example = "queue=default,docker=true,ruby2=true";
-        description = ''
-          Meta data for the agent. This is a comma-separated list of
-          <code>key=value</code> pairs.
-        '';
-      };
-
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        example = "debug=true";
-        description = ''
-          Extra lines to be added verbatim to the configuration file.
-        '';
-      };
-
-      openssh =
-        { privateKeyPath = mkOption {
-            type = types.path;
-            description = ''
-              Private agent key.
-
-              A run-time path to the key file, which is supposed to be provisioned
-              outside of Nix store.
-            '';
-          };
-          publicKeyPath = mkOption {
-            type = types.path;
-            description = ''
-              Public agent key.
-
-              A run-time path to the key file, which is supposed to be provisioned
-              outside of Nix store.
-            '';
-          };
-        };
-
-      hooks = mkHookOptions [
-        { name = "checkout";
-          description = ''
-            The `checkout` hook script will replace the default checkout routine of the
-            bootstrap.sh script. You can use this hook to do your own SCM checkout
-            behaviour
-          ''; }
-        { name = "command";
-          description = ''
-            The `command` hook script will replace the default implementation of running
-            the build command.
-          ''; }
-        { name = "environment";
-          description = ''
-            The `environment` hook will run before all other commands, and can be used
-            to set up secrets, data, etc. Anything exported in hooks will be available
-            to the build script.
-
-            Note: the contents of this file will be copied to the world-readable
-            Nix store.
-          '';
-          example = ''
-            export SECRET_VAR=`head -1 /run/keys/secret`
-          ''; }
-        { name = "post-artifact";
-          description = ''
-            The `post-artifact` hook will run just after artifacts are uploaded
-          ''; }
-        { name = "post-checkout";
-          description = ''
-            The `post-checkout` hook will run after the bootstrap script has checked out
-            your projects source code.
-          ''; }
-        { name = "post-command";
-          description = ''
-            The `post-command` hook will run after the bootstrap script has run your
-            build commands
-          ''; }
-        { name = "pre-artifact";
-          description = ''
-            The `pre-artifact` hook will run just before artifacts are uploaded
-          ''; }
-        { name = "pre-checkout";
-          description = ''
-            The `pre-checkout` hook will run just before your projects source code is
-            checked out from your SCM provider
-          ''; }
-        { name = "pre-command";
-          description = ''
-            The `pre-command` hook will run just before your build command runs
-          ''; }
-        { name = "pre-exit";
-          description = ''
-            The `pre-exit` hook will run just before your build job finishes
-          ''; }
-      ];
+    services.buildkite-agent.package = mkOption {
+      default = pkgs.buildkite-agent;
+      defaultText = "pkgs.buildkite-agent";
+      description = "Which buildkite-agent derivation to use";
+      type = types.package;
     };
+
+    services.buildkite-agent.dataDir = mkOption {
+      default = "/var/lib/buildkite-agent";
+      description = "The workdir for the agent";
+      type = types.str;
+    };
+
+    services.buildkite-agent.runtimePackages = mkOption {
+      default = [ pkgs.bash pkgs.nix ];
+      defaultText = "[ pkgs.bash pkgs.nix ]";
+      description = "Add programs to the buildkite-agent environment";
+      type = types.listOf types.package;
+    };
+
+    services.buildkite-agent.tokenPath = mkOption {
+      type = types.path;
+      description = ''
+        The token from your Buildkite "Agents" page.
+
+        A run-time path to the token file, which is supposed to be provisioned
+        outside of Nix store.
+      '';
+    };
+
+    services.buildkite-agent.name = mkOption {
+      type = types.str;
+      default = "%hostname-%n";
+      description = ''
+        The name of the agent.
+      '';
+    };
+
+    services.buildkite-agent.meta-data = mkOption {
+      type = types.str;
+      default = "";
+      example = "queue=default,docker=true,ruby2=true";
+      description = ''
+        Meta data for the agent. This is a comma-separated list of
+        <code>key=value</code> pairs.
+      '';
+    };
+
+    services.buildkite-agent.extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = "debug=true";
+      description = ''
+        Extra lines to be added verbatim to the configuration file.
+      '';
+    };
+
+    services.buildkite-agent.openssh =
+      { privateKeyPath = mkOption {
+          type = types.path;
+          description = ''
+            Private agent key.
+
+            A run-time path to the key file, which is supposed to be provisioned
+            outside of Nix store.
+          '';
+        };
+        publicKeyPath = mkOption {
+          type = types.path;
+          description = ''
+            Public agent key.
+
+            A run-time path to the key file, which is supposed to be provisioned
+            outside of Nix store.
+          '';
+        };
+      };
+
+    services.buildkite-agent.hooks = mkHookOptions [
+      { name = "checkout";
+        description = ''
+          The `checkout` hook script will replace the default checkout routine of the
+          bootstrap.sh script. You can use this hook to do your own SCM checkout
+          behaviour
+        ''; }
+      { name = "command";
+        description = ''
+          The `command` hook script will replace the default implementation of running
+          the build command.
+        ''; }
+      { name = "environment";
+        description = ''
+          The `environment` hook will run before all other commands, and can be used
+          to set up secrets, data, etc. Anything exported in hooks will be available
+          to the build script.
+
+          Note: the contents of this file will be copied to the world-readable
+          Nix store.
+        '';
+        example = ''
+          export SECRET_VAR=`head -1 /run/keys/secret`
+        ''; }
+      { name = "post-artifact";
+        description = ''
+          The `post-artifact` hook will run just after artifacts are uploaded
+        ''; }
+      { name = "post-checkout";
+        description = ''
+          The `post-checkout` hook will run after the bootstrap script has checked out
+          your projects source code.
+        ''; }
+      { name = "post-command";
+        description = ''
+          The `post-command` hook will run after the bootstrap script has run your
+          build commands
+        ''; }
+      { name = "pre-artifact";
+        description = ''
+          The `pre-artifact` hook will run just before artifacts are uploaded
+        ''; }
+      { name = "pre-checkout";
+        description = ''
+          The `pre-checkout` hook will run just before your projects source code is
+          checked out from your SCM provider
+        ''; }
+      { name = "pre-command";
+        description = ''
+          The `pre-command` hook will run just before your build command runs
+        ''; }
+      { name = "pre-exit";
+        description = ''
+          The `pre-exit` hook will run just before your build job finishes
+        ''; }
+    ];
   };
 
   config = mkIf config.services.buildkite-agent.enable {
@@ -178,25 +176,21 @@ in
       { name = "buildkite-agent";
         home = cfg.dataDir;
         description = "Buildkite agent user";
-        uid = 532;
-        gid = 532;
       };
     users.groups.buildkite-agent =
       { name = "buildkite-agent";
         description = "Buildkite agent user group";
-        gid = 532;
       };
 
     environment.systemPackages = [ cfg.package ];
 
     launchd.daemons.buildkite-agent =
       {
-        path = cfg.runtimePackages ++ [ pkgs.coreutils cfg.package ];
+        path = cfg.runtimePackages ++ [ pkgs.coreutils pkgs.darwin.DarwinTools cfg.package ];
         environment = {
           HOME = cfg.dataDir;
-          NIX_REMOTE = "daemon";
           NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-        };
+        } // (if config.nix.useDaemon then { NIX_REMOTE = "daemon"; } else {});
 
         ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
         ##     don't end up in the Nix store.
@@ -222,20 +216,21 @@ in
             chmod 750 "${cfg.dataDir}"
             chmod 640 "${cfg.dataDir}/buildkite-agent.cfg"
 
-            # Make /usr/bin/sw_vers accessible
-            export PATH=$PATH:/usr/bin
-
-            exec buildkite-agent start --config /var/lib/buildkite-agent/buildkite-agent.cfg
+            exec buildkite-agent start --config "${cfg.dataDir}/buildkite-agent.cfg"
           '';
 
-        serviceConfig.KeepAlive = true;
-        serviceConfig.RunAtLoad = true;
+        serviceConfig = {
+          KeepAlive = true;
+          RunAtLoad = true;
+          ProcessType = "Interactive";
+          ThrottleInterval = 30;
 
-        serviceConfig.GroupName = "buildkite-agent";
-        serviceConfig.UserName = "buildkite-agent";
-        serviceConfig.WorkingDirectory = config.users.users.buildkite-agent.home;
-        serviceConfig.StandardErrorPath = "${cfg.dataDir}/buildkite-agent.log";
-        serviceConfig.StandardOutPath = "${cfg.dataDir}/buildkite-agent.log";
+          GroupName = "buildkite-agent";
+          UserName = "buildkite-agent";
+          WorkingDirectory = config.users.users.buildkite-agent.home;
+          StandardErrorPath = "${cfg.dataDir}/buildkite-agent.log";
+          StandardOutPath = "${cfg.dataDir}/buildkite-agent.log";
+        };
       };
   };
 }

--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -186,7 +186,8 @@ in
 
     launchd.daemons.buildkite-agent =
       {
-        path = cfg.runtimePackages ++ [ pkgs.coreutils pkgs.darwin.DarwinTools cfg.package ];
+        path = cfg.runtimePackages ++ [ pkgs.coreutils cfg.package ]
+          ++ (if pkgs.stdenv.isDarwin then [ pkgs.darwin.DarwinTools ] else []);
         environment = {
           HOME = cfg.dataDir;
           NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/release.nix
+++ b/release.nix
@@ -105,6 +105,7 @@ let
     tests.system-path-fish = makeTest ./tests/system-path-fish.nix;
     tests.system-shells = makeTest ./tests/system-shells.nix;
     tests.users-groups = makeTest ./tests/users-groups.nix;
+    tests.buildkite-agent = makeTest ./tests/buildkite-agent.nix;
 
   }
   // (mapTestOn (packagePlatforms packageSet));

--- a/tests/buildkite-agent.nix
+++ b/tests/buildkite-agent.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, ... }:
+
+let
+  tokenPath = pkgs.writeText "buildkite_token" "TEST_TOKEN";
+in {
+  services.buildkite-agent = {
+    enable = true;
+    extraConfig = "yolo=1";
+    openssh.privateKeyPath = "/dev/null";
+    openssh.publicKeyPath = "/dev/null";
+    hooks.command = "echo test";
+    inherit tokenPath;
+  };
+
+  test = ''
+    echo "checking buildkite-agent service in /Library/LaunchDaemons" >&2
+    grep "org.nixos.buildkite-agent" ${config.out}/Library/LaunchDaemons/org.nixos.buildkite-agent.plist
+
+    echo "checking creation of buildkite-agent service config" >&2
+    script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.buildkite-agent.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
+    grep "yolo=1" "$script"
+    grep "${tokenPath}" "$script"
+  '';
+}


### PR DESCRIPTION
This module lets you use your Mac as a build slave for the Buildkite CI system.

The `buildkite-agent` package used will need to come from the unstable channel.