### PR TITLE
adds skhd module

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -56,6 +56,7 @@ let
         ./modules/services/ofborg
         ./modules/services/postgresql
         ./modules/services/redis
+        ./modules/services/skhd
         ./modules/programs/bash
         ./modules/programs/fish.nix
         ./modules/programs/man.nix

--- a/modules/services/skhd/default.nix
+++ b/modules/services/skhd/default.nix
@@ -30,8 +30,6 @@ in {
 
   config = mkIf cfg.enable {
 
-    security.accessibilityPrograms = [ "${cfg.package}/bin/skhd" ];
-
     environment.etc."skhdrc".text = cfg.skhdConfig;
 
     launchd.user.agents.skhd = {

--- a/modules/services/skhd/default.nix
+++ b/modules/services/skhd/default.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.skhd;
+
+in {
+
+  options = {
+    services.skhd.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable the skhd hotkey daemon.";
+    };
+
+    services.skhd.package = mkOption {
+      type = types.package;
+      example = literalExample "pkgs.skhd";
+      description = "This option specifies the skhd package to use.";
+    };
+
+    services.skhd.skhdConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = "alt + shift - r   :   chunkc quit";
+      description = "Config to use for <filename>skhdrc</filename>.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    security.accessibilityPrograms = [ "${cfg.package}/bin/skhd" ];
+
+    environment.etc."skhdrc".text = cfg.skhdConfig;
+
+    launchd.user.agents.skhd = {
+      path = [ cfg.package config.environment.systemPath ];
+
+      serviceConfig.ProgramArguments = [ "${cfg.package}/bin/skhd" ]
+        ++ optionals (cfg.skhdConfig != "") [ "-c" "/etc/skhdrc" ];
+      serviceConfig.KeepAlive = true;
+      serviceConfig.ProcessType = "Interactive";
+      serviceConfig.StandardOutPath = "/tmp/skhd.out";
+      serviceConfig.StandardErrorPath = "/tmp/skhd.err";
+    };
+
+  };
+}


### PR DESCRIPTION
This adds [koekeishiya/skhd](https://github.com/koekeishiya/skhd) module. An alternative to already existing [khd](../tree/master/modules/services/khd) one that promises (and delivers) significant speedup. Currently we're not providing a default configuration for khd hence there is no default for skhd.