### PR TITLE
system.defaults.dock: add `show-recents` option

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -138,6 +138,14 @@ in {
       '';
     };
 
+    system.defaults.dock.show-recents = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show recent applications in the dock. The default is true.
+      '';
+    };
+
     system.defaults.dock.static-only = mkOption {
       type = types.nullOr types.bool;
       default = null;


### PR DESCRIPTION
New option introduced in Mojave.