### PR TITLE
postgresql: Use core `ln` from coreutils

### DIFF
--- a/modules/services/postgresql/default.nix
+++ b/modules/services/postgresql/default.nix
@@ -71,7 +71,7 @@ in
           if ! test -e ${cfg.dataDir}/PG_VERSION; then
             initdb -U postgres -D ${cfg.dataDir}
           fi
-          ln -sfn ${configFile} ${cfg.dataDir}/postgresql.conf
+          ${pkgs.coreutils}/bin/ln -sfn ${configFile} ${cfg.dataDir}/postgresql.conf
 
           exec ${cfg.package}/bin/postgres -D ${cfg.dataDir} ${optionalString cfg.enableTCPIP "-i"}
         '';


### PR DESCRIPTION
Otherwise it fallbacks to `/bin/ln` which is outdated and might not work.

I'm in macOS 10.12 and this `ln` doesn't work