### PR TITLE
fonts: rewrite activation

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -1,57 +1,72 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-with builtins;
 
 let
   cfg = config.fonts;
-  readDirsRec = path: let
-    home = readDir path;
-    list = mapAttrsToList (name: type:
-      let newPath = "${path}/${name}";
-      in if (type == "directory" || type == "symlink") && !(isFont name) then readDirsRec newPath else [ newPath ]) home;
-    in flatten list;
-  isFont = name: let
-    fontExt = [ ".ttf" ".otf" ];
-    hasExt = exts: name: foldl' (acc: ext: (hasSuffix ext name) || acc) false exts;
-    in hasExt fontExt name;
-  fontFiles = dir: filter isFont (readDirsRec dir);
-  libraryLink = font: "ln -fn '/run/current-system/sw/share/fonts/${baseNameOf font}' '/Library/Fonts/${baseNameOf font}'";
-  outLink = font: "ln -sfn -t $out/share/fonts/ '${font}'";
-  fontLinks = link: dir: concatMapStringsSep "\n" link (fontFiles dir);
-  systemFontsDir = pkgs.runCommand "systemFontsDir" {} ''
-    mkdir -p "$out/share/fonts"
-    echo ${toString config.fonts.fonts}
-    ${concatMapStringsSep "\n" (fontLinks outLink) config.fonts.fonts}
-  '';
-in {
+in
+
+{
   options = {
-    fonts = {
-      enableFontDir = mkOption {
-        default = false;
-        description = ''
-          Whether to enable font directory management and link all fonts in <filename>/run/current-system/sw/share/fonts</filename>.
-          Important: removes all manually-added fonts.
-        '';
-      };
-      fonts = mkOption {
-        type = types.listOf types.path;
-        default = [];
-        example = literalExample "[ pkgs.dejavu_fonts ]";
-        description = "List of primary font paths.";
-      };
+    fonts.enableFontDir = mkOption {
+      default = false;
+      description = ''
+        Whether to enable font management and install configured fonts to
+        <filename>/Library/Fonts</filename>.
+
+        NOTE: removes any manually-added fonts.
+      '';
+    };
+
+    fonts.fonts = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = literalExample "[ pkgs.dejavu_fonts ]";
+      description = "List of fonts to install.";
     };
   };
-  
+
   config = {
-    system.activationScripts.fonts.text = "" + optionalString cfg.enableFontDir ''
+
+    system.build.fonts = pkgs.runCommandNoCC "fonts"
+      { paths = cfg.fonts; preferLocalBuild = true; }
+      ''
+        mkdir -p $out/Library/Fonts
+        for path in $paths; do
+            find -L $path/share/fonts -type f -print0 | while IFS= read -rd "" f; do
+                ln -s "$f" $out/Library/Fonts
+            done
+        done
+      '';
+
+    system.activationScripts.fonts.text = optionalString cfg.enableFontDir ''
       # Set up fonts.
-      echo "resetting fonts..." >&2
-      fontrestore default -n 2>&1 | grep -o '/Library/Fonts/.*' | tr '\n' '\0' | xargs -0 rm || true
-      echo "updating fonts..." >&2
-      ${fontLinks libraryLink systemFontsDir}
+      echo "configuring fonts..." >&2
+      find -L "$systemConfig/Library/Fonts" -type f -print0 | while IFS= read -rd "" l; do
+          font=''${l##*/}
+          f=$(readlink -f "$l")
+          if [ ! -e "/Library/Fonts/$font" ] || [ $(stat -c '%i' "$f") != $(stat -c '%i' "/Library/Fonts/$font") ]; then
+              echo "updating font $font..." >&2
+              # FIXME: hardlink, won't work if nix is on a dedicated filesystem.
+              ln -fn "$f" /Library/Fonts
+          fi
+      done
+
+      fontrestore default -n 2>&1 | while read -r f; do
+          case $f in
+              /Library/Fonts/*)
+                  font=''${f##*/}
+                  if [ ! -e "$systemConfig/Library/Fonts/$font" ]; then
+                      echo "removing font $font..." >&2
+                      rm "/Library/Fonts/$font"
+                  fi
+                  ;;
+              /*)
+                  # ignoring unexpected fonts
+                  ;;
+          esac
+      done
     '';
-    environment.systemPackages = [ systemFontsDir ];
-    environment.pathsToLink = [ "/share/fonts" ];
+
   };
 }

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -91,6 +91,7 @@ in
 
         mkdir -p $out/Library
         ln -s ${cfg.build.applications}/Applications $out/Applications
+        ln -s ${cfg.build.fonts}/Library/Fonts $out/Library/Fonts
         ln -s ${cfg.build.launchd}/Library/LaunchAgents $out/Library/LaunchAgents
         ln -s ${cfg.build.launchd}/Library/LaunchDaemons $out/Library/LaunchDaemons
 

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -12,9 +12,13 @@ in
   fonts.fonts = [ font ];
  
   test = ''
-    echo checking installed fonts >&2
-    grep -o "fontrestore default -n" ${config.out}/activate
-    grep -o "ln -fn '/run/current-system/sw/share/fonts/Font.ttf' '/Library/Fonts/Font.ttf'" ${config.out}/activate
+    echo "checking fonts in /Library/Fonts" >&2
+    test -e ${config.out}/Library/Fonts/Font.ttf
+
+    echo "checking activation of fonts in /activate" >&2
+    grep "fontrestore default -n 2>&1" ${config.out}/activate
+    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate
+    grep 'rm "/Library/Fonts/.*"' ${config.out}/activate
   '';
 }
 


### PR DESCRIPTION
The new implementation is a bit smarter and only updates fonts that
changed.  But more importantly /run/current-system isn't used anymore
which breaks initial activation and installs the previous set of fonts
instead of the one in the new system.

Fixes #115