### PR TITLE
Fix sourcing nix-darwin environment in zsh

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -117,10 +117,6 @@ in
       # Don't execute this file when running in a pure nix-shell.
       if test -n "$IN_NIX_SHELL"; then return; fi
 
-      if [ -z "$__NIX_DARWIN_SET_ENVIRONMENT_DONE" ]; then
-        . ${config.system.build.setEnvironment}
-      fi
-
       ${cfg.shellInit}
 
       # Read system-wide modifications.
@@ -155,6 +151,13 @@ in
       # Only execute this file once per shell.
       if [ -n "$__ETC_ZSHRC_SOURCED" -o -n "$NOSYSZSHRC" ]; then return; fi
       __ETC_ZSHRC_SOURCED=1
+
+      # Don't execute this file when running in a pure nix-shell.
+      if test -n "$IN_NIX_SHELL"; then return; fi
+
+      if [ -z "$__NIX_DARWIN_SET_ENVIRONMENT_DONE" ]; then
+        . ${config.system.build.setEnvironment}
+      fi
 
       # history defaults
       SAVEHIST=2000

--- a/tests/programs-zsh.nix
+++ b/tests/programs-zsh.nix
@@ -20,13 +20,13 @@
      echo >&2 "checking for share/zsh in /sw"
      test -e ${config.out}/sw/share/zsh
 
-     echo >&2 "checking setEnvironment in /etc/zshenv"
-     fgrep '. ${config.system.build.setEnvironment}' ${config.out}/etc/zshenv
      echo >&2 "checking nix-shell return /etc/zshenv"
      grep 'if test -n "$IN_NIX_SHELL"; then return; fi' ${config.out}/etc/zshenv
      echo >&2 "checking zshenv.d in /etc/zshenv"
      grep 'source /etc/zshenv.d/\*.conf' ${config.out}/etc/zshenv
 
+     echo >&2 "checking setEnvironment in /etc/zshrc"
+     fgrep '. ${config.system.build.setEnvironment}' ${config.out}/etc/zshrc
      echo >&2 "checking environment.d in /etc/zshrc"
      grep 'source /etc/environment.d/\*.conf' ${config.out}/etc/zshrc
      echo >&2 "checking zshrc.d in /etc/zshrc"


### PR DESCRIPTION
As discussed in the comments of #158, the environment set by `nix-darwin` for `zsh` is clobbered by the one set by Nix itself due to `zsh`'s load order. This PR moves the environment sourcing to a more convenient location in the load order. Fixes #151  and #158.