### PR TITLE
Remove deprecated types.loaOf

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -722,7 +722,7 @@ with lib;
 
         The parameters below are used as inputs to call <literal>getaddrinfo(3)</literal>.
       '';
-      type = types.nullOr (types.loaOf (types.submodule {
+      type = types.nullOr (types.attrsOf (types.submodule {
         options = {
           SockType = mkOption {
             type = types.nullOr (types.enum [ "stream" "dgram" "seqpacket" ]);

--- a/modules/programs/ssh/default.nix
+++ b/modules/programs/ssh/default.nix
@@ -54,7 +54,7 @@ in
 
     programs.ssh.knownHosts = mkOption {
       default = {};
-      type = types.loaOf (types.submodule host);
+      type = types.attrsOf (types.submodule host);
       description = ''
         The set of system-wide known SSH hosts.
       '';

--- a/modules/system/etc.nix
+++ b/modules/system/etc.nix
@@ -20,7 +20,7 @@ in
   options = {
 
     environment.etc = mkOption {
-      type = types.loaOf (types.submodule text);
+      type = types.attrsOf (types.submodule text);
       default = {};
       description = ''
         Set of files that have to be linked in <filename>/etc</filename>.

--- a/modules/system/launchd.nix
+++ b/modules/system/launchd.nix
@@ -57,7 +57,7 @@ in
   options = {
 
     environment.launchAgents = mkOption {
-      type = types.loaOf (types.submodule text);
+      type = types.attrsOf (types.submodule text);
       default = {};
       description = ''
         Set of files that have to be linked in <filename>/Library/LaunchAgents</filename>.
@@ -65,7 +65,7 @@ in
     };
 
     environment.launchDaemons = mkOption {
-      type = types.loaOf (types.submodule text);
+      type = types.attrsOf (types.submodule text);
       default = {};
       description = ''
         Set of files that have to be linked in <filename>/Library/LaunchDaemons</filename>.
@@ -73,7 +73,7 @@ in
     };
 
     environment.userLaunchAgents = mkOption {
-      type = types.loaOf (types.submodule text);
+      type = types.attrsOf (types.submodule text);
       default = {};
       description = ''
         Set of files that have to be linked in <filename>~/Library/LaunchAgents</filename>.

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -49,13 +49,13 @@ in
     };
 
     users.groups = mkOption {
-      type = types.loaOf (types.submodule group);
+      type = types.attrsOf (types.submodule group);
       default = {};
       description = "Configuration for groups.";
     };
 
     users.users = mkOption {
-      type = types.loaOf (types.submodule user);
+      type = types.attrsOf (types.submodule user);
       default = {};
       description = "Configuration for users.";
     };


### PR DESCRIPTION
`types.loaOf` has been deprecated for a long time and is now in the process of removal. 
See: https://github.com/NixOS/nixpkgs/pull/96042