### PR TITLE
[services.emacs] use `fg-daemon` flag for service

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -36,7 +36,7 @@ in
     launchd.user.agents.emacs = {
       serviceConfig.ProgramArguments = [
         "${cfg.package}/bin/${cfg.exec}"
-        "--daemon"
+        "--fg-daemon"
       ];
       serviceConfig.RunAtLoad = true;
     };


### PR DESCRIPTION
As the default package is now emacs 26.1 and --daemon flag falls back to forking behaviour the recommended way is to use fg-daemon, see: https://lists.gnu.org/archive/html/emacs-devel/2016-11/msg00383.html, https://lists.gnu.org/archive/html/emacs-devel/2017-05/msg00861.html