### PR TITLE
gnupg: add gpg-agent service

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,6 +59,7 @@ let
         ./modules/services/skhd
         ./modules/programs/bash
         ./modules/programs/fish.nix
+        ./modules/programs/gnupg.nix
         ./modules/programs/man.nix
         ./modules/programs/info
         ./modules/programs/nix-index

--- a/modules/programs/gnupg.nix
+++ b/modules/programs/gnupg.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.gnupg;
+
+in
+
+{
+  options.programs.gnupg = {
+    agent.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables GnuPG agent for every user session.
+      '';
+    };
+
+    agent.enableSSHSupport = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable SSH agent support in GnuPG agent. Also sets SSH_AUTH_SOCK
+        environment variable correctly.
+      '';
+    };
+  };
+
+  config = mkIf cfg.agent.enable {
+    launchd.user.agents.gnupg-agent.serviceConfig = {
+      ProgramArguments = [
+        "${pkgs.gnupg}/bin/gpg-connect-agent" "/bye"
+      ];
+      RunAtLoad = cfg.agent.enableSSHSupport;
+      KeepAlive = true;
+    };
+
+    environment.extraInit = ''
+      # Bind gpg-agent to this TTY if gpg commands are used.
+      export GPG_TTY=$(tty)
+    '' + (optionalString cfg.agent.enableSSHSupport ''
+      # SSH agent protocol doesn't support changing TTYs, so bind the agent
+      # to every new TTY.
+      ${pkgs.gnupg}/bin/gpg-connect-agent --quiet updatestartuptty /bye > /dev/null
+
+      export SSH_AUTH_SOCK=$(${pkgs.gnupg}/bin/gpgconf --list-dirs agent-ssh-socket)
+    '');
+  };
+}


### PR DESCRIPTION
Add

```
  programs.gnupg.agent.enable = true;
  programs.gnupg.agent.enableSSHSupport = true;
```

to your config to get `gpg-agent` with SSH support.

Without `enableSSHSupport` this doesn’t really do anything, because, well, with the current design of GnuPG the agent is spawned automatically when needed.  So this whole thing is really only useful for ssh.

I tried to make it socket-activated, but `gpg-agent` only supports systemd-style socket activation. I think, theoretically, it should be possible to have a wrapper that will make systemd-style activated servers compatible with launchd, but I couldn’t figure our the launchd activation protocol :/.

Closes #77.