### PR TITLE
Add nix.registry options

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -345,6 +345,58 @@ in
         ordering will be used.
       '';
     };
+
+    nix.registry = mkOption {
+      type = types.attrsOf (types.submodule (
+        let
+          inputAttrs = types.attrsOf (types.oneOf [types.str types.int types.bool types.package]);
+        in
+        { config, name, ... }:
+        { options = {
+            from = mkOption {
+              type = inputAttrs;
+              example = { type = "indirect"; id = "nixpkgs"; };
+              description = "The flake reference to be rewritten.";
+            };
+            to = mkOption {
+              type = inputAttrs;
+              example = { type = "github"; owner = "my-org"; repo = "my-nixpkgs"; };
+              description = "The flake reference to which <option>from></option> is to be rewritten.";
+            };
+            flake = mkOption {
+              type = types.unspecified;
+              default = null;
+              example = literalExample "nixpkgs";
+              description = ''
+                The flake input to which <option>from></option> is to be rewritten.
+              '';
+            };
+            exact = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Whether the <option>from</option> reference needs to match exactly. If set,
+                a <option>from</option> reference like <literal>nixpkgs</literal> does not
+                match with a reference like <literal>nixpkgs/nixos-20.03</literal>.
+              '';
+            };
+          };
+          config = {
+            from = mkDefault { type = "indirect"; id = name; };
+            to = mkIf (config.flake != null)
+              ({ type = "path";
+                 path = config.flake.outPath;
+               } // lib.filterAttrs
+                 (n: v: n == "lastModified" || n == "rev" || n == "revCount" || n == "narHash")
+                 config.flake);
+          };
+        }
+      ));
+      default = {};
+      description = ''
+        A system-wide flake registry.
+      '';
+    };
   };
 
   config = {
@@ -384,6 +436,11 @@ in
     environment.etc."nix/nix.conf".knownSha256Hashes = [
       "c4ecc3d541c163c8fcc954ccae6b8cab28c973dc283fea5995c69aaabcdf785f"  # nix installer
     ];
+
+    environment.etc."nix/registry.json".text = builtins.toJSON {
+      version = 2;
+      flakes = mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
+    };
 
     # List of machines for distributed Nix builds in the format
     # expected by build-remote.


### PR DESCRIPTION
This ports the `nix.registry` option from NixOS, which allows managing the global flake registry, aka. `/etc/nix/registry.json`.

This allows to define registry items from nix-darwin, and most importantly have it match what the `flake.lock` defines.

---

### Example:

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    darwin.url = "github:LnL7/nix-darwin";
    darwin.inputs.nixpkgs.follows = "nixpkgs";
  };
  outputs = { self, nixpkgs, darwin }: {
    darwinConfigurations."example" = darwin.lib.darwinSystem {
      modules = [{ pkgs, ... }: {
        nix = {
          package = pkgs.nixFlakes;
          registry.nixpkgs.flake = nixpkgs;
          extraOptions = ''
            experimental-features = nix-command flakes
          '';
        };
      }];
    };
  };
}
```

`/etc/nix/registry.json` should contain something like this:

```json
{
  "flakes": [
    {
      "exact": true,
      "from": {
        "id": "nixpkgs",
        "type": "indirect"
      },
      "to": {
        "lastModified": 1607522989,
        "narHash": "sha256-o/jWhOSAlaK7y2M57OIriRt6whuVVocS/T0mG7fd1TI=",
        "path": "/nix/store/cig3zz9li4b3cv2pvh7f32glb2h7l4c2-source",
        "rev": "e9158eca70ae59e73fae23be5d13d3fa0cfc78b4",
        "type": "path"
      }
    }
  ],
  "version": 2
}
```

`nix registry list` outputs:

```
system flake:nixpkgs path:/nix/store/cig3zz9li4b3cv2pvh7f32glb2h7l4c2-source?lastModified=1607522989&narHash=sha256-o%2fjWhOSAlaK7y2M57OIriRt6whuVVocS%2fT0mG7fd1TI=&rev=e9158eca70ae59e73fae23be5d13d3fa0cfc78b4
global flake:blender-bin github:edolstra/nix-warez?dir=blender
global flake:dwarffs github:edolstra/dwarffs
global flake:hydra github:NixOS/hydra
global flake:mach-nix github:DavHau/mach-nix
global flake:nimble github:nix-community/flake-nimble
global flake:nix github:NixOS/nix
global flake:nixops github:NixOS/nixops
global flake:nixos-hardware github:NixOS/nixos-hardware
global flake:nixos-homepage github:NixOS/nixos-homepage/flake
global flake:nur github:nix-community/NUR
global flake:nixpkgs/release-19.09 github:edolstra/nixpkgs/release-19.09
global flake:nixpkgs github:NixOS/nixpkgs
global flake:templates github:NixOS/templates
global flake:patchelf github:NixOS/patchelf
global flake:nix-serve github:edolstra/nix-serve
global flake:nickel github:tweag/nickel
```

---

You can also see this in action in [my personal nix configuration](https://github.com/sandhose/nixconf/blob/7a40e6ca323dd4e1406ea9a6bfed1f71b6cc30b6/common/default.nix#L10) in a part shared by both my NixOS system and my darwin one.