### PR TITLE
documentation: Don't set localSystem which doesn't exist

### DIFF
--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -17,7 +17,7 @@ let
     options =
       let
         scrubbedEval = evalModules {
-          modules = [ { nixpkgs.localSystem = config.nixpkgs.localSystem; } ] ++ baseModules;
+          modules = baseModules;
           args = (config._module.args) // { modules = [ ]; };
           specialArgs = { pkgs = scrubDerivations "pkgs" pkgs; };
         };


### PR DESCRIPTION
This is safe to remove, because it is not referenced anywhere in
nix-darwin.
It should have been discovered way earlier, but a bug in the
module system has allowed this value to be defined until
https://github.com/NixOS/nixpkgs/commit/fd75dc876586bde8cdb683a6952a41132e8db166