### PR TITLE
fonts: Adds support if Nix is on another filesystem.

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -45,10 +45,12 @@ in
       find -L "$systemConfig/Library/Fonts" -type f -print0 | while IFS= read -rd "" l; do
           font=''${l##*/}
           f=$(readlink -f "$l")
-          if [ ! -e "/Library/Fonts/$font" ] || [ $(stat -c '%i' "$f") != $(stat -c '%i' "/Library/Fonts/$font") ]; then
+          if [ ! -e "/Library/Fonts/$font" ]; then
               echo "updating font $font..." >&2
-              # FIXME: hardlink, won't work if nix is on a dedicated filesystem.
-              ln -fn "$f" /Library/Fonts
+              ln -fn -- "$f" /Library/Fonts 2>/dev/null || {
+                echo "Could not create hard link. Nix is probably on another filesystem. Copying the font instead..." >&2
+                cp -fP "$f" /Library/Fonts
+              }
           fi
       done
 

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -49,7 +49,7 @@ in
               echo "updating font $font..." >&2
               ln -fn -- "$f" /Library/Fonts 2>/dev/null || {
                 echo "Could not create hard link. Nix is probably on another filesystem. Copying the font instead..." >&2
-                cp -fP "$f" /Library/Fonts
+                rsync -az --inplace "$f" /Library/Fonts
               }
           fi
       done

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -17,7 +17,7 @@ in
 
     echo "checking activation of fonts in /activate" >&2
     grep "fontrestore default -n 2>&1" ${config.out}/activate
-    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate
+    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate || grep 'cp -fP ".*" /Library/Fonts' ${config.out}/activate
     grep 'rm "/Library/Fonts/.*"' ${config.out}/activate
   '';
 }

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -17,7 +17,7 @@ in
 
     echo "checking activation of fonts in /activate" >&2
     grep "fontrestore default -n 2>&1" ${config.out}/activate
-    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate || grep 'cp -fP ".*" /Library/Fonts' ${config.out}/activate
+    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate || grep 'rsync -az --inplace ".*" /Library/Fonts' ${config.out}/activate
     grep 'rm "/Library/Fonts/.*"' ${config.out}/activate
   '';
 }


### PR DESCRIPTION
On Catalina, the default way is to install Nix on a new volume which breaks hardlinking the font files. If that is the case I just copy them.