### PR TITLE
Make the skhd service default to the skhd package

### DIFF
--- a/modules/services/skhd/default.nix
+++ b/modules/services/skhd/default.nix
@@ -16,7 +16,7 @@ in
 
     services.skhd.package = mkOption {
       type = types.package;
-      example = literalExample "pkgs.skhd";
+      default = pkgs.skhd;
       description = "This option specifies the skhd package to use.";
     };
 


### PR DESCRIPTION
This can be overrided if necessary, but I don't see any reason the nixpkgs package shouldn't be the default. It looks like this package didn't exist when the service was created.