### PR TITLE
Allow the `pkgs` arg to be pinned via the `nixpkgs.pkgs` option

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,6 @@ let
   packages = { config, lib, pkgs, ... }: {
     _file = ./default.nix;
     config = {
-      _module.args.pkgs = import nixpkgs config.nixpkgs;
       nixpkgs.system = system;
     };
   };


### PR DESCRIPTION
I didn't hear back about #211 so I had a crack at adding a `nixpkgs.pkgs` config option, similar to NixOS.

jamesottaway/nix-config@faeac44fd0dc28e72d84e9311a2880212e404ff4 is my WIP attempt to pin `nixpkgs` in my personal nix-darwin config.