### PR TITLE
Enable setting dark mode

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -23,6 +23,14 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain.AppleInterfaceStyle = mkOption {
+      type = types.nullOr (types.enum [ "Dark" ]);
+      default = null;
+      description = ''
+        Set to 'Dark' to enable dark mode, or leave unset for normal mod.
+      '';
+    };
+
     system.defaults.NSGlobalDomain.AppleKeyboardUIMode = mkOption {
       type = types.nullOr (types.enum [ 3 ]);
       default = null;


### PR DESCRIPTION
This option does not take effect until the user logs out and then back in.  I didn't call this out because I think there are several options like this already.

I'm not sure Mac OS sets "Auto", but it isn't by setting this default.