### PR TITLE
environment: add currentSystemPath option for /run/current-system

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -37,6 +37,15 @@ in
       apply = x: if isList x then makeDrvBinPath x else x;
     };
 
+    environment.currentSystemPath = mkOption {
+      type = types.either types.path types.str;
+      description = ''
+        The location where to expose the nix-darwin system.
+      '';
+      default = /run/current-system;
+      apply = p: builtins.toString p;
+    };
+
     environment.profiles = mkOption {
       type = types.listOf types.str;
       description = "A list of profiles used to setup the global environment.";
@@ -155,7 +164,7 @@ in
     # Use user, default and system profiles.
     environment.profiles = mkMerge [
       (mkOrder 800 [ "$HOME/.nix-profile" ])
-      [ "/run/current-system/sw" "/nix/var/nix/profiles/default" ]
+      [ "${config.environment.currentSystemPath}/sw" "/nix/var/nix/profiles/default" ]
     ];
 
     environment.pathsToLink = [ "/bin" "/share/locale" ];

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -443,7 +443,7 @@ in
     '';
 
     system.activationScripts.nix-daemon.text = mkIf cfg.useDaemon ''
-      if ! diff /etc/nix/nix.conf /run/current-system/etc/nix/nix.conf &> /dev/null; then
+      if ! diff /etc/nix/nix.conf ${config.environment.currentSystemPath}/etc/nix/nix.conf &> /dev/null; then
           echo "reloading nix-daemon..." >&2
           launchctl kill HUP system/org.nixos.nix-daemon
       fi

--- a/modules/services/activate-system/default.nix
+++ b/modules/services/activate-system/default.nix
@@ -23,12 +23,12 @@ in
       script = ''
         # Make this configuration the current configuration.
         # The readlink is there to ensure that when $systemConfig = /system
-        # (which is a symlink to the store), /run/current-system is still
+        # (which is a symlink to the store), ${config.environment.currentSystemPath} is still
         # used as a garbage collection root.
-        ln -sfn $(cat ${config.system.profile}/systemConfig) /run/current-system
+        ln -sfn $(cat ${config.system.profile}/systemConfig) ${config.environment.currentSystemPath}
 
         # Prevent the current configuration from being garbage-collected.
-        ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+        ln -sfn ${config.environment.currentSystemPath} /nix/var/nix/gcroots/current-system
 
         ${config.system.activationScripts.keyboard.text}
         ${config.system.activationScripts.nix.text}

--- a/modules/services/chunkwm.nix
+++ b/modules/services/chunkwm.nix
@@ -36,7 +36,7 @@ in
 
     services.chunkwm.plugins.dir = mkOption {
       type = types.path;
-      default = "/run/current-system/sw/lib/chunkwm/plugins";
+      default = "${config.environment.currentSystemPath}/sw/lib/chunkwm/plugins";
       description = "Chunkwm Plugins directory.";
     };
 

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -75,12 +75,12 @@ in
 
       # Make this configuration the current configuration.
       # The readlink is there to ensure that when $systemConfig = /system
-      # (which is a symlink to the store), /run/current-system is still
+      # (which is a symlink to the store), ${config.environment.currentSystemPath} is still
       # used as a garbage collection root.
-      ln -sfn "$(readlink -f "$systemConfig")" /run/current-system
+      ln -sfn "$(readlink -f "$systemConfig")" ${config.environment.currentSystemPath}
 
       # Prevent the current configuration from being garbage-collected.
-      ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+      ln -sfn ${config.environment.currentSystemPath} /nix/var/nix/gcroots/current-system
 
       exit $_status
     '';

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -7,11 +7,11 @@ let
 
   darwinChanges = ''
     darwinChanges=/dev/null
-    if test -e /run/current-system/darwin-changes; then
-      darwinChanges=/run/current-system/darwin-changes
+    if test -e ${config.environment.currentSystemPath}/darwin-changes; then
+      darwinChanges=${config.environment.currentSystemPath}/darwin-changes
     fi
 
-    darwinChanges=$(diff --changed-group-format='%>' --unchanged-group-format= /run/current-system/darwin-changes $systemConfig/darwin-changes 2> /dev/null) || true
+    darwinChanges=$(diff --changed-group-format='%>' --unchanged-group-format= ${config.environment.currentSystemPath}/darwin-changes $systemConfig/darwin-changes 2> /dev/null) || true
     if test -n "$darwinChanges"; then
       echo >&2
       echo "[1;1mCHANGELOG[0m" >&2

--- a/modules/system/launchd.nix
+++ b/modules/system/launchd.nix
@@ -105,7 +105,7 @@ in
       ${concatMapStringsSep "\n" (attr: launchdActivation "LaunchAgents" attr.target) launchAgents}
       ${concatMapStringsSep "\n" (attr: launchdActivation "LaunchDaemons" attr.target) launchDaemons}
 
-      for f in $(ls /run/current-system/Library/LaunchAgents 2> /dev/null); do
+      for f in $(ls ${config.environment.currentSystemPath}/Library/LaunchAgents 2> /dev/null); do
         if test ! -e "${cfg.build.launchd}/Library/LaunchAgents/$f"; then
           echo "removing service $(basename $f .plist)" >&2
           launchctl unload "/Library/LaunchAgents/$f" || true
@@ -113,7 +113,7 @@ in
         fi
       done
 
-      for f in $(ls /run/current-system/Library/LaunchDaemons 2> /dev/null); do
+      for f in $(ls ${config.environment.currentSystemPath}/Library/LaunchDaemons 2> /dev/null); do
         if test ! -e "${cfg.build.launchd}/Library/LaunchDaemons/$f"; then
           echo "removing service $(basename $f .plist)" >&2
           launchctl unload "/Library/LaunchDaemons/$f" || true
@@ -133,7 +133,7 @@ in
       ''}
       ${concatMapStringsSep "\n" (attr: userLaunchdActivation attr.target) userLaunchAgents}
 
-      for f in $(ls /run/current-system/user/Library/LaunchAgents 2> /dev/null); do
+      for f in $(ls ${config.environment.currentSystemPath}/user/Library/LaunchAgents 2> /dev/null); do
         if test ! -e "${cfg.build.launchd}/user/Library/LaunchAgents/$f"; then
           echo "removing user service $(basename $f .plist)" >&2
           launchctl unload ~/Library/LaunchAgents/$f || true

--- a/modules/system/shells.nix
+++ b/modules/system/shells.nix
@@ -18,7 +18,7 @@ in
         and other shells that are available by default on
         macOS.
       '';
-      apply = map (v: if types.shellPackage.check v then "/run/current-system/sw${v.shellPath}" else v);
+      apply = map (v: if types.shellPackage.check v then "${config.environment.currentSystemPath}/sw${v.shellPath}" else v);
     };
   };
 

--- a/release.nix
+++ b/release.nix
@@ -101,6 +101,7 @@ let
     tests.autossh = makeTest ./tests/autossh.nix;
     tests.checks-nix-gc = makeTest ./tests/checks-nix-gc.nix;
     tests.environment-path = makeTest ./tests/environment-path.nix;
+    tests.environment-path-custom = makeTest ./tests/environment-path-custom.nix;
     tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;
     tests.launchd-setenv = makeTest ./tests/launchd-setenv.nix;
     tests.networking-hostname = makeTest ./tests/networking-hostname.nix;
@@ -111,6 +112,7 @@ let
     tests.programs-zsh = makeTest ./tests/programs-zsh.nix;
     tests.security-pki = makeTest ./tests/security-pki.nix;
     tests.services-activate-system = makeTest ./tests/services-activate-system.nix;
+    tests.services-activate-system-custom = makeTest ./tests/services-activate-system-custom.nix;
     tests.services-buildkite-agent = makeTest ./tests/services-buildkite-agent.nix;
     tests.services-nix-daemon = makeTest ./tests/services-nix-daemon.nix;
     tests.sockets-nix-daemon = makeTest ./tests/sockets-nix-daemon.nix;
@@ -127,6 +129,7 @@ let
     tests.system-packages = makeTest ./tests/system-packages.nix;
     tests.system-path = makeTest ./tests/system-path.nix;
     tests.system-shells = makeTest ./tests/system-shells.nix;
+    tests.system-shells-custom = makeTest ./tests/system-shells-custom.nix;
     tests.users-groups = makeTest ./tests/users-groups.nix;
     tests.users-packages = makeTest ./tests/users-packages.nix;
     tests.fonts = makeTest ./tests/fonts.nix;

--- a/tests/environment-path-custom.nix
+++ b/tests/environment-path-custom.nix
@@ -1,0 +1,12 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  environment.currentSystemPath = /run/to/current/system;
+
+  test = ''
+    echo checking /run/to/current/system/sw/bin in environment >&2
+    grep 'export PATH=.*:/run/to/current/system/sw/bin' ${config.system.build.setEnvironment}
+  '';
+}

--- a/tests/services-activate-system-custom.nix
+++ b/tests/services-activate-system-custom.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+
+{
+  services.activate-system.enable = true;
+  environment.currentSystemPath = /run/to/current/system;
+
+  test = ''
+    echo checking activation service in /Library/LaunchDaemons >&2
+    grep "org.nixos.activate-system" ${config.out}/Library/LaunchDaemons/org.nixos.activate-system.plist
+
+    echo checking activation of /run/to/current/system >&2
+    script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.activate-system.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
+    grep "ln -sfn .* /run/to/current/system" "$script"
+  '';
+}

--- a/tests/system-shells-custom.nix
+++ b/tests/system-shells-custom.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+
+{
+   environment.shells = [ pkgs.zsh ];
+   environment.currentSystemPath = /run/to/current/system;
+
+   test = ''
+     echo checking zsh in /etc/shells >&2
+     grep '/run/to/current/system/sw/bin/zsh' ${config.out}/etc/shells
+   '';
+}


### PR DESCRIPTION
By adding this option, it allows multiple instances of nix-darwin to setup the machine.

At work, I'm adding nix-darwin as a submodule of our module system so we can install daemons for the user. However, it's not currently possible as it conflicts with the user installed nix-darwin.