### PR TITLE
launchd: allow customization of the default launchd prefix

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -88,7 +88,7 @@ let
           ${config.script}
         '');
 
-        serviceConfig.Label = mkDefault "org.nixos.${name}";
+        serviceConfig.Label = mkDefault "${cfg.labelPrefix}.${name}";
         serviceConfig.ProgramArguments = mkIf (cmd != "") [ "/bin/sh" "-c" "exec ${cmd}" ];
         serviceConfig.EnvironmentVariables = mkIf (env != {}) env;
       };
@@ -97,6 +97,15 @@ in
 
 {
   options = {
+    launchd.labelPrefix = mkOption {
+      type = types.str;
+      default = "org.nixos";
+      description = ''
+        The default prefix of the service label. Individual services can
+        override this by setting the Label attribute.
+      '';
+    };
+
     launchd.envVariables = mkOption {
       type = types.attrsOf (types.either types.str (types.listOf types.str));
       default = {};

--- a/modules/services/nix-daemon.nix
+++ b/modules/services/nix-daemon.nix
@@ -51,6 +51,7 @@ in
       serviceConfig.ProcessType = mkDefault "Interactive";
       serviceConfig.LowPriorityIO = config.nix.daemonIONice;
       serviceConfig.Nice = config.nix.daemonNiceLevel;
+      serviceConfig.Label = "org.nixos.nix-daemon"; # must match daemon installed by Nix regardless of the launchd label Prefix
       serviceConfig.SoftResourceLimits.NumberOfFiles = mkDefault 4096;
       serviceConfig.StandardErrorPath = cfg.logFile;
 

--- a/release.nix
+++ b/release.nix
@@ -111,6 +111,7 @@ let
     tests.programs-zsh = makeTest ./tests/programs-zsh.nix;
     tests.security-pki = makeTest ./tests/security-pki.nix;
     tests.services-activate-system = makeTest ./tests/services-activate-system.nix;
+    tests.services-activate-system-changed-label-prefix = makeTest ./tests/services-activate-system-changed-label-prefix.nix;
     tests.services-buildkite-agent = makeTest ./tests/services-buildkite-agent.nix;
     tests.services-nix-daemon = makeTest ./tests/services-nix-daemon.nix;
     tests.sockets-nix-daemon = makeTest ./tests/sockets-nix-daemon.nix;

--- a/tests/services-activate-system-changed-label-prefix.nix
+++ b/tests/services-activate-system-changed-label-prefix.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+
+{
+  services.activate-system.enable = true;
+  launchd.labelPrefix = "org.nix-darwin";
+
+  test = ''
+    echo checking activation service in /Library/LaunchDaemons >&2
+    grep "org.nix-darwin.activate-system" ${config.out}/Library/LaunchDaemons/org.nix-darwin.activate-system.plist
+
+    echo checking activation of /run/current-system >&2
+    script=$(cat ${config.out}/Library/LaunchDaemons/org.nix-darwin.activate-system.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
+    grep "ln -sfn .* /run/current-system" "$script"
+  '';
+}

--- a/tests/services-nix-daemon.nix
+++ b/tests/services-nix-daemon.nix
@@ -8,6 +8,7 @@ in
 {
   services.nix-daemon.enable = true;
   nix.package = nix;
+  launchd.labelPrefix = "org.nix-darwin"; # should not have an effect on nix-daemon
 
   environment.variables.NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-certificates.crt";
 

--- a/tests/sockets-nix-daemon.nix
+++ b/tests/sockets-nix-daemon.nix
@@ -8,6 +8,7 @@ in
   services.nix-daemon.enable = true;
   services.nix-daemon.enableSocketListener = true;
   nix.package = nix;
+  launchd.labelPrefix = "org.nix-darwin"; # should not have an effect on nix-daemon
 
   test = ''
     echo checking nix-daemon service in /Library/LaunchDaemons >&2


### PR DESCRIPTION
By adding this option, it allows multiple instances of nix-darwin to setup the machine.

At work, I'm adding nix-darwin as a submodule of our module system so we can install daemons for the user. However, it's not currently possible as it conflicts with the user installed nix-darwin.