### PR TITLE
modules: remove usages of types.string

### DIFF
--- a/modules/services/autossh.nix
+++ b/modules/services/autossh.nix
@@ -20,12 +20,12 @@ in
         type = types.listOf (types.submodule {
           options = {
             name = mkOption {
-              type = types.string;
+              type = types.str;
               example = "socks-peer";
               description = "Name of the local AutoSSH session";
             };
             user = mkOption {
-              type = types.string;
+              type = types.str;
               example = "bill";
               description = "Name of the user the AutoSSH session should run as";
             };
@@ -40,7 +40,7 @@ in
               '';
             };
             extraArguments = mkOption {
-              type = types.string;
+              type = types.str;
               example = "-N -D4343 bill@socks.example.net";
               description = ''
                 Arguments to be passed to AutoSSH and retransmitted to SSH

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -17,7 +17,7 @@ in {
       description = "Alternative base URL for the Hercules API";
       example = "https://hercules-ci.com";
       default = null;
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
     };
 
     clusterJoinTokenPath = mkOption {

--- a/modules/services/postgresql/default.nix
+++ b/modules/services/postgresql/default.nix
@@ -62,7 +62,7 @@ in
       };
 
       characterSet = mkOption {
-        type = types.string;
+        type = types.str;
         default = "UTF8";
         example = "SJIS";
         description = ''Character set specified during initialization'';


### PR DESCRIPTION
nixpkgs recently properly deprecated `types.string`: https://github.com/NixOS/nixpkgs/pull/66346