### PR TITLE
environment.nix: Split "less -R" into PAGER and LESS

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -173,7 +173,8 @@ in
         XDG_CONFIG_DIRS = map (path: path + "/etc/xdg") cfg.profiles;
         XDG_DATA_DIRS = map (path: path + "/share") cfg.profiles;
         EDITOR = mkDefault "nano";
-        PAGER = mkDefault "less -R";
+        PAGER = mkDefault "less";
+        LESS = mkDefault "-R";
       };
 
     system.path = pkgs.buildEnv {


### PR DESCRIPTION
Same change as NixOS/nixpkgs#110960.

Setting `PAGER="less -R"` relies on word splitting to work out properly.
Less also reads options from from a variable named `LESS`, by setting
`PAGER="less"` and `LESS="-R"` we don't have to rely on word splitting.

###### Motivation for this change

The `PAGER="less -R"` setting has always worked fine for me until today. I was trying out a [bash script for note-taking](https://xwmx.github.io/nb/) and it errored with "command not found: less -R". By setting the option in `LESS="-R"` instead we can avoid relying on word splitting. I believe this should only make it work in *more* cases not less.

One backwards incompatibility issue is that people who don't like the `-R` flag and have overridden `PAGER` with `less` would have to clear the setting for `LESS`.