### PR TITLE
zsh: Add vendor-completions to fpath

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -173,7 +173,7 @@ in
 
       # Tell zsh how to find installed completions
       for p in ''${(z)NIX_PROFILES}; do
-        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions)
+        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
       done
 
       ${cfg.promptInit}


### PR DESCRIPTION
This was added to NixOS in NixOS/nixpkgs@003cd41310b5b7839eb4c402d84dc25068026c3e, but apparently never got ported to nix-darwin.

This change makes, at least, `stack` and `git-annex` completions work for me.