### PR TITLE
tmux: clear __NIX_DARWIN_SET_ENVIRONMENT_DONE

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -18,6 +18,7 @@ let
         --set __ETC_ZPROFILE_SOURCED  "" \
         --set __ETC_ZSHENV_SOURCED "" \
         --set __ETC_ZSHRC_SOURCED "" \
+        --set __NIX_DARWIN_SET_ENVIRONMENT_DONE "" \
         --add-flags -f --add-flags /etc/tmux.conf
     '';
 


### PR DESCRIPTION
This change fixes #173.

This is necessary to allow shell sessions inside tmux having a chance to set environment properly.