### PR TITLE
[WIP] Ability to load kernel modules

### DIFF
--- a/modules/services/activate-system/default.nix
+++ b/modules/services/activate-system/default.nix
@@ -32,6 +32,7 @@ in
 
         ${config.system.activationScripts.keyboard.text}
         ${config.system.activationScripts.nix.text}
+        ${config.system.activationScripts.kexts.text}
       '';
       serviceConfig.RunAtLoad = true;
       serviceConfig.KeepAlive.SuccessfulExit = false;

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -61,6 +61,7 @@ in
       ${cfg.activationScripts.defaults.text}
       ${cfg.activationScripts.launchd.text}
       ${cfg.activationScripts.nix-daemon.text}
+      ${cfg.activationScripts.kexts.text}
       ${cfg.activationScripts.time.text}
       ${cfg.activationScripts.networking.text}
       ${cfg.activationScripts.keyboard.text}

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -94,8 +94,8 @@ in
 
     system.activationScripts.kexts.text = ''
       for f in $(ls "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/" 2> /dev/null); do
-        echo "loading kext [$f]" >&2
-        kextutil -v 1 $(readlink "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/$f") || true
+        echo "loading kext [$f]:"
+        kextutil -v 1 $(readlink "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/$f") 2>&1 >/dev/null | sed "s/^/> /"
       done
 
       for f in $(ls /run/current-system/Library/Extensions 2> /dev/null); do

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -89,7 +89,7 @@ in
     system.kernel.extraModulePackagesPath = pkgs.buildEnv {
       name = "system-kexts";
       paths = cfg.kernel.extraModulePackages;
-      pathsToLink = "/Library/Extensions";
+      pathsToLink = [ "/Extensions" "/Library/Extensions" ];
     };
 
     system.activationScripts.kexts.text = ''

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -139,7 +139,7 @@ in
         ln -s ${cfg.build.applications}/Applications $out/Applications
         ln -s ${cfg.build.launchd}/Library/LaunchAgents $out/Library/LaunchAgents
         ln -s ${cfg.build.launchd}/Library/LaunchDaemons $out/Library/LaunchDaemons
-        # Kexts must have root:wheel permissions to be loadable
+        # Kexts
         ln -s "${cfg.kernel.extraModulePackagesPath}/Library/Extensions" "$out/Library/Extensions"
 
         mkdir -p $out/user/Library

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -92,6 +92,20 @@ in
       pathsToLink = "/Library/Extensions";
     };
 
+    system.activationScripts.kexts.text = ''
+      for f in $(ls "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/" 2> /dev/null); do
+        echo "loading kext [$f]" >&2
+        kextutil -v 1 $(readlink "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/$f") || true
+      done
+
+      for f in $(ls /run/current-system/Library/Extensions 2> /dev/null); do
+        if test ! -e "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/$f"; then
+          echo "unloading kext [$f]" >&2
+          kextunload -v 1 "/run/current-system/Library/Extensions/$f" || true
+        fi
+      done
+    '';
+
     system.build.toplevel = throwAssertions (showWarnings (stdenvNoCC.mkDerivation {
       name = "darwin-system-${cfg.darwinLabel}";
       preferLocalBuild = true;

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -106,6 +106,16 @@ in
       done
     '';
 
+    launchd.daemons.load-kexts = {
+      script = ''
+        for f in /run/current-system/Library/Extensions/* do
+          echo "loading kext [$f]:"
+          kextutil -v 1 $(readlink "${cfg.kernel.extraModulePackagesPath}/Library/Extensions/$f") 2>&1 >/dev/null | sed "s/^/> /"
+        done
+      '';
+      KeepAlive = false;
+    }
+
     system.build.toplevel = throwAssertions (showWarnings (stdenvNoCC.mkDerivation {
       name = "darwin-system-${cfg.darwinLabel}";
       preferLocalBuild = true;


### PR DESCRIPTION
Continued from #54
This module adds the `system.kernel.extraModulePackages` option, which is used as follows:
```
system.kernel.extraModulePackages = [ pkgs.darwin.nvidia-cuda-driver ];
```
Module-providing packages must place kexts in `$out/Library/Extensions` or `$out/Extensions`

To try it out:
* clone my [nixpkgs branch](https://github.com/lukeadams/nixpkgs/tree/cuda-drivers-darwin) which has the cuda driver
* clone my [nix-darwin branch](https://github.com/lukeadams/nix-darwin/tree/kextload)
* add the line above to `~/.nixpkgs/darwin-configuration.nix`
* `darwin-rebuild -I nixpkgs=<nixpkgs_clone> -I darwin=<nix-darwin_clone> switch`
You should see the CUDA driver successfully loaded:
```
~ kextstat | grep CUDA
  162    0 0xffffff7f83c4a000 0x2000     0x2000     com.nvidia.CUDA (1.1.0) 4329B052-6C8A-3900-8E83-744487AEDEF1 <4 1>
```

[WIP]: I need to squash commits and add a few comments before this is merge ready. It may be ideal to move the kext stuff into their own module as well.