### PR TITLE
Add /bin/dash to shells

### DIFF
--- a/modules/system/shells.nix
+++ b/modules/system/shells.nix
@@ -31,6 +31,7 @@ in
 
       /bin/bash
       /bin/csh
+      /bin/dash
       /bin/ksh
       /bin/sh
       /bin/tcsh


### PR DESCRIPTION
I just installed the 10.15.7 upgrade, and noticed it replaced `/etc/shells` with a version that includes dash. I'm not sure which macOS release adds this, and if we should make this conditional somehow, or if this change matters at all.