### PR TITLE
programs.nix-index: add common-not-found support for Fish

### DIFF
--- a/modules/programs/nix-index/default.nix
+++ b/modules/programs/nix-index/default.nix
@@ -29,5 +29,12 @@ in
 
     environment.interactiveShellInit = "source ${cfg.package}/etc/profile.d/command-not-found.sh";
 
+    programs.fish.interactiveShellInit = ''
+      function __fish_command_not_found_handler --on-event="fish_command_not_found"
+        ${pkgs.bashInteractive}/bin/bash -c \
+          "source ${pkgs.nix-index}/etc/profile.d/command-not-found.sh; command_not_found_handle $argv"
+      end
+    '';
+
   };
 }

--- a/modules/programs/nix-index/default.nix
+++ b/modules/programs/nix-index/default.nix
@@ -32,7 +32,7 @@ in
     programs.fish.interactiveShellInit = ''
       function __fish_command_not_found_handler --on-event="fish_command_not_found"
         ${pkgs.bashInteractive}/bin/bash -c \
-          "source ${pkgs.nix-index}/etc/profile.d/command-not-found.sh; command_not_found_handle $argv"
+          "source ${cfg.package}/etc/profile.d/command-not-found.sh; command_not_found_handle $argv"
       end
     '';
 

--- a/modules/programs/nix-index/default.nix
+++ b/modules/programs/nix-index/default.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.programs.nix-index;
+  command-not-found-script = "${cfg.package}/etc/profile.d/command-not-found.sh";
 in
 
 {
@@ -27,12 +28,16 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    environment.interactiveShellInit = "source ${cfg.package}/etc/profile.d/command-not-found.sh";
+    environment.interactiveShellInit = "source ${command-not-found-script}";
 
     programs.fish.interactiveShellInit = ''
       function __fish_command_not_found_handler --on-event="fish_command_not_found"
+        ${if config.programs.fish.useBabelfish then ''
+        command_not_found_handle $argv
+        '' else ''
         ${pkgs.bashInteractive}/bin/bash -c \
-          "source ${cfg.package}/etc/profile.d/command-not-found.sh; command_not_found_handle $argv"
+          "source ${command-not-found-script}; command_not_found_handle $argv"
+        ''}
       end
     '';
 


### PR DESCRIPTION
Works like a charm for me!
```
❯ dot
The program 'dot' is currently not installed. It is provided by
several packages. You can install it by typing one of the following:
  nix-env -iA nixpkgs.graphviz_2_32.out
  nix-env -iA nixpkgs.graphviz-nox.out
  nix-env -iA nixpkgs.graphviz.out
```