### PR TITLE
nix: better defaults settings for maxJobs/buildCores

### DIFF
--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -469,9 +469,4 @@
 
   users.nix.configureBuildUsers = true;
   users.nix.nrBuildUsers = 32;
-
-  # You should generally set this to the total number of logical cores in your system.
-  # $ sysctl -n hw.ncpu
-  nix.maxJobs = 1;
-  nix.buildCores = 1;
 }

--- a/modules/examples/ofborg.nix
+++ b/modules/examples/ofborg.nix
@@ -26,9 +26,4 @@ with lib;
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
   system.stateVersion = 4;
-
-  # You should generally set this to the total number of logical cores in your system.
-  # $ sysctl -n hw.ncpu
-  nix.maxJobs = 1;
-  nix.buildCores = 1;
 }

--- a/modules/examples/simple.nix
+++ b/modules/examples/simple.nix
@@ -23,9 +23,4 @@
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
   system.stateVersion = 4;
-
-  # You should generally set this to the total number of logical cores in your system.
-  # $ sysctl -n hw.ncpu
-  nix.maxJobs = 1;
-  nix.buildCores = 1;
 }

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -82,24 +82,25 @@ in
     };
 
     nix.maxJobs = mkOption {
-      type = types.int;
-      default = 1;
+      type = types.either types.int (types.enum ["auto"]);
+      default = "auto";
       example = 64;
       description = ''
-        This option defines the maximum number of jobs that Nix will try
-        to build in parallel.  The default is 1.  You should generally
-        set it to the total number of logical cores in your system (e.g., 16
-        for two CPUs with 4 cores each and hyper-threading).
+        This option defines the maximum number of jobs that Nix will try to
+        build in parallel. The default is auto, which means it will use all
+        available logical cores. It is recommend to set it to the total
+        number of logical cores in your system (e.g., 16 for two CPUs with 4
+        cores each and hyper-threading).
       '';
     };
 
     nix.buildCores = mkOption {
       type = types.int;
-      default = 1;
+      default = 0;
       example = 64;
       description = ''
         This option defines the maximum number of concurrent tasks during
-        one build. It affects, e.g., -j option for make. The default is 1.
+        one build. It affects, e.g., -j option for make.
         The special value 0 means that the builder should use all
         available CPU cores in the system. Some builds may become
         non-deterministic with this option; use with care! Packages will


### PR DESCRIPTION
most users just want to use all available cores.
This commit aligns our defaults with what we do in NixOS