### PR TITLE
defaults: introduce NSGlobalDomain option for "_HIHideMenuBar"

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -297,6 +297,14 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain._HIHideMenuBar = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to autohide the menu bar.  The default is false.
+      '';
+    };
+
   };
 
 }


### PR DESCRIPTION
Hey @LnL7 👋   

Wanted to set my menu bar to autohide on my system and figured I'd introduce an option to do it declaratively :)

Have tested locally on Catalina 10.15.2

Let me know if there's anything you want me to change!