### PR TITLE
yabai: load scripting addition in yabai-sa daemon

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -93,6 +93,8 @@ in
           if [ ! $(${cfg.package}/bin/yabai --check-sa) ]; then
             ${cfg.package}/bin/yabai --install-sa
           fi
+
+          ${cfg.package}/bin/yabai --load-sa
         '';
 
         serviceConfig.RunAtLoad = true;


### PR DESCRIPTION
Big Sur brought some changes which requires yabai's scripting addition to be loaded by root.  
These changes ensure it happens on boot.