### PR TITLE
Init offlineimap service

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,6 +50,7 @@ let
         ./modules/services/emacs.nix
         ./modules/services/khd
         ./modules/services/kwm
+        ./modules/services/mail/offlineimap.nix
         ./modules/services/mopidy.nix
         ./modules/services/nix-daemon.nix
         ./modules/services/nix-gc

--- a/modules/services/mail/offlineimap.nix
+++ b/modules/services/mail/offlineimap.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.offlineimap;
+in {
+
+  options.services.offlineimap = {
+    enable = mkEnableOption "Offlineimap, a software to dispose your mailbox(es) as a local Maildir(s).";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.offlineimap;
+      defaultText = "pkgs.offlineimap";
+      description = "Offlineimap derivation to use.";
+    };
+
+    path = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = literalExample "[ pkgs.pass pkgs.bash pkgs.notmuch ]";
+      description = "List of derivations to put in Offlineimap's path.";
+    };
+
+    startInterval = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = literalExample "300";
+      description = "Optional key to start offlineimap services each N seconds";
+    };
+
+    runQuick = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Run only quick synchronizations.
+        Ignore any flag updates on IMAP servers. If a flag on the remote IMAP changes, and we have the message locally, it will be left untouched in a quick run.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional text to be appended to <filename>offlineimaprc</filename>.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    environment.etc."offlineimaprc".text = cfg.extraConfig;
+    launchd.user.agents.offlineimap = {
+      path                            = [ cfg.package ];
+      command                         = "offlineimap";
+      serviceConfig.KeepAlive         = false;
+      serviceConfig.RunAtLoad         = true;
+      serviceConfig.ProgramArguments  = [ "-c" "/etc/offlineimaprc" ] ++ optional (cfg.runQuick != null) "-q";
+      serviceConfig.StartInterval     = cfg.startInterval;
+      serviceConfig.StandardErrorPath = "/var/log/offlineimap.log";
+      serviceConfig.StandardOutPath   = "/var/log/offlineimap.log";
+    };
+  };
+}

--- a/modules/services/mail/offlineimap.nix
+++ b/modules/services/mail/offlineimap.nix
@@ -25,14 +25,14 @@ in {
 
     startInterval = mkOption {
       type = types.nullOr types.int;
-      default = null;
+      default = 300;
       example = literalExample "300";
       description = "Optional key to start offlineimap services each N seconds";
     };
 
     runQuick = mkOption {
-      type = types.nullOr types.bool;
-      default = null;
+      type = types.bool;
+      default = false;
       description = ''
         Run only quick synchronizations.
         Ignore any flag updates on IMAP servers. If a flag on the remote IMAP changes, and we have the message locally, it will be left untouched in a quick run.
@@ -54,7 +54,7 @@ in {
       command                         = "offlineimap";
       serviceConfig.KeepAlive         = false;
       serviceConfig.RunAtLoad         = true;
-      serviceConfig.ProgramArguments  = [ "-c" "/etc/offlineimaprc" ] ++ optional (cfg.runQuick != null) "-q";
+      serviceConfig.ProgramArguments  = [ "-c" "/etc/offlineimaprc" ] ++ optional (cfg.runQuick) "-q";
       serviceConfig.StartInterval     = cfg.startInterval;
       serviceConfig.StandardErrorPath = "/var/log/offlineimap.log";
       serviceConfig.StandardOutPath   = "/var/log/offlineimap.log";

--- a/release.nix
+++ b/release.nix
@@ -101,6 +101,7 @@ let
     tests.services-activate-system = makeTest ./tests/services-activate-system.nix;
     tests.services-buildkite-agent = makeTest ./tests/services-buildkite-agent.nix;
     tests.services-ofborg = makeTest ./tests/services-ofborg.nix;
+    tests.services-offlineimap = makeTest ./tests/services-offlineimap.nix;
     tests.services-skhd = makeTest ./tests/services-skhd.nix;
     tests.system-defaults-write = makeTest ./tests/system-defaults-write.nix;
     tests.system-keyboard-mapping = makeTest ./tests/system-keyboard-mapping.nix;

--- a/tests/services-offlineimap.nix
+++ b/tests/services-offlineimap.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  offlineimap = pkgs.runCommand "offlineimap-0.0.0" {} "mkdir -p $out";
+in
+
+{
+  services.offlineimap.enable = true;
+  services.offlineimap.package = offlineimap;
+  services.offlineimap.runQuick = true;
+  services.offlineimap.extraConfig = ''
+    [general]
+    accounts = test
+    ui = quiet
+
+    [Account test]
+    localrepository = testLocal
+    remoterepository = testRemote
+    autorefresh = 2
+    maxage = 2017-07-01
+
+    [Repository testLocal]
+    type = GmailMaildir
+
+    [Repository testRemote]
+    type = Gmail
+    ssl = yes
+    starttls = no
+    expunge = yes
+  '';
+
+  test = ''
+    echo >&2 "checking offlineimap service in ~/Library/LaunchAgents"
+    grep "org.nixos.offlineimap" ${config.out}/user/Library/LaunchAgents/org.nixos.offlineimap.plist
+    grep "exec\ offlineimap" ${config.out}/user/Library/LaunchAgents/org.nixos.offlineimap.plist
+    grep "\-q" ${config.out}/user/Library/LaunchAgents/org.nixos.offlineimap.plist
+
+    echo >&2 "checking config in /etc/offlineimaprc"
+    grep "accounts\ \=\ test" ${config.out}/etc/offlineimaprc
+  '';
+}


### PR DESCRIPTION
# Motivation
This PR provides a basic service module for `offlineimap`. Offlineimap can be heavily configured by cli parameters as well as through an rc file. The service module offers only basic startup options and lets the rest of the configuration to be done through an run control script `.offlineimaprc`, because account management and credentials are beyond the scope of nix-darwin afaik.

# Things done
- [x] Building with nix-darwin
- [x] Provides tests for service configuration
- [x] Smoke tests with a test confoguration

~**Disclaimer:** The tests and some local smoke tests are passing for this PR. However, i am away from one of my machines, where i make use of offlineimap. I can cover this by the end of June.~