### PR TITLE
Fix path to darwin-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sudo ln -s private/var/run /run
 # Configure the channel
 nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
 nix-channel --update
-export NIX_PATH=darwin=darwin-config=$HOME/.nixpkgs/darwin-configuration.nix:$HOME/.nix-defexpr/channels:$NIX_PATH
+export NIX_PATH=darwin-config=$HOME/.nixpkgs/darwin-configuration.nix:$HOME/.nix-defexpr/channels:$NIX_PATH
 
 # Or use a local git repository
 git clone git@github.com:LnL7/nix-darwin.git ~/.nix-defexpr/darwin


### PR DESCRIPTION
Original version leads to an error:
```
$(nix-build '<darwin>' -A system --no-out-link)/sw/bin/darwin-rebuild build
warning: Nix search path entry 'darwin-config=/Users/test/.nixpkgs/darwin-configuration.nix' does not exist, ignoring
error: file 'darwin-config' was not found in the Nix search path (add it using $NIX_PATH or -I), at /nix/store/z7469wjnpii0ybkfs2ny1lh4vw308n3k-darwin/darwin/default.nix:1:40
(use '--show-trace' to show detailed location information)
```