### PR TITLE
programs.ssh: write ssh known_hosts only if there are any set

### DIFF
--- a/modules/programs/ssh/default.nix
+++ b/modules/programs/ssh/default.nix
@@ -151,12 +151,13 @@ in
     services.openssh.authorizedKeysFiles = [ "%h/.ssh/authorized_keys" "/etc/ssh/authorized_keys.d/%u" ];
 
     environment.etc = authKeysFiles //
-      { "ssh/ssh_known_hosts".text = (flip (concatMapStringsSep "\n") knownHosts
-        (h: assert h.hostNames != [];
-          concatStringsSep "," h.hostNames + " "
-          + (if h.publicKey != null then h.publicKey else readFile h.publicKeyFile)
-        )) + "\n";
-
+      { "ssh/ssh_known_hosts" = mkIf (builtins.length knownHosts > 0) {
+          text = (flip (concatMapStringsSep "\n") knownHosts
+            (h: assert h.hostNames != [];
+              concatStringsSep "," h.hostNames + " "
+              + (if h.publicKey != null then h.publicKey else readFile h.publicKeyFile)
+            )) + "\n";
+        };
         "ssh/sshd_config.d/101-authorized-keys.conf" = {
           text = "AuthorizedKeysFile ${toString config.services.openssh.authorizedKeysFiles}\n";
           # Allows us to automatically migrate from using a file to a symlink

--- a/release.nix
+++ b/release.nix
@@ -114,6 +114,7 @@ let
     tests.programs-ssh = makeTest ./tests/programs-ssh.nix;
     tests.programs-tmux = makeTest ./tests/programs-tmux.nix;
     tests.programs-zsh = makeTest ./tests/programs-zsh.nix;
+    tests.programs-ssh-empty-known-hosts = makeTest ./tests/programs-ssh-empty-known-hosts.nix;
     tests.security-pki = makeTest ./tests/security-pki.nix;
     tests.services-activate-system = makeTest ./tests/services-activate-system.nix;
     tests.services-activate-system-changed-label-prefix = makeTest ./tests/services-activate-system-changed-label-prefix.nix;

--- a/tests/programs-ssh-empty-known-hosts.nix
+++ b/tests/programs-ssh-empty-known-hosts.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+
+{
+  test = ''
+    echo >&2 "checking existance of /etc/ssh/ssh_known_hosts"
+    if test -e ${config.out}/etc/ssh/ssh_known_hosts; then
+      echo >&2 "/etc/ssh/ssh_known_hosts exists but it shouldn't!"
+      exit 1
+    fi
+  '';
+}


### PR DESCRIPTION
I noticed that I'm getting an empty `/etc/ssh/ssh_known_hosts`, and it seems that we were not gating its config.