### PR TITLE
Rename programs.tmux.tmuxConfig -> extraConfig

### DIFF
--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -106,7 +106,7 @@
   programs.tmux.enableFzf = true;
   programs.tmux.enableVim = true;
 
-  programs.tmux.tmuxConfig = ''
+  programs.tmux.extraConfig = ''
     bind 0 set status
     bind S choose-session
 

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -39,6 +39,9 @@ let
 in
 
 {
+  imports = [
+    (mkRenamedOptionModule [ "programs" "tmux" "tmuxConfig" ] [ "programs" "tmux" "extraConfig" ])
+  ];
   options = {
     programs.tmux.enable = mkOption {
       type = types.bool;
@@ -92,7 +95,7 @@ in
       default = {};
     };
 
-    programs.tmux.tmuxConfig = mkOption {
+    programs.tmux.extraConfig = mkOption {
       type = types.lines;
       default = "";
       description = "Extra configuration to add to <filename>tmux.conf</filename>.";
@@ -112,7 +115,7 @@ in
 
     environment.etc."tmux.conf".text = ''
       ${tmuxOptions}
-      ${cfg.tmuxConfig}
+      ${cfg.extraConfig}
 
       source-file -q /etc/tmux.conf.local
     '';


### PR DESCRIPTION
The old option is still supported for now, but the user is warned.