### PR TITLE
Add extraConfig option to Redis

### DIFF
--- a/modules/services/redis/default.nix
+++ b/modules/services/redis/default.nix
@@ -52,6 +52,12 @@ in
       default = false;
       description = "By default data is only periodically persisted to disk, enable this option to use an append-only file for improved persistence.";
     };
+
+    services.redis.extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional text to be appended to <filename>redis.conf</filename>.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -69,6 +75,7 @@ in
       ${optionalString (cfg.unixSocket != null) "unixsocket ${cfg.unixSocket}"}
       dir ${cfg.dataDir}
       appendOnly ${if cfg.appendOnly then "yes" else "no"}
+      ${cfg.extraConfig}
     '';
 
   };

--- a/release.nix
+++ b/release.nix
@@ -121,6 +121,7 @@ let
     tests.services-ofborg = makeTest ./tests/services-ofborg.nix;
     tests.services-offlineimap = makeTest ./tests/services-offlineimap.nix;
     tests.services-privoxy = makeTest ./tests/services-privoxy.nix;
+    tests.services-redis = makeTest ./tests/services-redis.nix;
     tests.services-skhd = makeTest ./tests/services-skhd.nix;
     tests.services-spacebar = makeTest ./tests/services-spacebar.nix;
     tests.services-synapse-bt = makeTest ./tests/services-synapse-bt.nix;

--- a/tests/services-redis.nix
+++ b/tests/services-redis.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  redis = pkgs.runCommand "redis-0.0.0" {} "mkdir $out";
+in
+
+{
+  services.redis.enable = true;
+  services.redis.package = redis;
+  services.redis.extraConfig = ''
+    maxmemory-policy allkeys-lru
+    stop-writes-on-bgsave-error no
+  '';
+
+  test = ''
+    echo >&2 "checking redis service in ~/Library/LaunchAgents"
+    grep "org.nixos.redis" ${config.out}/user/Library/LaunchAgents/org.nixos.redis.plist
+    grep "${redis}/bin/redis-server /etc/redis.conf" ${config.out}/user/Library/LaunchAgents/org.nixos.redis.plist
+
+    echo >&2 "checking config in /etc/redis.conf"
+    grep "maxmemory-policy allkeys-lru" ${config.out}/etc/redis.conf
+    grep "stop-writes-on-bgsave-error no" ${config.out}/etc/redis.conf
+  '';
+}


### PR DESCRIPTION
👋 Hi, I tested this out with this bit from the README:
```sh
darwin-rebuild switch -I darwin=.
```

It worked on macOS Catalina with the following in my `~/.nixpkgs/darwin-configuration.nix`:
```nix
{
  # ...

  services.redis = {
    enable = true;
    extraConfig = ''
      stop-writes-on-bgsave-error no
    '';
  };

  # ...
}
```

I'm happy to run any additional tests if necessary, but I'm fairly new to Nix so I might need a little pointing in the right direction. 