### PR TITLE
users: install user packages via users.users.<name?>.packages

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -152,12 +152,11 @@ in
 
     environment.systemPath = [ (makeBinPath cfg.profiles) "/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin" ];
 
-    environment.profiles =
-      [ # Use user, default and system profiles.
-        "$HOME/.nix-profile"
-        "/run/current-system/sw"
-        "/nix/var/nix/profiles/default"
-      ];
+    # Use user, default and system profiles.
+    environment.profiles = mkMerge [
+      (mkOrder 800 [ "$HOME/.nix-profile" ])
+      [ "/run/current-system/sw" "/nix/var/nix/profiles/default" ]
+    ];
 
     environment.pathsToLink = [ "/bin" "/share/locale" ];
 

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -158,5 +158,16 @@ in
       '') deletedUsers}
     '';
 
+    environment.etc = mapAttrs' (name: { packages, ... }: {
+      name = "profiles/per-user/${name}";
+      value.source = pkgs.buildEnv {
+        name = "user-environment";
+        paths = packages;
+        inherit (config.environment) pathsToLink extraOutputsToInstall;
+        inherit (config.system.path) postBuild;
+      };
+    }) (filterAttrs (_: u: u.packages != []) cfg.users);
+
+    environment.profiles = [ "/etc/profiles/per-user/$USER" ];
   };
 }

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -168,6 +168,6 @@ in
       };
     }) (filterAttrs (_: u: u.packages != []) cfg.users);
 
-    environment.profiles = [ "/etc/profiles/per-user/$USER" ];
+    environment.profiles = mkOrder 900 [ "/etc/profiles/per-user/$USER" ];
   };
 }

--- a/modules/users/user.nix
+++ b/modules/users/user.nix
@@ -57,6 +57,17 @@ with lib;
       example = literalExample "pkgs.bashInteractive";
       description = "The user's shell.";
     };
+
+    packages = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      example = literalExample "[ pkgs.firefox pkgs.thunderbird ]";
+      description = ''
+        The set of packages that should be made availabe to the user.
+        This is in contrast to <option>environment.systemPackages</option>,
+        which adds packages to all users.
+      '';
+    };
   };
 
   config = {

--- a/release.nix
+++ b/release.nix
@@ -117,6 +117,7 @@ let
     tests.system-path = makeTest ./tests/system-path.nix;
     tests.system-shells = makeTest ./tests/system-shells.nix;
     tests.users-groups = makeTest ./tests/users-groups.nix;
+    tests.users-packages = makeTest ./tests/users-packages.nix;
     tests.fonts = makeTest ./tests/fonts.nix;
 
   }

--- a/tests/users-packages.nix
+++ b/tests/users-packages.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+
+{
+  users.knownUsers = [ "foo" ];
+  users.users.foo.uid = 42000;
+  users.users.foo.gid = 42000;
+  users.users.foo.description = "Foo user";
+  users.users.foo.isHidden = false;
+  users.users.foo.home = "/Users/foo";
+  users.users.foo.shell = "/run/current-system/sw/bin/bash";
+  users.users.foo.packages = [ pkgs.hello ];
+
+  test = ''
+    echo "checking for hello in /etc/profiles/per-user/foo" >&2
+    test -x /etc/profiles/per-user/foo/bin/hello
+  '';
+}


### PR DESCRIPTION
Nix darwin can now install user packages in a dedicated user-profile under `/etc/profiles/per-user/<name?>`.