### PR TITLE
add mas module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -63,6 +63,7 @@
   ./programs/gnupg.nix
   ./programs/man.nix
   ./programs/info
+  ./programs/mas.nix
   ./programs/nix-index
   ./programs/ssh
   ./programs/tmux.nix

--- a/modules/programs/mas.nix
+++ b/modules/programs/mas.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.programs.mas;
+in
+{
+  options = {
+    programs.mas.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable mas.";
+    };
+
+    programs.mas.applications = mkOption {
+      type = types.listOf types.string;
+      default = [ ];
+      example = literalExample
+        ''
+          [
+          "497799835" # Xcode
+          ]
+        '';
+      description = "List of App Store applications for mas to install.";
+    };
+
+    programs.mas.package = mkOption {
+      internal = true;
+      type = types.package;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    system.activationScripts.extraUserActivation.text = ''
+      echo "setting up App Store applications..."
+      ${cfg.package}/bin/mas install ${lib.concatStringsSep " " cfg.applications}
+    '';
+
+  };
+}

--- a/modules/programs/mas.nix
+++ b/modules/programs/mas.nix
@@ -17,7 +17,7 @@ in
       default = [ ];
       example = literalExample
         ''
-          [ "497799835" # Xcode ]
+          [ "497799835" /* Xcode */ ]
         '';
       description = "List of App Store applications for mas to install.";
     };
@@ -30,10 +30,9 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-    users.activationScripts.mas.text = ''
+    system.activationScripts.mas.text = ''
       echo "setting up App Store applications..."
       ${cfg.package}/bin/mas install ${lib.concatStringsSep " " cfg.applications}
-      ${cfg.package}/bin/mas upgrade ${lib.concatStringsSep " " cfg.applications}
     '';
 
   };

--- a/modules/programs/mas.nix
+++ b/modules/programs/mas.nix
@@ -17,9 +17,7 @@ in
       default = [ ];
       example = literalExample
         ''
-          [
-          "497799835" # Xcode
-          ]
+          [ "497799835" # Xcode ]
         '';
       description = "List of App Store applications for mas to install.";
     };
@@ -32,7 +30,7 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-    user.activationScripts.mas.text = ''
+    users.activationScripts.mas.text = ''
       echo "setting up App Store applications..."
       ${cfg.package}/bin/mas install ${lib.concatStringsSep " " cfg.applications}
       ${cfg.package}/bin/mas upgrade ${lib.concatStringsSep " " cfg.applications}

--- a/modules/programs/mas.nix
+++ b/modules/programs/mas.nix
@@ -32,9 +32,10 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-    system.activationScripts.extraUserActivation.text = ''
+    user.activationScripts.mas.text = ''
       echo "setting up App Store applications..."
       ${cfg.package}/bin/mas install ${lib.concatStringsSep " " cfg.applications}
+      ${cfg.package}/bin/mas upgrade ${lib.concatStringsSep " " cfg.applications}
     '';
 
   };


### PR DESCRIPTION
This is very impure and has some behavior that at the very least fails the principle of least astonishment, so I'm not expecting this to necessarily get merged, but I did want to throw the concept out there. 

[mas](https://github.com/mas-cli/mas) is a tool to manage app store installations, but its [build system](https://github.com/mas-cli/mas/blob/master/script/build) is not something that looks like it's going to be easily packaged for darwin in the near future, at least purely.

I put my derivation for `mas` up in a gist here: https://gist.github.com/zachcoyle/1cb276b2b9633d9da3601608f5ba0c5d and just had that sitting in an overlay.  

Regardless, it was pretty fun learning how to build a module from scratch, and I have a better understanding of how they work now!