### PR TITLE
installer: prefer nix from default profile

### DIFF
--- a/pkgs/darwin-installer/configuration.nix
+++ b/pkgs/darwin-installer/configuration.nix
@@ -11,6 +11,8 @@ with lib;
   users.knownUsers = [ "nixbld1" "nixbld2" "nixbld3" "nixbld4" "nixbld5" "nixbld6" "nixbld7" "nixbld8" "nixbld9" "nixbld10" ];
 
   system.activationScripts.preUserActivation.text = mkBefore ''
+    PATH=/nix/var/nix/profiles/default/bin:$PATH
+
     darwinPath=$(NIX_PATH=${concatStringsSep ":" config.nix.nixPath} nix-instantiate --eval -E '<darwin>' 2> /dev/null) || true
     if ! test -e "$darwinPath"; then
         if test -t 1; then

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -19,7 +19,7 @@ with lib;
     fi
 
     if test -L ~/.nix-defexpr/channels/darwin; then
-        nix-channel --remove darwin
+        nix-channel --remove darwin || true
     fi
   '';
 
@@ -31,7 +31,7 @@ with lib;
     if test -O /nix/store; then
         l=$(readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist) || true
         if test "$l" != "/nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist"; then
-            sudo launchctl unload -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2> /dev/null || true
+            sudo launchctl remove org.nixos.nix-daemon 2> /dev/null || true
             sudo ln -sfn /nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist /Library/LaunchDaemons/org.nixos.nix-daemon.plist
             sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist
         fi


### PR DESCRIPTION
Using a nix 2.1 nix-channel/nix-env with a 2.0 nix-daemon doesn't work
because the buildenv implementation was moved to the daemon.  This means
the nix version of the target darwin system can't be used because the
daemon isn't upgraded yet.

    error: unsupported builtin function 'buildenv'