### PR TITLE
add new option - system.keyboard.swapLeftCommandAndLeftAlt

### DIFF
--- a/modules/system/keyboard.nix
+++ b/modules/system/keyboard.nix
@@ -32,6 +32,12 @@ in
       description = "Whether to remap the Tilde key on non-us keyboards.";
     };
 
+    system.keyboard.swapLeftCommandAndLeftAlt = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to swap the left Command key and left Alt key.";
+    };
+
     system.keyboard.userKeyMapping = mkOption {
       internal = true;
       type = types.listOf (types.attrsOf types.int);
@@ -52,6 +58,14 @@ in
       (mkIf cfg.remapCapsLockToControl { HIDKeyboardModifierMappingSrc = 30064771129; HIDKeyboardModifierMappingDst = 30064771296; })
       (mkIf cfg.remapCapsLockToEscape { HIDKeyboardModifierMappingSrc = 30064771129; HIDKeyboardModifierMappingDst = 30064771113; })
       (mkIf cfg.nonUS.remapTilde { HIDKeyboardModifierMappingSrc = 30064771172; HIDKeyboardModifierMappingDst = 30064771125; })
+      (mkIf cfg.swapLeftCommandAndLeftAlt {
+        HIDKeyboardModifierMappingSrc = 30064771299;
+        HIDKeyboardModifierMappingDst = 30064771298;
+      })
+      (mkIf cfg.swapLeftCommandAndLeftAlt {
+        HIDKeyboardModifierMappingSrc = 30064771298;
+        HIDKeyboardModifierMappingDst = 30064771299;
+      })
     ];
 
     system.activationScripts.keyboard.text = optionalString cfg.enableKeyMapping ''

--- a/tests/system-keyboard-mapping.nix
+++ b/tests/system-keyboard-mapping.nix
@@ -5,6 +5,7 @@
   system.keyboard.remapCapsLockToControl = true;
   system.keyboard.remapCapsLockToEscape = true;
   system.keyboard.nonUS.remapTilde = true;
+  system.keyboard.swapLeftCommandAndLeftAlt = true;
 
   test = ''
     echo checking keyboard mappings in /activate >&2
@@ -14,6 +15,7 @@
     grep "\"HIDKeyboardModifierMappingDst\":30064771113" ${config.out}/activate
     grep "\"HIDKeyboardModifierMappingDst\":30064771125" ${config.out}/activate
     grep "\"HIDKeyboardModifierMappingDst\":30064771296" ${config.out}/activate
+    grep "\"HIDKeyboardModifierMappingDst\":30064771298" ${config.out}/activate
+    grep "\"HIDKeyboardModifierMappingDst\":30064771299" ${config.out}/activate
   '';
 }
-


### PR DESCRIPTION
+ Tested with `darwin-rebuild switch -I darwin=.` in macOS Catalina.
+ Tested with `nix-build release.nix -A tests.system-keyboard-mapping`.
