### PR TITLE
add git, gnutar and gzip to lorri's path

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -32,7 +32,7 @@ in
     environment.systemPackages = [ pkgs.lorri ];
     launchd.user.agents.lorri = {
       command = with pkgs; "${lorri}/bin/lorri daemon";
-      path = with pkgs; [ nix ];
+      path = with pkgs; [ config.nix.package git gnutar gzip ];
       serviceConfig = {
         KeepAlive = true;
         RunAtLoad = true;


### PR DESCRIPTION
When trying to use lorri, I kept getting errors similar to those mentioned by @wentasah on https://github.com/target/lorri/issues/385#issuecomment-661779666. I compared the relevant NixOS setting (shared by @curiousleo here https://github.com/target/lorri/issues/385#issuecomment-620477432) with the equivalent `darwin-nix` expression and I noticed that the one here lacked `git gnutar gzip`, so I added them. 