### PR TITLE
fish: fix fenv reference on 20.09

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -18,7 +18,7 @@ let
 
   envInteractiveShellInit = pkgs.writeText "interactiveShellInit" cfge.interactiveShellInit;
 
-  fenv = pkgs.fish-foreign-env or pkgs.fishPlugins.foreign-env;
+  fenv = pkgs.fishPlugins.foreign-env or pkgs.fish-foreign-env;
 
   sourceEnv = file:
   if cfg.useBabelfish then


### PR DESCRIPTION
Referring to the deprecated package first causes
an error to be thrown before the correct package can be selected.

Fixes issue found in https://github.com/LnL7/nix-darwin/pull/270#issuecomment-769923166