### PR TITLE
fixes zsh module shell variable assignments

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -105,8 +105,8 @@ in
 
     environment.pathsToLink = [ "/share/zsh" ];
 
-    environment.loginShell = "zsh -l";
-    environment.variables.SHELL = "${pkgs.zsh}/bin/zsh";
+    environment.loginShell = mkDefault "zsh -l";
+    environment.variables.SHELL = mkDefault "${pkgs.zsh}/bin/zsh";
 
     environment.etc."zshenv".text = ''
       # /etc/zshenv: DO NOT EDIT -- this file has been generated automatically.


### PR DESCRIPTION
Without this, there's a collision when you define them top-level (e.g. necessary if you enable both bash & zsh, but want bash to be the default shell)