### PR TITLE
buildkite-agent fixes

### DIFF
--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -17,7 +17,7 @@ let
 
   hooksDir = let
     mkHookEntry = name: value: ''
-      cat > $out/${name} <<EOF
+      cat > $out/${name} <<'EOF'
       #! ${pkgs.stdenv.shell}
       set -e
       ${value}

--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -221,10 +221,19 @@ in
           '';
 
         serviceConfig = {
-          KeepAlive = true;
-          RunAtLoad = true;
           ProcessType = "Interactive";
           ThrottleInterval = 30;
+
+          # The combination of KeepAlive.NetworkState and WatchPaths
+          # will ensure that buildkite-agent is started on boot, but
+          # after networking is available (so the hostname is
+          # correct).
+          RunAtLoad = true;
+          KeepAlive.NetworkState = true;
+          WatchPaths = [
+            "/etc/resolv.conf"
+            "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
+          ];
 
           GroupName = "buildkite-agent";
           UserName = "buildkite-agent";

--- a/tests/services-buildkite-agent.nix
+++ b/tests/services-buildkite-agent.nix
@@ -12,7 +12,7 @@ in
     extraConfig = "yolo=1";
     openssh.privateKeyPath = "/dev/null";
     openssh.publicKeyPath = "/dev/null";
-    hooks.command = "echo test";
+    hooks.command = "echo test hook";
     inherit tokenPath;
   };
 
@@ -24,5 +24,9 @@ in
     script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.buildkite-agent.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
     grep "yolo=1" "$script"
     grep "${tokenPath}" "$script"
+
+    echo "checking that a buildkite-agent hook works" >&2
+    hooks_path=$(cat $script | awk -F'"' '/^hooks-path/ {print $2;}')
+    $hooks_path/command | grep test
   '';
 }


### PR DESCRIPTION
Here are two fixes for buildkite-agent.

1. Port a shell quoting fix from NixOS/nixpkgs#38326
2. The daemon was starting before the hostname was set, which caused it to register itself as "localhost". This adds a fix for that.

Cheers
