### PR TITLE
More system.defaults

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -11,6 +11,7 @@
   ./system/defaults/LaunchServices.nix
   ./system/defaults/NSGlobalDomain.nix
   ./system/defaults/GlobalPreferences.nix
+  ./system/defaults/desktopservices.nix
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
   ./system/defaults/screencapture.nix

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -20,6 +20,7 @@
   ./system/defaults/smb.nix
   ./system/defaults/SoftwareUpdate.nix
   ./system/defaults/spaces.nix
+  ./system/defaults/textedit.nix
   ./system/defaults/trackpad.nix
   ./system/etc.nix
   ./system/keyboard.nix

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -21,6 +21,8 @@
   ./system/defaults/SoftwareUpdate.nix
   ./system/defaults/spaces.nix
   ./system/defaults/textedit.nix
+  # timemachine is not writable
+  #./system/defaults/timemachine.nix
   ./system/defaults/trackpad.nix
   ./system/etc.nix
   ./system/keyboard.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -14,6 +14,7 @@ let
     if isInt value then "-int ${toString value}" else
     if isFloat value then "-float ${toString value}" else
     if isString value then "-string '${value}'" else
+    if isList value then "-array ${concatStringsSep " " (map (v: writeValue v)value)}" else
     throw "invalid value type";
 
   writeDefault = domain: key: value:

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -24,6 +24,7 @@ let
   NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
   GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
+  desktopservices = defaultsToList "com.apple.desktopservices" cfg.desktopservices;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
   alf = defaultsToList "/Library/Preferences/com.apple.alf" cfg.alf;
@@ -52,7 +53,7 @@ in
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
-      [ NSGlobalDomain GlobalPreferences LaunchServices dock finder screencapture spaces trackpad trackpadBluetooth ]
+      [ NSGlobalDomain GlobalPreferences LaunchServices desktopservices dock finder screencapture spaces trackpad trackpadBluetooth ]
       ''
         # Set defaults
         echo >&2 "user defaults..."
@@ -60,6 +61,7 @@ in
         ${concatStringsSep "\n" NSGlobalDomain}
         ${concatStringsSep "\n" GlobalPreferences}
         ${concatStringsSep "\n" LaunchServices}
+        ${concatStringsSep "\n" desktopservices}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
         ${concatStringsSep "\n" screencapture}

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -36,6 +36,7 @@ let
   spaces = defaultsToList "com.apple.spaces" cfg.spaces;
   textedit = defaultsToList "com.apple.TextEdit" cfg.textedit;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
+  timemachine = [];  # defaultsToList "/Library/Preferences/com.apple.TimeMachine" cfg.timemachine;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != {}) list);
@@ -44,12 +45,13 @@ in
 {
   config = {
 
-    system.activationScripts.defaults.text = mkIfAttrs [ alf loginwindow smb SoftwareUpdate ]
+    system.activationScripts.defaults.text = mkIfAttrs [ alf loginwindow timemachine smb SoftwareUpdate ]
       ''
         # Set defaults
         echo >&2 "system defaults..."
         ${concatStringsSep "\n" alf}
         ${concatStringsSep "\n" loginwindow}
+        #${concatStringsSep "\n" timemachine}
         ${concatStringsSep "\n" smb}
         ${concatStringsSep "\n" SoftwareUpdate}
       '';

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -33,6 +33,7 @@ let
   SoftwareUpdate = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.SoftwareUpdate" cfg.SoftwareUpdate;
   screencapture = defaultsToList "com.apple.screencapture" cfg.screencapture;
   spaces = defaultsToList "com.apple.spaces" cfg.spaces;
+  textedit = defaultsToList "com.apple.TextEdit" cfg.textedit;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
 
@@ -66,6 +67,7 @@ in
         ${concatStringsSep "\n" finder}
         ${concatStringsSep "\n" screencapture}
         ${concatStringsSep "\n" spaces}
+        ${concatStringsSep "\n" textedit}
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}
       '';

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -57,7 +57,7 @@ in
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
-      [ NSGlobalDomain GlobalPreferences LaunchServices desktopservices dock finder screencapture spaces trackpad trackpadBluetooth ]
+      [ NSGlobalDomain GlobalPreferences LaunchServices desktopservices dock finder screencapture spaces textedit trackpad trackpadBluetooth ]
       ''
         # Set defaults
         echo >&2 "user defaults..."

--- a/modules/system/defaults/desktopservices.nix
+++ b/modules/system/defaults/desktopservices.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+
+with lib;
+{
+  options = {
+
+    system.defaults.desktopservices.DSDontWriteNetworkStores = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Disable creation of metadata files (.DS_Store/AppleDouble files) on network volumes.
+        Default is to create (false).
+      '';
+    };
+
+    system.defaults.desktopservices.DSDontWriteUSBStores = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Disable creation of metadata files (.DS_Store/AppleDouble files) on USB volumes.
+        Default is to create (false).
+      '';
+    };
+  };
+}

--- a/modules/system/defaults/textedit.nix
+++ b/modules/system/defaults/textedit.nix
@@ -1,0 +1,50 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.textedit.RichText = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to compose new documents as rich text or plain text.  The default is true (rich text).
+      '';
+    };
+
+    system.defaults.textedit.NSFont = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "Helvetica";
+      description = ''
+        Set the font for rich text documents. 
+      '';
+    };
+
+    system.defaults.textedit.NSFontSize = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+        Set the font size for rich text documents.
+      '';
+    };
+
+    system.defaults.textedit.NSFixedPitchFont = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "Menlo-Regular";
+      description = ''
+        Set the font for plain text documents. 
+      '';
+    };
+
+    system.defaults.textedit.NSFixedPitchFontSize = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+        Set the font size for plain text documents.
+      '';
+    };
+  };
+}

--- a/modules/system/defaults/timemachine.nix
+++ b/modules/system/defaults/timemachine.nix
@@ -1,0 +1,40 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.timemachine.AutoBackup = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+       Enable or disable automatic backup. Defaults to no automatic backup (false). 
+      '';
+    };
+
+    system.defaults.timemachine.SkipSystemFiles = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+       Wether to skip system files when backing up. Defaults to not skipping (false). 
+      '';
+    };
+
+
+    system.defaults.timemachine.SkipPaths = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      example = literalExample '' 
+        [
+          "~user/Music"
+          "~user/Downloads"
+        ]
+      '';
+      description = ''
+        Set the paths to exclude from the backup. Default: do not exclude anything (null).
+      '';
+    };
+
+  };
+}


### PR DESCRIPTION
This PR adds support for 
- com.apple.{desktopservices,TextEdit,TimeMachine} settings
- `-array` types from `types.listOf`

TimeMachine is disabled, because it does not seem writable (`Could not write domain /Library/Preferences/com.apple.TimeMachine; exiting`) and I don't know why that is.