### PR TITLE
defaults: Add screencapture.location

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ let
         ./modules/system/defaults/NSGlobalDomain.nix
         ./modules/system/defaults/dock.nix
         ./modules/system/defaults/finder.nix
+        ./modules/system/defaults/screencapture.nix
         ./modules/system/defaults/smb.nix
         ./modules/system/defaults/trackpad.nix
         ./modules/system/etc.nix

--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -21,6 +21,8 @@
   system.defaults.finder.QuitMenuItem = true;
   system.defaults.finder.FXEnableExtensionChangeWarning = false;
 
+  system.defaults.screencapture.location = "/tmp";
+
   system.defaults.trackpad.Clicking = true;
   system.defaults.trackpad.TrackpadThreeFingerDrag = true;
 

--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -21,8 +21,6 @@
   system.defaults.finder.QuitMenuItem = true;
   system.defaults.finder.FXEnableExtensionChangeWarning = false;
 
-  system.defaults.screencapture.location = "/tmp";
-
   system.defaults.trackpad.Clicking = true;
   system.defaults.trackpad.TrackpadThreeFingerDrag = true;
 

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -26,6 +26,7 @@ let
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
   smb = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.smb.server" cfg.smb;
+  screencapture = defaultsToList "com.apple.screencapture" cfg.screencapture;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
 
@@ -43,7 +44,7 @@ in
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
-      [ NSGlobalDomain LaunchServices dock finder trackpad trackpadBluetooth ]
+      [ NSGlobalDomain LaunchServices dock finder screencapture trackpad trackpadBluetooth ]
       ''
         # Set defaults
         echo >&2 "user defaults..."
@@ -52,6 +53,7 @@ in
         ${concatStringsSep "\n" LaunchServices}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
+        ${concatStringsSep "\n" screencapture}
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}
       '';

--- a/modules/system/defaults/screencapture.nix
+++ b/modules/system/defaults/screencapture.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.screencapture.location = mkOption {
+      type = types.string;
+      default = "~/Desktop";
+      description = ''
+          The filesystem path to which screencaptures should be written.
+        '';
+    };
+  };
+}

--- a/modules/system/defaults/screencapture.nix
+++ b/modules/system/defaults/screencapture.nix
@@ -6,8 +6,8 @@ with lib;
   options = {
 
     system.defaults.screencapture.location = mkOption {
-      type = types.string;
-      default = "~/Desktop";
+      type = types.nullOr types.str;
+      default = null;
       description = ''
           The filesystem path to which screencaptures should be written.
         '';


### PR DESCRIPTION
Very simple - I don't like cluttering my desktop 😉   
Tested and works like a charm: `defaults read com.apple.screencapture location` after customising it and rebuilding shows the new value. And, fortunately, works immediately: new screenshots go to the new specified location, without the need of a `killall SystemUIServer` (as some articles on the web would suggest is necessary).