### PR TITLE
Add DNSmasq service

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -38,6 +38,7 @@
   ./services/autossh.nix
   ./services/buildkite-agent.nix
   ./services/chunkwm.nix
+  ./services/dnsmasq.nix
   ./services/emacs.nix
   ./services/khd
   ./services/kwm

--- a/modules/services/dnsmasq.nix
+++ b/modules/services/dnsmasq.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dnsmasq;
+  mapA = f: attrs: with builtins; attrValues (mapAttrs f attrs);
+in
+
+{
+  options = {
+    services.dnsmasq.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable DNSmasq.";
+    };
+
+    services.dnsmasq.package = mkOption {
+      type = types.path;
+      default = pkgs.dnsmasq;
+      defaultText = "pkgs.dnsmasq";
+      description = "This option specifies the dnsmasq package to use.";
+    };
+
+    services.dnsmasq.bind = mkOption {
+      type = types.string;
+      default = "127.0.0.1";
+      description = "This option specifies the interface on which DNSmasq will listen.";
+    };
+
+    services.dnsmasq.port = mkOption {
+      type = types.int;
+      default = 53;
+      description = "This option specifies port on which DNSmasq will listen.";
+    };
+
+    services.dnsmasq.addresses = mkOption {
+      type = types.attrs;
+      default = {};
+      description = "List of domains that will be redirected by the DNSmasq";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    launchd.daemons.dnsmasq = {
+      serviceConfig.ProgramArguments = [
+        "${cfg.package}/bin/dnsmasq"
+        "--listen-address=${cfg.bind}"
+        "--port=${toString cfg.port}"
+        "--keep-in-foreground"
+      ] ++ (mapA (domain: addr: "--address=/${domain}/${addr}") cfg.addresses);
+
+      serviceConfig.KeepAlive = true;
+      serviceConfig.RunAtLoad = true;
+    };
+
+    environment.etc = builtins.listToAttrs (builtins.map (domain: {
+      name = "resolver/${domain}";
+      value = {
+        enable = true;
+        text = "nameserver ${cfg.bind}.${toString cfg.port}";
+      };
+    }) (builtins.attrNames cfg.addresses));
+  };
+}

--- a/modules/services/dnsmasq.nix
+++ b/modules/services/dnsmasq.nix
@@ -23,7 +23,7 @@ in
     };
 
     services.dnsmasq.bind = mkOption {
-      type = types.string;
+      type = types.str;
       default = "127.0.0.1";
       description = "This option specifies the interface on which DNSmasq will listen.";
     };

--- a/modules/services/dnsmasq.nix
+++ b/modules/services/dnsmasq.nix
@@ -37,7 +37,10 @@ in
     services.dnsmasq.addresses = mkOption {
       type = types.attrs;
       default = {};
-      description = "List of domains that will be redirected by the DNSmasq";
+      description = "List of domains that will be redirected by the DNSmasq.";
+      example = literalExample ''
+        { localhost = "127.0.0.1"; }
+        '';
     };
   };
 

--- a/release.nix
+++ b/release.nix
@@ -114,13 +114,14 @@ let
     tests.services-buildkite-agent = makeTest ./tests/services-buildkite-agent.nix;
     tests.services-nix-daemon = makeTest ./tests/services-nix-daemon.nix;
     tests.sockets-nix-daemon = makeTest ./tests/sockets-nix-daemon.nix;
+    tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
     tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
     tests.services-ofborg = makeTest ./tests/services-ofborg.nix;
     tests.services-offlineimap = makeTest ./tests/services-offlineimap.nix;
+    tests.services-privoxy = makeTest ./tests/services-privoxy.nix;
     tests.services-skhd = makeTest ./tests/services-skhd.nix;
     tests.services-synapse-bt = makeTest ./tests/services-synapse-bt.nix;
     tests.services-synergy = makeTest ./tests/services-synergy.nix;
-    tests.services-privoxy = makeTest ./tests/services-privoxy.nix;
     tests.system-defaults-write = makeTest ./tests/system-defaults-write.nix;
     tests.system-environment = makeTest ./tests/system-environment.nix;
     tests.system-keyboard-mapping = makeTest ./tests/system-keyboard-mapping.nix;

--- a/tests/services-dnsmasq.nix
+++ b/tests/services-dnsmasq.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  dnsmasq = pkgs.runCommand "dnsmasq-0.0.0" {} "mkdir $out";
+in
+
+{
+  services.dnsmasq.enable = true;
+  services.dnsmasq.package = dnsmasq;
+  services.dnsmasq.addresses = {
+    localhost = "127.0.0.1";
+  };
+
+  test = ''
+    echo >&2 "checking dnsmasq service in /Library/LaunchDaemons"
+    grep "org.nixos.dnsmasq" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
+    grep "${dnsmasq}/bin/dnsmasq" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
+    grep -F -- "--address=/localhost/127.0.0.1" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
+
+    echo >&2 "checking resolver config"
+    grep -F "nameserver 127.0.0.1.53" ${config.out}/etc/resolver/localhost
+  '';
+}


### PR DESCRIPTION
This is useful for redirecting some TLDs to the different addresses. For
example I use it to make all requests to `*.localhost` to be resolved to
loopback address which allows me to easily work and test services that
are relying on different domains.