### PR TITLE
Add defaults write for the alert sound

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -10,6 +10,7 @@
   ./system/defaults-write.nix
   ./system/defaults/LaunchServices.nix
   ./system/defaults/NSGlobalDomain.nix
+  ./system/defaults/GlobalPreferences.nix
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
   ./system/defaults/screencapture.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -22,6 +22,7 @@ let
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
 
   NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
+  GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
@@ -44,12 +45,13 @@ in
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
-      [ NSGlobalDomain LaunchServices dock finder screencapture trackpad trackpadBluetooth ]
+      [ NSGlobalDomain GlobalPreferences LaunchServices dock finder screencapture trackpad trackpadBluetooth ]
       ''
         # Set defaults
         echo >&2 "user defaults..."
 
         ${concatStringsSep "\n" NSGlobalDomain}
+        ${concatStringsSep "\n" GlobalPreferences}
         ${concatStringsSep "\n" LaunchServices}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}

--- a/modules/system/defaults/GlobalPreferences.nix
+++ b/modules/system/defaults/GlobalPreferences.nix
@@ -1,0 +1,20 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" =
+      mkOption {
+        type = types.nullOr (types.path);
+        default = null;
+        description = ''
+          Sets the system-wide alert sound. Found under "Sound Effects" in the
+          "Sound" section of "System Preferences". Look in
+          "/System/Library/Sounds" for possible candidates.
+        '';
+      };
+
+  };
+}

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -30,6 +30,7 @@
   system.defaults.NSGlobalDomain."com.apple.springing.enabled" = true;
   system.defaults.NSGlobalDomain."com.apple.springing.delay" = "0.0";
   system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" = true;
+  system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" = "/System/Library/Sounds/Funk.aiff";
   system.defaults.dock.autohide-delay = "0.24";
   system.defaults.dock.orientation = "left";
   system.defaults.screencapture.location = "/tmp";
@@ -71,6 +72,7 @@
     grep "defaults write -g 'com.apple.springing.enabled' -bool YES" ${config.out}/activate-user
     grep "defaults write -g 'com.apple.springing.delay' -float 0.0" ${config.out}/activate-user
     grep "defaults write -g 'com.apple.swipescrolldirection' -bool YES" ${config.out}/activate-user
+    grep "defaults write .GlobalPreferences 'com.apple.sound.beep.sound' -string '/System/Library/Sounds/Funk.aiff'" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'autohide-delay' -float 0.24" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'orientation' -string 'left'" ${config.out}/activate-user
     grep "defaults write com.apple.screencapture 'location' -string '/tmp'" ${config.out}/activate-user


### PR DESCRIPTION
Found in `System Preferences`->`Sound`->`Sound Effects`, the default is `Funk`.

I was missing this functionality. `.GlobalPreferences` has only been around since Sierra I believe, not sure if that matters. Also not sure if I should find more keys in this domain to make it a useful addition to nix-darwin?

I didn't verify that this works because I don't know how. Help in doing this would be appreciated.