### PR TITLE
Fix the Buildkite agent module

### DIFF
--- a/modules/services/buildkite-agent.nix
+++ b/modules/services/buildkite-agent.nix
@@ -236,14 +236,11 @@ in
           # after networking is available (so the hostname is
           # correct).
           RunAtLoad = true;
-          KeepAlive.NetworkState = true;
           WatchPaths = [
             "/etc/resolv.conf"
             "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
           ];
 
-          GroupName = "buildkite-agent";
-          UserName = "buildkite-agent";
           WorkingDirectory = config.users.users.buildkite-agent.home;
           StandardErrorPath = "${cfg.dataDir}/buildkite-agent.log";
           StandardOutPath = "${cfg.dataDir}/buildkite-agent.log";


### PR DESCRIPTION
I tried the following config in my `/etc/macos/configuration.nix`:

```nix
{
  services.buildkite-agent = {
    enable = true;
    tokenPath = ./token;
    openssh = {
      publicKeyPath = "/dev/null";
      privateKeyPath = "/dev/null";
    };
  };

  users.knownUsers = [ "buildkite-agent" ];
  users.users.buildkite-agent = {
    createHome = true;
    uid = 1009;
  };
}
```

When I ran `darwin-rebuild switch` I found the following errors in `syslog`:

```
❯ syslog | rg buildkite                                                                                                             ~
NOTE:  Most system logs have moved to a new logging system.  See log(1) for more information.
Oct 10 14:16:09 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[145]) <Warning>: Could not find user/group associated with service: 0: Undefined error: 0 buildkite-agent/buildkite-agent
Oct 10 14:16:09 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[145]) <Notice>: Service setup event to handle failure and will not launch until it fires.
Oct 10 14:16:09 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[145]) <Warning>: Service exited with abnormal code: 78
Oct 10 15:31:10 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[3247]) <Warning>: Could not find user/group associated with service: 0: Undefined error: 0 buildkite-agent/buildkite-agent
Oct 10 15:31:10 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[3247]) <Notice>: Service setup event to handle failure and will not launch until it fires.
Oct 10 15:31:10 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[3247]) <Warning>: Service exited with abnormal code: 78
Oct 11 12:05:14 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent) <Error>: The NetworkState key is no longer respected. Please remove it.
Oct 11 12:05:14 b12y-MBP com.apple.xpc.launchd[1] (com.apple.xpc.launchd.user.domain.501.100022.Aqua) <Error>: org.nixos.buildkite-agent (lint): UserName is not supported for non-System services.
Oct 11 12:05:14 b12y-MBP com.apple.xpc.launchd[1] (com.apple.xpc.launchd.user.domain.501.100022.Aqua) <Error>: org.nixos.buildkite-agent (lint): GroupName is not supported for non-System services.
Oct 11 12:05:14 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[28816]) <Error>: Service could not initialize: 19H2: xpcproxy + 14521 [839][C9A1BADB-35DE-3593-881A-1C75B5108198]: 0xd
Oct 11 12:05:14 b12y-MBP com.apple.xpc.launchd[1] (org.nixos.buildkite-agent[28816]) <Warning>: Service exited with abnormal code: 78
```

By removing these 3 lines I was able to get it working.