### PR TITLE
fonts: copy instead of hardlink for Catalina support

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -47,8 +47,7 @@ in
           f=$(readlink -f "$l")
           if [ ! -e "/Library/Fonts/$font" ] || [ $(stat -c '%i' "$f") != $(stat -c '%i' "/Library/Fonts/$font") ]; then
               echo "updating font $font..." >&2
-              # FIXME: hardlink, won't work if nix is on a dedicated filesystem.
-              ln -fn "$f" /Library/Fonts
+              cp -f "$f" /Library/Fonts
           fi
       done
 

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -47,6 +47,7 @@ in
           f=$(readlink -f "$l")
           if [ ! -e "/Library/Fonts/$font" ] || [ $(stat -c '%i' "$f") != $(stat -c '%i' "/Library/Fonts/$font") ]; then
               echo "updating font $font..." >&2
+              rm -f "/Library/Fonts/$f"
               cp -f "$f" /Library/Fonts
           fi
       done

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -10,14 +10,14 @@ in
 {
   fonts.enableFontDir = true;
   fonts.fonts = [ font ];
- 
+
   test = ''
     echo "checking fonts in /Library/Fonts" >&2
     test -e ${config.out}/Library/Fonts/Font.ttf
 
     echo "checking activation of fonts in /activate" >&2
     grep "fontrestore default -n 2>&1" ${config.out}/activate
-    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate
+    grep 'cp -f ".*" /Library/Fonts' ${config.out}/activate
     grep 'rm "/Library/Fonts/.*"' ${config.out}/activate
   '';
 }


### PR DESCRIPTION
I'm not able to activate my configuration when I install any font because it's not possible to create a hard link between volumes.