### PR TITLE
Use separate config option to set port of DNSmasq

### DIFF
--- a/modules/services/dnsmasq.nix
+++ b/modules/services/dnsmasq.nix
@@ -63,7 +63,10 @@ in
       name = "resolver/${domain}";
       value = {
         enable = true;
-        text = "nameserver ${cfg.bind}.${toString cfg.port}";
+        text = ''
+          port ${toString cfg.port}
+          nameserver ${cfg.bind}
+          '';
       };
     }) (builtins.attrNames cfg.addresses));
   };

--- a/tests/services-dnsmasq.nix
+++ b/tests/services-dnsmasq.nix
@@ -20,6 +20,7 @@ in
     grep -F -- "--address=/localhost/127.0.0.1" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
 
     echo >&2 "checking resolver config"
-    grep -F "nameserver 127.0.0.1.53" ${config.out}/etc/resolver/localhost
+    grep -F "port 53" ${config.out}/etc/resolver/localhost
+    grep -F "nameserver 127.0.0.1" ${config.out}/etc/resolver/localhost
   '';
 }


### PR DESCRIPTION
Older approach seems to not work on macOS 11 Big Sur for some reason.