### PR TITLE
Only enable `services.nix-daemon` when no config is present upon install

### DIFF
--- a/pkgs/darwin-installer/default.nix
+++ b/pkgs/darwin-installer/default.nix
@@ -54,11 +54,11 @@ stdenv.mkDerivation {
         mkdir -p "$HOME/.nixpkgs"
         cp "${toString ../../modules/examples/simple.nix}" "$config"
         chmod u+w "$config"
-    fi
 
-    # Enable nix-daemon service for multi-user installs.
-    if [ ! -w /nix/var/nix/db ]; then
-        sed -i 's/# services.nix-daemon.enable/services.nix-daemon.enable/' "$config"
+        # Enable nix-daemon service for multi-user installs.
+        if [ ! -w /nix/var/nix/db ]; then
+            sed -i 's/# services.nix-daemon.enable/services.nix-daemon.enable/' "$config"
+        fi
     fi
 
     # Skip when stdin is not a tty, eg.


### PR DESCRIPTION
I'm trying to bootstrap my machine from an existing config, which happens to be in a non-writable location. GNU `sed` doesn't like this and throws the following error:

```
sed: couldn't open temporary file /etc/macos/sedc9wviD: Permission denied
```

Would others agree it's reasonable to only run `sed` within the "config doesn't exist" branch?

Technically speaking this _could_ fail to enable `nix-daemon` on a multi-user install (by failing to un-comment the line) if the script failed between the calls to `cp` and `sed`, but that's a tiny window.

Another approach which wouldn't have that drawback would be to test that `$config` is writable before calling `sed`, however, I wanted to start with this solution because the spirit of the substitution is when the example config is first being written to `$HOME/.nixpkgs/darwin-configuration.nix`, and subsequent calls to the installer avoiding making any assumptions about the contents of `$config` where it already existed.