### PR TITLE
darwin-[un]installer: make sure all dependencies are part of the closure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,17 @@ let
   # Was moved in nixpkgs #82751, so both need to be handled here until 20.03 is deprecated.
   # https://github.com/NixOS/nixpkgs/commits/dcdd232939232d04c1132b4cc242dd3dac44be8c
   _module = eval._module or eval.config._module;
+
+  # The source code of this repo needed by the [un]installers.
+  nix-darwin = pkgs.lib.cleanSource (
+    pkgs.lib.cleanSourceWith {
+      # We explicitly specify a name here otherwise `cleanSource` will use the
+      # basename of ./.  which might be different for different clones of this
+      # repo leading to non-reproducible outputs.
+      name = "nix-darwin";
+      src = ./.;
+    }
+  );
 in
 
 {
@@ -32,6 +43,6 @@ in
 
   system = eval.config.system.build.toplevel;
 
-  installer = pkgs.callPackage ./pkgs/darwin-installer {};
-  uninstaller = pkgs.callPackage ./pkgs/darwin-uninstaller {};
+  installer = pkgs.callPackage ./pkgs/darwin-installer { inherit nix-darwin; };
+  uninstaller = pkgs.callPackage ./pkgs/darwin-uninstaller { inherit nix-darwin; };
 }

--- a/pkgs/darwin-installer/default.nix
+++ b/pkgs/darwin-installer/default.nix
@@ -1,10 +1,16 @@
-{ stdenv, writeScript, nix, pkgs }:
+{ stdenv, writeScript, nix, pkgs, nix-darwin }:
 
 let
+  configuration = builtins.path {
+    name = "nix-darwin-installer-configuration";
+    path = ./.;
+    filter = name: _type: name != toString ./default.nix;
+  };
+
   nixPath = stdenv.lib.concatStringsSep ":" [
-    "darwin-config=${toString ./configuration.nix}"
-    "darwin=${toString ../..}"
-    "nixpkgs=${toString pkgs.path}"
+    "darwin-config=${configuration}/configuration.nix"
+    "darwin=${nix-darwin}"
+    "nixpkgs=${pkgs.path}"
     "$HOME/.nix-defexpr/channels"
     "/nix/var/nix/profiles/per-user/root/channels"
     "$NIX_PATH"
@@ -52,7 +58,7 @@ stdenv.mkDerivation {
     if ! test -f "$config"; then
         echo "copying example configuration.nix" >&2
         mkdir -p "$HOME/.nixpkgs"
-        cp "${toString ../../modules/examples/simple.nix}" "$config"
+        cp "${../../modules/examples/simple.nix}" "$config"
         chmod u+w "$config"
 
         # Enable nix-daemon service for multi-user installs.

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -1,10 +1,16 @@
-{ stdenv, nix, pkgs }:
+{ stdenv, nix, pkgs, nix-darwin }:
 
 let
+  configuration = builtins.path {
+    name = "nix-darwin-uninstaller-configuration";
+    path = ./.;
+    filter = name: _type: name != toString ./default.nix;
+  };
+
   nixPath = stdenv.lib.concatStringsSep ":" [
-    "darwin-config=${toString ./configuration.nix}"
-    "darwin=${toString ../..}"
-    "nixpkgs=${toString pkgs.path}"
+    "darwin-config=${configuration}/configuration.nix"
+    "darwin=${nix-darwin}"
+    "nixpkgs=${pkgs.path}"
     "$NIX_PATH"
   ];
 in


### PR DESCRIPTION
This makes sure the `darwin-installer` and `darwin-uninstaller` packages can be nix copied to any target and reliably be executed there.