### PR TITLE
Separate yabai config and extra config by newline

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -14,7 +14,7 @@ let
       (if (cfg.config != {})
        then "${toYabaiConfig cfg.config}"
        else "")
-      + optionalString (cfg.extraConfig != "") cfg.extraConfig)}";
+      + optionalString (cfg.extraConfig != "") ("\n" + cfg.extraConfig + "\n"))}";
 in
 
 {

--- a/tests/services-yabai.nix
+++ b/tests/services-yabai.nix
@@ -23,5 +23,6 @@ in
     echo >&2 "checking config in $conf"
     grep "yabai -m config focus_follows_mouse autoraise" $conf
     grep "yabai -m rule --add app='System Preferences' manage=off" $conf
+    if [ `cat $conf | wc -l` -eq "2" ]; then echo "yabairc correctly contains 2 lines"; else return 1; fi
   '';
 }


### PR DESCRIPTION
If a user passes both `config` and `extraConfig` to the `yabai` serivce,
the generated `yabairc` file is invalid. This is because we do not add a
newline separator when we concatenate the config string generated by
`toYabaiConfig cfg.config` with `cfg.extraConfig`.

This PR prepends a newline to `cfg.extraConfig` if it is non-empty so
that the resulting `yabairc` config is valid.

@LnL7 @cmacrae could you please take a look? Let me know if I'm missing anything important. I tested this change locally and the generated `yabairc` is now correct. 