### PR TITLE
initialise fonts module

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Whether to activate system at boot time.
 ## Modules
 
 - [`environment`](https://github.com/LnL7/nix-darwin/blob/master/modules/environment)
+- [`fonts`](https://github.com/LnL7/nix-darwin/blob/master/modules/fonts)
 - [`launchd.daemons`](https://github.com/LnL7/nix-darwin/blob/master/modules/launchd/launchd.nix)
 - [`launchd.envVariables`](https://github.com/LnL7/nix-darwin/blob/master/modules/launchd)
 - [`launchd.user.agents`](https://github.com/LnL7/nix-darwin/blob/master/modules/launchd/launchd.nix)

--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,7 @@ let
         ./modules/nix/nix-info.nix
         ./modules/nix/nixpkgs.nix
         ./modules/environment
+        ./modules/fonts
         ./modules/launchd
         ./modules/services/activate-system
         ./modules/services/buildkite-agent.nix

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.fonts;
+in {
+  options = {
+    fonts = {
+      enableFontDir = mkOption {
+        default = false;
+        description = ''
+          Whether to create a directory with links to all fonts in
+          <filename>/run/current-system/sw/share/fonts</filename>.
+        '';
+      };
+      fonts = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        example = literalExample "[ pkgs.dejavu_fonts ]";
+        description = "List of primary font paths.";
+      };
+    };
+  };
+  
+  config = mkIf cfg.enableFontDir {
+    system.build.fonts = pkgs.buildEnv {
+      name = "system-fonts";
+      paths = cfg.fonts;
+      pathsToLink = "/share/fonts/truetype";
+    };
+    system.activationScripts.fonts.text = ''
+      # Set up fonts.
+      echo "setting up fonts..." >&2
+      /bin/ln -hf ${config.system.build.fonts}/share/fonts/truetype/* /Library/Fonts/
+      '';
+    environment.pathsToLink = [ "/share/fonts/truetype" ];
+  };
+
+}

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -9,9 +9,13 @@ let
       home = readDir path;
       list = mapAttrsToList (name: type:
         let newPath = "${path}/${name}";
-        in if (type == "directory" || type == "symlink") && !(hasSuffix ".ttf" name) then readDirsRec newPath else [ newPath ]) home;
+        in if (type == "directory" || type == "symlink") && !(isFont name) then readDirsRec newPath else [ newPath ]) home;
       in flatten list;
-    fontFiles = dir: filter (name: hasSuffix ".ttf" name) (readDirsRec dir);
+    isFont = name: let
+      fontExt = [ ".ttf" ".otf" ];
+      hasExt = exts: name: foldl' (acc: ext: (hasSuffix ext name) || acc) false exts;
+      in hasExt fontExt name;
+    fontFiles = dir: filter isFont (readDirsRec dir);
     print = font: "ln -fn '${font}' '/Library/Fonts/${baseNameOf font}'";
     in concatMapStringsSep "\n" print (fontFiles dir);
 in {

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -25,7 +25,7 @@ in {
         type = types.listOf types.path;
         default = [];
         example = literalExample "[ pkgs.dejavu_fonts ]";
-        description = "List of primary font paths.";
+        description = "List of primary font paths. Important: Manually added fonts will be removed upon rebuild.";
       };
     };
   };

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -23,15 +23,16 @@ in {
     };
   };
   
-  config = mkIf cfg.enableFontDir {
+  config = {
     system.build.fonts = pkgs.buildEnv {
       name = "system-fonts";
       paths = cfg.fonts;
       pathsToLink = "/share/fonts/truetype";
     };
-    system.activationScripts.fonts.text = ''
+    system.activationScripts.fonts.text = optionalString cfg.enableFontDir ''
       # Set up fonts.
       echo "setting up fonts..." >&2
+      fontrestore default -n 2>&1 | grep -o '/Library/Fonts/.*' | tr '\n' '\0' | xargs -0 sudo rm
       /bin/ln -hf ${config.system.build.fonts}/share/fonts/truetype/* /Library/Fonts/
       '';
     environment.pathsToLink = [ "/share/fonts/truetype" ];

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -16,16 +16,22 @@ let
     hasExt = exts: name: foldl' (acc: ext: (hasSuffix ext name) || acc) false exts;
     in hasExt fontExt name;
   fontFiles = dir: filter isFont (readDirsRec dir);
-  print = font: "ln -fn '${font}' '/Library/Fonts/${baseNameOf font}'";
-  printLinks = dir: concatMapStringsSep "\n" print (fontFiles dir);
+  libraryLink = font: "ln -fn '/run/current-system/sw/share/fonts/${baseNameOf font}' '/Library/Fonts/${baseNameOf font}'";
+  outLink = font: "ln -sfn -t $out/share/fonts/ '${font}'";
+  fontLinks = link: dir: concatMapStringsSep "\n" link (fontFiles dir);
+  systemFontsDir = pkgs.runCommand "systemFontsDir" {} ''
+    mkdir -p "$out/share/fonts"
+    echo ${toString config.fonts.fonts}
+    ${concatMapStringsSep "\n" (fontLinks outLink) config.fonts.fonts}
+  '';
 in {
   options = {
     fonts = {
       enableFontDir = mkOption {
         default = false;
         description = ''
-          Whether to enable font directory management. 
-          Important: enabling font directory management removes all manually-added fonts.
+          Whether to enable font directory management and link all fonts in <filename>/run/current-system/sw/share/fonts</filename>.
+          Important: removes all manually-added fonts.
         '';
       };
       fonts = mkOption {
@@ -38,18 +44,14 @@ in {
   };
   
   config = {
-    system.build.fonts = mkIf cfg.enableFontDir (pkgs.buildEnv {
-      name = "system-fonts";
-      paths = cfg.fonts;
-      pathsToLink = "/share/fonts";
-    });
     system.activationScripts.fonts.text = "" + optionalString cfg.enableFontDir ''
       # Set up fonts.
       echo "resetting fonts..." >&2
       fontrestore default -n 2>&1 | grep -o '/Library/Fonts/.*' | tr '\n' '\0' | xargs -0 rm || true
       echo "updating fonts..." >&2
-      ${printLinks config.system.build.fonts}
-   '';
+      ${fontLinks libraryLink systemFontsDir}
+    '';
+    environment.systemPackages = [ systemFontsDir ];
     environment.pathsToLink = [ "/share/fonts" ];
   };
 }

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -21,22 +21,29 @@ let
 in {
   options = {
     fonts = {
+      enableFontDir = mkOption {
+        default = false;
+        description = ''
+          Whether to enable font directory management. 
+          Important: enabling font directory management removes all manually-added fonts.
+        '';
+      };
       fonts = mkOption {
         type = types.listOf types.path;
         default = [];
         example = literalExample "[ pkgs.dejavu_fonts ]";
-        description = "List of primary font paths. Important: Manually added fonts will be removed upon rebuild.";
+        description = "List of primary font paths.";
       };
     };
   };
   
   config = {
-    system.build.fonts = pkgs.buildEnv {
+    system.build.fonts = mkIf cfg.enableFontDir (pkgs.buildEnv {
       name = "system-fonts";
       paths = cfg.fonts;
       pathsToLink = "/share/fonts";
-    };
-    system.activationScripts.fonts.text = ''
+    });
+    system.activationScripts.fonts.text = "" + optionalString cfg.enableFontDir ''
       # Set up fonts.
       echo "resetting fonts..." >&2
       fontrestore default -n 2>&1 | grep -o '/Library/Fonts/.*' | tr '\n' '\0' | xargs -0 rm || true

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -1,23 +1,23 @@
 { config, lib, pkgs, ... }:
 
 with lib;
+with builtins;
 
 let
   cfg = config.fonts;
-  printLinks = dir: with builtins;
-    let readDirsRec = path: let
-      home = readDir path;
-      list = mapAttrsToList (name: type:
-        let newPath = "${path}/${name}";
-        in if (type == "directory" || type == "symlink") && !(isFont name) then readDirsRec newPath else [ newPath ]) home;
-      in flatten list;
-    isFont = name: let
-      fontExt = [ ".ttf" ".otf" ];
-      hasExt = exts: name: foldl' (acc: ext: (hasSuffix ext name) || acc) false exts;
-      in hasExt fontExt name;
-    fontFiles = dir: filter isFont (readDirsRec dir);
-    print = font: "ln -fn '${font}' '/Library/Fonts/${baseNameOf font}'";
-    in concatMapStringsSep "\n" print (fontFiles dir);
+  readDirsRec = path: let
+    home = readDir path;
+    list = mapAttrsToList (name: type:
+      let newPath = "${path}/${name}";
+      in if (type == "directory" || type == "symlink") && !(isFont name) then readDirsRec newPath else [ newPath ]) home;
+    in flatten list;
+  isFont = name: let
+    fontExt = [ ".ttf" ".otf" ];
+    hasExt = exts: name: foldl' (acc: ext: (hasSuffix ext name) || acc) false exts;
+    in hasExt fontExt name;
+  fontFiles = dir: filter isFont (readDirsRec dir);
+  print = font: "ln -fn '${font}' '/Library/Fonts/${baseNameOf font}'";
+  printLinks = dir: concatMapStringsSep "\n" print (fontFiles dir);
 in {
   options = {
     fonts = {

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -64,6 +64,7 @@ in
       ${cfg.activationScripts.time.text}
       ${cfg.activationScripts.networking.text}
       ${cfg.activationScripts.keyboard.text}
+      ${cfg.activationScripts.fonts.text}
 
       ${cfg.activationScripts.postActivation.text}
 

--- a/release.nix
+++ b/release.nix
@@ -114,6 +114,7 @@ let
     tests.system-path-fish = makeTest ./tests/system-path-fish.nix;
     tests.system-shells = makeTest ./tests/system-shells.nix;
     tests.users-groups = makeTest ./tests/users-groups.nix;
+    tests.fonts = makeTest ./tests/fonts.nix;
 
   }
   // (mapTestOn (packagePlatforms packageSet));

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, ... }:
+
+let
+  fonts = pkgs.runCommand "fonts-0.0.0" {} "mkdir -p $out";
+in {
+  fonts.fonts = [ pkgs.dejavu_fonts ];
+ 
+  test = ''
+    echo checking installed fonts >&2
+    grep -o "fontrestore default -n" ${config.out}/activate
+    grep -o "/share/fonts/truetype/DejaVuSans.ttf /Library/Fonts/DejaVuSans.ttf" ${config.out}/activate
+  '';
+}
+

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -8,7 +8,7 @@ in {
   test = ''
     echo checking installed fonts >&2
     grep -o "fontrestore default -n" ${config.out}/activate
-    grep -o "/share/fonts/truetype/DejaVuSans.ttf /Library/Fonts/DejaVuSans.ttf" ${config.out}/activate
+    grep -o "/share/fonts/truetype/DejaVuSans.ttf' '/Library/Fonts/DejaVuSans.ttf'" ${config.out}/activate
   '';
 }
 

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -3,7 +3,10 @@
 let
   fonts = pkgs.runCommand "fonts-0.0.0" {} "mkdir -p $out";
 in {
-  fonts.fonts = [ pkgs.dejavu_fonts ];
+  fonts = {
+    enableFontDir = true;
+    fonts = [ pkgs.dejavu_fonts ];
+  };
  
   test = ''
     echo checking installed fonts >&2

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -11,7 +11,7 @@ in {
   test = ''
     echo checking installed fonts >&2
     grep -o "fontrestore default -n" ${config.out}/activate
-    grep -o "/share/fonts/truetype/DejaVuSans.ttf' '/Library/Fonts/DejaVuSans.ttf'" ${config.out}/activate
+    grep -o "ln -fn '/run/current-system/sw/share/fonts/DejaVuSans.ttf' '/Library/Fonts/DejaVuSans.ttf'" ${config.out}/activate
   '';
 }
 


### PR DESCRIPTION
Adds a `fonts` module that once enabled (`enableFontDir`) takes fonts under nix management. Supports both `.ttf` and `.otf` fonts available in nixpkgs.

The effect is the fonts are *hardlinked* (symlinks do not work with darwin's way of loading fonts) into `/Library/Fonts` and cleaned-up and relinked upon rebuild. Manually copied fonts will be removed unless `enableFontDir` is set to false again.

Sample config:
```
fonts = {
   enableFontDir = true;
   fonts = [ pkgs.dejavu_fonts ];
 };
```

Effect:
```
ls -l /Library/Fonts | grep Prag
-r--r--r--    2 root 1.5M Jan  1  1970 FSD - PragmataPro-Bold.ttf
-r--r--r--    2 root 1.4M Jan  1  1970 FSD - PragmataPro-BoldItalic.ttf
-r--r--r--    2 root 1.4M Jan  1  1970 FSD - PragmataPro-Italic.ttf
-r--r--r--    2 root 2.0M Jan  1  1970 FSD - PragmataPro.ttf
-r--r--r--    2 root 982K Jan  1  1970 FSD - PragmataProMono-Bold.ttf
-r--r--r--    2 root 909K Jan  1  1970 FSD - PragmataProMono-BoldItalic.ttf
-r--r--r--    2 root 902K Jan  1  1970 FSD - PragmataProMono-Italic.ttf
-r--r--r--    2 root 1.5M Jan  1  1970 FSD - PragmataProMono.ttf
```

and most notably the fonts are now also available in FontBook. 

---
fixes #49 