### PR TITLE
modules: add nextdns service

### DIFF
--- a/modules/services/nextdns/default.nix
+++ b/modules/services/nextdns/default.nix
@@ -28,7 +28,7 @@ in {
 
     environment.systemPackages = [ nextdns ];
 
-    launchd.user.agents.nextdns = {
+    launchd.daemons.nextdns = {
       path = [ nextdns ];
       script = ''
         "${pkgs.nextdns}/bin/nextdns run ${escapeShellArgs cfg.arguments}";

--- a/modules/services/nextdns/default.nix
+++ b/modules/services/nextdns/default.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.nextdns;
+  nextdns = pkgs.nextdns;
+
+in {
+  options = {
+    services.nextdns = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          "Whether to enable the NextDNS DNS/53 to DoH Proxy service.";
+      };
+      arguments = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "-config" "10.0.3.0/24=abcdef" ];
+        description = "Additional arguments to be passed to nextdns run.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ nextdns ];
+
+    launchd.user.agents.nextdns = {
+      path = [ nextdns ];
+      script = ''
+        "${pkgs.nextdns}/bin/nextdns run ${escapeShellArgs cfg.arguments}";
+      '';
+
+      serviceConfig.KeepAlive = true;
+      serviceConfig.RunAtLoad = true;
+    };
+
+  };
+}


### PR DESCRIPTION
Adding the nextdns service.

I've tested by adding the corresponding launchd entry in my `darwin-configuration`. I don't know how to test the default.nix file.

It's pretty much taken from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/networking/nextdns.nix
just switching systemd to launchd