### PR TITLE
update fish-foreign-env package

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -106,7 +106,7 @@ in
     environment.etc."fish/nixos-env-preinit.fish".text = ''
       # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
       # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
-      set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
+      set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
       
       # source the NixOS environment config
       if [ -z "$__NIX_DARWIN_SET_ENVIRONMENT_DONE" ]
@@ -122,7 +122,7 @@ in
 
       # if we haven't sourced the general config, do it
       if not set -q __fish_nix_darwin_general_config_sourced
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
+        set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish-foreign-env/functions $fish_function_path
         fenv source /etc/fish/foreign-env/shellInit > /dev/null
         set -e fish_function_path[1]
         
@@ -136,7 +136,7 @@ in
       # if we haven't sourced the login config, do it
       status --is-login; and not set -q __fish_nix_darwin_login_config_sourced
       and begin
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
+        set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish-foreign-env/functions $fish_function_path
         fenv source /etc/fish/foreign-env/loginShellInit > /dev/null
         set -e fish_function_path[1]
         
@@ -153,7 +153,7 @@ in
         ${fishAliases}
         
 
-        set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $fish_function_path
+        set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish-foreign-env/functions $fish_function_path
         fenv source /etc/fish/foreign-env/interactiveShellInit > /dev/null
         set -e fish_function_path[1]
         


### PR DESCRIPTION
Fish foreign env package has change its name on nixpkgs unstable.
nix-darwin can't be built anymore with the unstable channel.

I'm not sure what the process for updating something like this should be. Since on the latest stable channel the package still has it's old name.

Let me know if I can help with anything.