### PR TITLE
fish: generate environment natively

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -8,6 +8,9 @@ let
   exportVariables =
     mapAttrsToList (n: v: ''export ${n}="${v}"'') cfg.variables;
 
+  exportVariablesFish =
+    mapAttrsToList (n: v: ''set -g -x ${n} "${v}"'') cfg.variables;
+
   aliasCommands =
     mapAttrsFlatten (n: v: ''alias ${n}="${v}"'') cfg.shellAliases;
 
@@ -168,6 +171,8 @@ in
        export NIX_PROFILES="${concatStringsSep " " (reverseList cfg.profiles)}"
     '';
 
+    environment.etc."fish/foreign-env/extraInit".text = cfg.extraInit;
+
     environment.variables =
       {
         XDG_CONFIG_DIRS = map (path: path + "/etc/xdg") cfg.profiles;
@@ -191,6 +196,21 @@ in
 
       # Extra initialisation
       ${cfg.extraInit}
+    '';
+
+    system.build.setEnvironmentFish = pkgs.writeText "set-environment-fish" ''
+      # Prevent this file from being sourced by child shells.
+      set -g -x __NIX_DARWIN_SET_ENVIRONMENT_DONE 1
+
+      set -g -x PATH ${config.environment.systemPath}
+      ${concatStringsSep "\n" exportVariablesFish}
+
+      # Extra initialisation
+      set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
+      fenv "source /etc/fish/foreign-env/extraInit" > /dev/null
+
+      # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
+      set -e fish_function_path
     '';
 
     system.build.setAliases = pkgs.writeText "set-aliases" ''

--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -206,7 +206,7 @@ in
       ${concatStringsSep "\n" exportVariablesFish}
 
       # Extra initialisation
-      set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
+      set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/vendor_functions.d $__fish_datadir/functions
       fenv "source /etc/fish/foreign-env/extraInit" > /dev/null
 
       # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -27,7 +27,7 @@ in
         '';
         type = types.bool;
       };
-      
+
       vendor.config.enable = mkOption {
         type = types.bool;
         default = true;
@@ -43,7 +43,7 @@ in
           Whether fish should use completion files provided by other packages.
         '';
       };
-      
+
       vendor.functions.enable = mkOption {
         type = types.bool;
         default = true;
@@ -99,18 +99,10 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.etc."fish/foreign-env/shellInit".text = cfge.shellInit;
-    environment.etc."fish/foreign-env/loginShellInit".text = cfge.loginShellInit;
-    environment.etc."fish/foreign-env/interactiveShellInit".text = cfge.interactiveShellInit;
-
     environment.etc."fish/nixos-env-preinit.fish".text = ''
-      # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
-      # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
-      set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
-      
       # source the NixOS environment config
       if [ -z "$__NIX_DARWIN_SET_ENVIRONMENT_DONE" ]
-          fenv source ${config.system.build.setEnvironment}
+        source ${config.system.build.setEnvironmentFish}
       end
 
       # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
@@ -122,10 +114,7 @@ in
 
       # if we haven't sourced the general config, do it
       if not set -q __fish_nix_darwin_general_config_sourced
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
-        fenv source /etc/fish/foreign-env/shellInit > /dev/null
-        set -e fish_function_path[1]
-        
+
         ${cfg.shellInit}
 
         # and leave a note so we don't source this config section again from
@@ -136,10 +125,7 @@ in
       # if we haven't sourced the login config, do it
       status --is-login; and not set -q __fish_nix_darwin_login_config_sourced
       and begin
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
-        fenv source /etc/fish/foreign-env/loginShellInit > /dev/null
-        set -e fish_function_path[1]
-        
+
         ${cfg.loginShellInit}
 
         # and leave a note so we don't source this config section again from
@@ -151,12 +137,7 @@ in
       status --is-interactive; and not set -q __fish_nix_darwin_interactive_config_sourced
       and begin
         ${fishAliases}
-        
 
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
-        fenv source /etc/fish/foreign-env/interactiveShellInit > /dev/null
-        set -e fish_function_path[1]
-        
         ${cfg.promptInit}
         ${cfg.interactiveShellInit}
 
@@ -172,7 +153,7 @@ in
       ++ optional cfg.vendor.config.enable "/share/fish/vendor_conf.d"
       ++ optional cfg.vendor.completions.enable "/share/fish/vendor_completions.d"
       ++ optional cfg.vendor.functions.enable "/share/fish/vendor_functions.d";
-    
+
     environment.systemPackages = [ pkgs.fish ];
 
   };

--- a/tests/system-environment.nix
+++ b/tests/system-environment.nix
@@ -10,7 +10,7 @@
      fgrep '. ${config.system.build.setEnvironment}' ${config.out}/etc/bashrc
 
      echo checking setEnvironment in /etc/fish/nixos-env-preinit.fish >&2
-     grep 'fenv source ${config.system.build.setEnvironment}' ${config.out}/etc/fish/nixos-env-preinit.fish
+     fgrep 'source ${config.system.build.setEnvironmentFish}' ${config.out}/etc/fish/nixos-env-preinit.fish
 
      echo checking setEnvironment in /etc/zshenv >&2
      fgrep '. ${config.system.build.setEnvironment}' ${config.out}/etc/zshenv


### PR DESCRIPTION
I found in my testing that the calls to `fenv` were slowing fish launch by more than 2x on my machine. While it's still easiest to maintain it for configuration shared with bash and zsh, a pretty good speedup can be had by generating native `set` commands at build time.

I made a few changes that might be breaking, but have added comments below for discussion.