### PR TITLE
Add AppleAccentColor AppleHighlightColor defaults

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -46,7 +46,7 @@ let
     };
     Blue = {
       accent = 4;
-      highlight = null;
+      highlight = "0.698039 0.843137 1.000000 Blue";
     };
     Purple = {
       accent = 5;

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -98,6 +98,9 @@ in {
         (types.nullOr types.int);
       default = null;
       description = ''
+        Configures the color of native controls.
+        Catalina: The default is Blue
+        Big Sur: The default is multicolor
       '';
     };
 
@@ -108,6 +111,9 @@ in {
         (types.nullOr types.string);
       default = null;
       description = ''
+        Configures the highlight color for text, files, etc.
+        Catalina: The default is Blue
+        Big Sur: The default is multicolor
       '';
     };
 

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -114,6 +114,8 @@ in {
         Configures the highlight color for text, files, etc.
         Catalina: The default is Blue
         Big Sur: The default is multicolor
+        
+        If left unset, AppleHighlightColor will match AppleAccentColor
       '';
     };
 

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -87,7 +87,7 @@ in {
       type = types.nullOr (types.enum [ "Dark" ]);
       default = null;
       description = ''
-        Set to 'Dark' to enable dark mode, or leave unset for normal mod.
+        Set to 'Dark' to enable dark mode, or leave unset for normal mode.
       '';
     };
 


### PR DESCRIPTION
Rewrite of PR #133 

This adds the ability to control NSGlobalDomain.AppleAccentColor and NSGlobalDomain.AppleHighlightColor. 
Following the behavior of System Preferences, if AppleAccentColor is specified, AppleHighlightColor will be set to match, unless a value is explicitly set. 

There is currently no way to set AppleHighlightColor to the system Blue, for reasons related to #88
For AppleHighlightColor, Blue is the absence of the default, but luckily for AppleAccentColor, Blue is either the absence of the default or 4.

I don't have descriptions or tests yet, but will get those added when I get a chance 