### PR TITLE
Remove trailing slash from path in commitIdFromGitRepo call

### DIFF
--- a/modules/system/version.nix
+++ b/modules/system/version.nix
@@ -8,8 +8,8 @@ let
   defaultStateVersion = options.system.stateVersion.default;
 
   parseGit = path:
-    if pathExists "${path}/.git/" then rec {
-      rev = commitIdFromGitRepo "${path}/.git/";
+    if pathExists "${path}/.git" then rec {
+      rev = commitIdFromGitRepo "${path}/.git";
       shortRev = substring 0 7 rev;
     }
     else if pathExists "${path}/.git-revision" then rec {


### PR DESCRIPTION
A change of `commitIdFromGitRepo` in nixpkgs/lib/sources.nix
resulted in the error message
"attribute '.git' missing at nixpkgs/lib/sources.nix:7:32" when
executing darwin-rebuils switch.
The commit with the change is
https://github.com/NixOS/nixpkgs/commit/c9214c394b248e1f26e45dbe1be2bd82363af3a6

Removing the trailing slash resolves the error.