### PR TITLE
nix module: don't disable the builders by default

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -41,9 +41,6 @@ let
           ''}
           trusted-users = ${toString cfg.trustedUsers}
           allowed-users = ${toString cfg.allowedUsers}
-          ${optionalString (isNix20 && !cfg.distributedBuilds) ''
-            builders =
-          ''}
           $extraOptions
           END
         '';


### PR DESCRIPTION
If nix.distributedBuilds is set then it means that /etc/nix/machines is
being managed by nix-darwin. Otherwise, leave that impure.

This will allow to fix https://github.com/nix-community/linuxkit-nix/issues/7