### PR TITLE
System packages to applications

### DIFF
--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -6,6 +6,17 @@ let
 
   cfg = config.system;
 
+  packageUsers = filterAttrs (_: u: u.packages != []) config.users.users;
+
+  userApplications = mapAttrs (name: { packages, home, ... }: {
+    home = home;
+    applications = pkgs.buildEnv {
+      name = "${name}-applications";
+      paths = packages;
+      pathsToLink = "/Applications";
+    };
+  }) packageUsers;
+
 in
 
 {
@@ -29,6 +40,19 @@ in
       else
         echo "warning: /Applications/Nix Apps is a directory, skipping App linking..." >&2
       fi
+
+      ${concatStringsSep "\n" (mapAttrsToList (name: { applications, home }: ''
+        # Set up applications for ${name}
+        echo "setting up ${home}/Applications"
+
+        if [ ! -e ${home}/Applications -o -L ${home}/Applications ]; then
+          ln -sfn ${applications}/Applications ${home}/Applications
+        elif [ ! -e ${home}/Applications/Nix\ Apps -o -L ${home}/Applications/Nix\ Apps ]; then
+          ln -sfn ${applications}/Applications ${home}/Applications/Nix\ Apps
+        else
+          echo "warning: ${home}/Applications and ${home}/Applications/Nix Apps are directories, skipping App linking..." >&2
+        fi
+      '') userApplications)}
     '';
 
   };

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -22,14 +22,12 @@ in
 
     system.activationScripts.applications.text = ''
       # Set up applications.
-      echo "setting up ~/Applications..." >&2
+      echo "setting up /Applications/Nix Apps..." >&2
 
-      if [ ! -e ~/Applications -o -L ~/Applications ]; then
-        ln -sfn ${cfg.build.applications}/Applications ~/Applications
-      elif [ ! -e ~/Applications/Nix\ Apps -o -L ~/Applications/Nix\ Apps ]; then
-        ln -sfn ${cfg.build.applications}/Applications ~/Applications/Nix\ Apps
+      if [ ! -e /Applications/Nix\ Apps -o -L /Applications/Nix\ Apps ]; then
+        ln -sfn ${cfg.build.applications}/Applications /Applications/Nix\ Apps
       else
-        echo "warning: ~/Applications and ~/Applications/Nix Apps are directories, skipping App linking..." >&2
+        echo "warning: /Applications/Nix Apps is a directory, skipping App linking..." >&2
       fi
     '';
 

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -14,8 +14,8 @@ with lib;
   launchd.user.agents = mkForce {};
 
   system.activationScripts.postUserActivation.text = mkAfter ''
-    if test -L ~/Applications; then
-        rm ~/Applications
+    if test -L /Applications/Nix\ Apps; then
+        rm /Applications/Nix\ Apps
     fi
 
     if test -L ~/.nix-defexpr/channels/darwin; then

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     echo >&2
     echo >&2 "Uninstalling nix-darwin, this will:"
     echo >&2
-    echo >&2 "    - remove ~/Applications link."
+    echo >&2 "    - remove /Applications/Nix Apps link."
     echo >&2 "    - cleanup static /etc files."
     echo >&2 "    - disable and remove all launchd services managed by nix-darwin."
     echo >&2 "    - restore daemon service from nix installer (only when this is a multi-user install)."


### PR DESCRIPTION
this moves system packages to `/Applications` and user applications to `~/Applications` or `~/Applications/Nix Apps`.

resolves one bullet of #96, #139.