### PR TITLE
emacs: add system path env var

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -6,9 +6,7 @@ let
 
   cfg = config.services.emacs;
 
-in
-
-{
+in {
   options = {
     services.emacs = {
       enable = mkOption {
@@ -23,6 +21,17 @@ in
         description = "This option specifies the emacs package to use.";
       };
 
+      additionalPath = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "/Users/my_user_name" ];
+        description = ''
+          This option specifies additional PATH that the emacs daemon would have.
+          Typically if you have binaries in your home directory that is what you would add your home path here.
+          One caveat is that there won't be shell variable expansion, so you can't use $HOME for example
+        '';
+      };
+
       exec = mkOption {
         type = types.str;
         default = "emacs";
@@ -34,10 +43,9 @@ in
   config = mkIf cfg.enable {
 
     launchd.user.agents.emacs = {
-      serviceConfig.ProgramArguments = [
-        "${cfg.package}/bin/${cfg.exec}"
-        "--fg-daemon"
-      ];
+      path = cfg.additionalPath ++ [ config.environment.systemPath ];
+      serviceConfig.ProgramArguments =
+        [ "${cfg.package}/bin/${cfg.exec}" "--fg-daemon" ];
       serviceConfig.RunAtLoad = true;
     };
 


### PR DESCRIPTION
Thanks for the help on this one!

Currently running the emacs daemon, will not set the path to the system path. So anything installed with nix won't be found (ripgrep, things for fancy git diffs...). This PR fixes that.

I've tested the fix by adding the same line in my `darwin-configuration.nix` file and it worked. Let me know if you want me to do something else.

I was running with the automated formatter on, so a couple of lines have changed formatting. It doesn't look like a bad thing, but let me know if it will be a problem.

closes #250 

I have question though. After using this, when I check the `getenv PATH` in emacs, I see `$HOME/.nix-profile/bin` however it looks like that  `$HOME` is hardcode and not properly replaced by it's value. I'm not sure how to fix that. 