### PR TITLE
module: add Lorri service

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -42,6 +42,7 @@
   ./services/emacs.nix
   ./services/khd
   ./services/kwm
+  ./services/lorri.nix
   ./services/mail/offlineimap.nix
   ./services/mopidy.nix
   ./services/nix-daemon.nix

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.lorri;
+
+in {
+
+  options = {
+    services.lorri = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable to Lorri Daemon.";
+      };
+
+      package = mkOption {
+        type = types.path;
+        default = pkgs.lorri;
+        description = "This option specifies the lorri package to use.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    launchd.user.agents.lorri = {
+      command = "${cfg.package}/bin/lorri daemon";
+      serviceConfig.KeepAlive = true;
+    };
+
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -113,6 +113,7 @@ let
     tests.services-activate-system = makeTest ./tests/services-activate-system.nix;
     tests.services-activate-system-changed-label-prefix = makeTest ./tests/services-activate-system-changed-label-prefix.nix;
     tests.services-buildkite-agent = makeTest ./tests/services-buildkite-agent.nix;
+    tests.services-lorri = makeTest ./tests/services-lorri.nix;
     tests.services-nix-daemon = makeTest ./tests/services-nix-daemon.nix;
     tests.sockets-nix-daemon = makeTest ./tests/sockets-nix-daemon.nix;
     tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;

--- a/tests/services-lorri.nix
+++ b/tests/services-lorri.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+
+{
+  services.lorri.enable = true;
+
+  test = ''
+    echo >&2 "checking lorri service in ~/Library/LaunchAgents"
+    grep "org.nixos.lorri" ${config.out}/user/Library/LaunchAgents/org.nixos.lorri.plist
+    grep "${pkgs.lorri}/bin/lorri" ${config.out}/user/Library/LaunchAgents/org.nixos.lorri.plist
+  '';
+}


### PR DESCRIPTION
I've added a service module to enable the Lorri daemon, adapted from the home-manager Lorri service.  
It may still be missing something, as I'm not sure exactly what the following lines do:
https://github.com/rycee/home-manager/blob/8af92f844f6acb3957dd68072e8fc0e00d4c3eba/modules/services/lorri.nix#L41-L44