### PR TITLE
Add separate options for ComputerName and LocalHostName in networking module

### DIFF
--- a/tests/networking-hostname.nix
+++ b/tests/networking-hostname.nix
@@ -2,10 +2,11 @@
 
 {
   networking.hostName = "EVE";
+  networking.computerName = "EVE’s MacBook Pro";
 
   test = ''
     echo checking hostname in /activate >&2
-    grep "scutil --set ComputerName 'EVE'" ${config.out}/activate
+    grep "scutil --set ComputerName 'EVE’s MacBook Pro'" ${config.out}/activate
     grep "scutil --set LocalHostName 'EVE'" ${config.out}/activate
     grep "scutil --set HostName 'EVE'" ${config.out}/activate
     echo checking defaults write in ${config.out}/activate-user >&2


### PR DESCRIPTION
I usually want my Mac's "computer name" to be different from its hostname. Currently this isn't possible with `nix-darwin` since setting `networking.hostname` changes all three of the hostname, local hostname and "computer name" to the same thing.

This PR makes the following changes:

* adds the options `networking.localHostName` and `networking.computerName`,
* Refines the types of `networking.HostName` to only accept strings that are valid hostnames and uses this type for `networking.localHostName` as well,
* changes the default behavior of setting `networking.hostname` to only set the system's hostname and local hostname (if the `networking.localHostName` option isn't set separately), and
  * (This is done by having each option set the corresponding name for the system, and setting the default value of `networking.localHostName` to the value of `networking.hostname`. The idea being that I expect it to be much less common that people will want their system to have a different hostname and local hostname, and much more common to want the "computer name" to be different since it's allowed to contain spaces and arbitrary Unicode characters.)
* updates tests in `tests.networking-hostname`.