### PR TITLE
buildkite: add preCommands option

### DIFF
--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -89,6 +89,13 @@ in
         Extra lines to be added verbatim to the configuration file.
       '';
     };
+    services.buildkite-agent.preCommands = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra commands to run before starting buildkite.
+      '';
+    };
 
     services.buildkite-agent.openssh =
       { privateKeyPath = mkOption {
@@ -214,6 +221,8 @@ in
             # Secrets exist in the buildkite-agent home directory
             chmod 750 "${cfg.dataDir}"
             chmod 640 "${cfg.dataDir}/buildkite-agent.cfg"
+
+            ${cfg.preCommands}
 
             exec buildkite-agent start --config "${cfg.dataDir}/buildkite-agent.cfg"
           '';


### PR DESCRIPTION
This adds a `services.buildkite-agent.preCommands` option. This is used to execute any commands you want to run directly before starting the buildkite agent.