### PR TITLE
port autossh service from nixos

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -30,6 +30,7 @@
   ./fonts
   ./launchd
   ./services/activate-system
+  ./services/autossh.nix
   ./services/buildkite-agent.nix
   ./services/chunkwm.nix
   ./services/emacs.nix

--- a/modules/services/autossh.nix
+++ b/modules/services/autossh.nix
@@ -1,0 +1,106 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.autossh;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.autossh = {
+
+      sessions = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            name = mkOption {
+              type = types.string;
+              example = "socks-peer";
+              description = "Name of the local AutoSSH session";
+            };
+            user = mkOption {
+              type = types.string;
+              example = "bill";
+              description = "Name of the user the AutoSSH session should run as";
+            };
+            monitoringPort = mkOption {
+              type = types.int;
+              default = 0;
+              example = 20000;
+              description = ''
+                Port to be used by AutoSSH for peer monitoring. Note, that
+                AutoSSH also uses mport+1. Value of 0 disables the keep-alive
+                style monitoring
+              '';
+            };
+            extraArguments = mkOption {
+              type = types.string;
+              example = "-N -D4343 bill@socks.example.net";
+              description = ''
+                Arguments to be passed to AutoSSH and retransmitted to SSH
+                process. Some meaningful options include -N (don't run remote
+                command), -D (open SOCKS proxy on local port), -R (forward
+                remote port), -L (forward local port), -v (Enable debug). Check
+                ssh manual for the complete list.
+              '';
+            };
+          };
+        });
+
+        default = [];
+        description = ''
+          List of AutoSSH sessions to start as systemd services. Each service is
+          named 'autossh-{session.name}'.
+        '';
+
+        example = [
+          {
+            name="socks-peer";
+            user="bill";
+            monitoringPort = 20000;
+            extraArguments="-N -D4343 billremote@socks.host.net";
+          }
+        ];
+
+      };
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf (cfg.sessions != []) {
+
+    launchd.daemons =
+      lib.fold ( s : acc : acc //
+        {
+          "autossh-${s.name}" =
+            let
+              mport = if s ? monitoringPort then s.monitoringPort else 0;
+            in
+            {
+              # To be able to start the service with no network connection
+              environment.AUTOSSH_GATETIME="0";
+
+              # How often AutoSSH checks the network, in seconds
+              environment.AUTOSSH_POLL="30";
+
+              command = "${pkgs.autossh}/bin/autossh -M ${toString mport} ${s.extraArguments}";
+
+              serviceConfig = {
+                  KeepAlive = true;
+                  UserName = "${s.user}";
+              };
+            };
+        }) {} cfg.sessions;
+
+    environment.systemPackages = [ pkgs.autossh ];
+
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -98,6 +98,7 @@ let
     examples.simple = makeSystem ./modules/examples/simple.nix;
 
     tests.activation-scripts = makeTest ./tests/activation-scripts.nix;
+    tests.autossh = makeTest ./tests/autossh.nix;
     tests.checks-nix-gc = makeTest ./tests/checks-nix-gc.nix;
     tests.environment-path = makeTest ./tests/environment-path.nix;
     tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;

--- a/tests/autossh.nix
+++ b/tests/autossh.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+
+{
+  services.autossh.sessions = [ {
+    name = "foo";
+    user = "jfelice";
+    extraArguments = "-i /some/key -T -N bar.eraserhead.net";
+  } ];
+
+  test = ''
+    plist=${config.out}/Library/LaunchDaemons/org.nixos.autossh-foo.plist
+    test -f $plist
+    grep '<string>exec /nix/store/.*/bin/autossh ' $plist
+    grep '<string>exec.*-i /some/key ' $plist
+    tr -d '\n\t ' <$plist |grep '<key>KeepAlive</key><true */>'
+  '';
+}


### PR DESCRIPTION
The options are identical, the only change is the use of `launchd.daemons` rather than the systemd configuration for starting sessions.  Well, that and `KeepAlive` is instructed to restart even on error exit, instead of just on success exit.  I'm not sure why you'd want to not restart on error.

It is working for me with [this config](https://github.com/eraserhd/dotfiles/blob/develop/macbook.nix#L23-L36).