### PR TITLE
installer: Bring our own `nix-instantiate`

### DIFF
--- a/pkgs/darwin-installer/default.nix
+++ b/pkgs/darwin-installer/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
 
     export nix=${nix}
 
-    config=$(nix-instantiate --eval -E '<darwin-config>' 2> /dev/null || echo "$HOME/.nixpkgs/darwin-configuration.nix")
+    config=$($nix/bin/nix-instantiate --eval -E '<darwin-config>' 2> /dev/null || echo "$HOME/.nixpkgs/darwin-configuration.nix")
     if ! test -f "$config"; then
         echo "copying example configuration.nix" >&2
         mkdir -p "$HOME/.nixpkgs"


### PR DESCRIPTION
This is needed for the case when the user already has their config on `NIX_PATH` but has no working Nix. (🤷‍♀️ Things happen!)