### PR TITLE
hercules-ci-agent: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ information on the `-I` flag look at the nix-build manpage.
 darwin-rebuild switch -I darwin=.
 ```
 
+If you're adding a module, please add yourself to `meta.maintainers`, for example
+
+```nix
+  meta.maintainers = [
+    lib.maintainers.alice or "alice"
+  ];
+
+  options.services.alicebot = { # ...
+```
+
+The `or` operator takes care of graceful degradation when `lib` from Nixpkgs
+goes out of sync.
+
 Also feel free to contact me if you have questions,
 - IRC - LnL, you can find me in #nixos or #nix-darwin on freenode.net
 - @lnl7 on twitter

--- a/modules/meta.nix
+++ b/modules/meta.nix
@@ -1,0 +1,54 @@
+# This module was derived from
+# https://github.com/NixOS/nixpkgs/blob/000387627d26f245a6d9a0a7a60b7feddecaeec0/nixos/modules/misc/meta.nix
+{ lib, ... }:
+
+with lib;
+
+let
+  maintainer = mkOptionType {
+    name = "maintainer";
+    check = email: elem email (attrValues lib.maintainers);
+    merge = loc: defs: listToAttrs (singleton (nameValuePair (last defs).file (last defs).value));
+  };
+
+  listOfMaintainers = types.listOf maintainer // {
+    # Returns list of
+    #   { "module-file" = [
+    #        "maintainer1 <first@nixos.org>"
+    #        "maintainer2 <second@nixos.org>" ];
+    #   }
+    merge = loc: defs:
+      zipAttrs
+        (flatten (imap1 (n: def: imap1 (m: def':
+          maintainer.merge (loc ++ ["[${toString n}-${toString m}]"])
+            [{ inherit (def) file; value = def'; }]) def.value) defs));
+  };
+
+in
+
+{
+  options = {
+    meta = {
+
+      maintainers = mkOption {
+        type = listOfMaintainers;
+        internal = true;
+        default = [];
+        example = [ lib.maintainers.all ];
+        description = ''
+          List of maintainers of each module.  This option should be defined at
+          most once per module.
+
+          NOTE: <literal>lib</literal> comes from Nixpkgs, which can go out of
+          sync with nix-darwin. For this reason, use definitions like
+          <literal>maintainers.alice or "alice"</literal>.
+        '';
+      };
+
+    };
+  };
+
+  meta.maintainers = [
+    maintainers.roberth or "roberth"
+  ];
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -1,6 +1,7 @@
 [
   ./alias.nix
   ./documentation
+  ./meta.nix
   ./security/pki
   ./security/sandbox
   ./system

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -44,6 +44,7 @@
   ./services/cachix-agent.nix
   ./services/dnsmasq.nix
   ./services/emacs.nix
+  ./services/hercules-ci-agent
   ./services/khd
   ./services/kwm
   ./services/lorri.nix

--- a/modules/services/hercules-ci-agent/common.nix
+++ b/modules/services/hercules-ci-agent/common.nix
@@ -1,0 +1,192 @@
+/*
+
+This file is for options that NixOS and nix-darwin have in common.
+
+Platform-specific code is in the respective default.nix files.
+
+ */
+
+{ config, lib, options, pkgs, ... }:
+let
+  inherit (lib)
+    filterAttrs
+    literalExample
+    mkIf
+    mkOption
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    types
+    ;
+
+  cfg =
+    config.services.hercules-ci-agent;
+
+  format = pkgs.formats.toml { };
+
+  settingsModule = { config, ... }: {
+    freeformType = format.type;
+    options = {
+      baseDirectory = mkOption {
+        type = types.path;
+        default = "/var/lib/hercules-ci-agent";
+        description = ''
+          State directory (secrets, work directory, etc) for agent
+        '';
+      };
+      concurrentTasks = mkOption {
+        description = ''
+          Number of tasks to perform simultaneously.
+
+          A task is a single derivation build or an evaluation.
+          At minimum, you need 2 concurrent tasks for <literal>x86_64-linux</literal>
+          in your cluster, to allow for import from derivation.
+
+          <literal>concurrentTasks</literal> can be around the CPU core count or lower if memory is
+          the bottleneck.
+        '';
+        type = types.int;
+        default = 4;
+      };
+      workDirectory = mkOption {
+        description = ''
+          The directory in which temporary subdirectories are created for task state. This includes sources for Nix evaluation.
+        '';
+        type = types.path;
+        default = config.baseDirectory + "/work";
+        defaultText = literalExample ''baseDirectory + "/work"'';
+      };
+      staticSecretsDirectory = mkOption {
+        description = ''
+          This is the default directory to look for statically configured secrets like <literal>cluster-join-token.key</literal>.
+        '';
+        type = types.path;
+        default = config.baseDirectory + "/secrets";
+        defaultText = literalExample ''baseDirectory + "/secrets"'';
+      };
+      clusterJoinTokenPath = mkOption {
+        description = ''
+          Location of the cluster-join-token.key file.
+        '';
+        type = types.path;
+        default = config.staticSecretsDirectory + "/cluster-join-token.key";
+        defaultText = literalExample ''staticSecretsDirectory + "/cluster-join-token.key"'';
+        # internal: It's a bit too detailed to show by default in the docs,
+        # but useful to define explicitly to allow reuse by other modules.
+        internal = true;
+      };
+      binaryCachesPath = mkOption {
+        description = ''
+          Location of the binary-caches.json file.
+        '';
+        type = types.path;
+        default = config.staticSecretsDirectory + "/binary-caches.json";
+        defaultText = literalExample ''staticSecretsDirectory + "/binary-caches.json"'';
+        # internal: It's a bit too detailed to show by default in the docs,
+        # but useful to define explicitly to allow reuse by other modules.
+        internal = true;
+      };
+    };
+  };
+
+  # TODO (roberth, >=2022) remove
+  checkNix =
+    if !cfg.checkNix
+    then ""
+    else if lib.versionAtLeast config.nix.package.version "2.3.10"
+    then ""
+    else
+      pkgs.stdenv.mkDerivation {
+        name = "hercules-ci-check-system-nix-src";
+        inherit (config.nix.package) src patches;
+        configurePhase = ":";
+        buildPhase = ''
+          echo "Checking in-memory pathInfoCache expiry"
+          if ! grep 'PathInfoCacheValue' src/libstore/store-api.hh >/dev/null; then
+            cat 1>&2 <<EOF
+
+            You are deploying Hercules CI Agent on a system with an incompatible
+            nix-daemon. Please make sure nix.package is set to a Nix version of at
+            least 2.3.10 or a master version more recent than Mar 12, 2020.
+          EOF
+            exit 1
+          fi
+        '';
+        installPhase = "touch $out";
+      };
+
+in
+{
+  imports = [
+    (mkRenamedOptionModule [ "services" "hercules-ci-agent" "extraOptions" ] [ "services" "hercules-ci-agent" "settings" ])
+    (mkRenamedOptionModule [ "services" "hercules-ci-agent" "baseDirectory" ] [ "services" "hercules-ci-agent" "settings" "baseDirectory" ])
+    (mkRenamedOptionModule [ "services" "hercules-ci-agent" "concurrentTasks" ] [ "services" "hercules-ci-agent" "settings" "concurrentTasks" ])
+    (mkRemovedOptionModule [ "services" "hercules-ci-agent" "patchNix" ] "Nix versions packaged in this version of Nixpkgs don't need a patched nix-daemon to work correctly in Hercules CI Agent clusters.")
+  ];
+
+  options.services.hercules-ci-agent = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable to run Hercules CI Agent as a system service.
+
+        <link xlink:href="https://hercules-ci.com">Hercules CI</link> is a
+        continuous integation service that is centered around Nix.
+
+        Support is available at <link xlink:href="mailto:help@hercules-ci.com">help@hercules-ci.com</link>.
+      '';
+    };
+    checkNix = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to make sure that the system's Nix (nix-daemon) is compatible.
+
+        If you set this to false, please keep up with the change log.
+      '';
+    };
+    package = mkOption {
+      description = ''
+        Package containing the bin/hercules-ci-agent executable.
+      '';
+      type = types.package;
+      default = pkgs.hercules-ci-agent;
+      defaultText = literalExample "pkgs.hercules-ci-agent";
+    };
+    settings = mkOption {
+      description = ''
+        These settings are written to the <literal>agent.toml</literal> file.
+
+        Not all settings are listed as options, can be set nonetheless.
+
+        For the exhaustive list of settings, see <link xlink:href="https://docs.hercules-ci.com/hercules-ci/reference/agent-config/"/>.
+      '';
+      type = types.submoduleWith { modules = [ settingsModule ]; };
+    };
+
+    /*
+      Internal and/or computed values.
+
+      These are written as options instead of let binding to allow sharing with
+      default.nix on both NixOS and nix-darwin.
+     */
+    tomlFile = mkOption {
+      type = types.path;
+      internal = true;
+      defaultText = "generated hercules-ci-agent.toml";
+      description = ''
+        The fully assembled config file.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nix.extraOptions = lib.addContextFrom checkNix ''
+      # A store path that was missing at first may well have finished building,
+      # even shortly after the previous lookup. This *also* applies to the daemon.
+      narinfo-cache-negative-ttl = 0
+    '';
+    services.hercules-ci-agent.tomlFile =
+      format.generate "hercules-ci-agent.toml" cfg.settings;
+  };
+}

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -8,6 +8,10 @@ in
 {
   imports = [ ./common.nix ];
 
+  meta.maintainers = [
+    lib.maintainers.roberth or "roberth"
+  ];
+
   options.services.hercules-ci-agent = {
 
     logFile = mkOption {

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -69,5 +69,13 @@ in
       name = "_hercules-ci-agent";
       description = "System group for the Hercules CI Agent";
     };
+
+    services.hercules-ci-agent.settings.labels = {
+      darwin.label = config.system.darwinLabel;
+      darwin.revision = config.system.darwinRevision;
+      darwin.version = config.system.darwinVersion;
+      darwin.nix.useDaemon = config.nix.useDaemon;
+      darwin.nix.useSandbox = config.nix.useSandbox;
+    };
   };
 }

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.hercules-ci-agent;
+  user = config.users.users.hercules-ci-agent;
+in
+{
+  imports = [ ./common.nix ];
+
+  options.services.hercules-ci-agent = {
+
+    logFile = mkOption {
+      type = types.path;
+      default = "/var/log/hercules-ci-agent.log";
+      description = "Stdout and sterr of hercules-ci-agent process.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    launchd.daemons.hercules-ci-agent = {
+      script = "exec ${cfg.package}/bin/hercules-ci-agent --config ${cfg.tomlFile}";
+
+      path = [ config.nix.package ];
+      environment = {
+        NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      };
+
+      serviceConfig.KeepAlive = true;
+      serviceConfig.RunAtLoad = true;
+      serviceConfig.StandardErrorPath = cfg.logFile;
+      serviceConfig.StandardOutPath = cfg.logFile;
+      serviceConfig.GroupName = "hercules-ci-agent";
+      serviceConfig.UserName = "hercules-ci-agent";
+      serviceConfig.WorkingDirectory = user.home;
+      serviceConfig.WatchPaths = [
+        cfg.settings.staticSecretsDirectory
+      ];
+    };
+
+    system.activationScripts.preActivation.text = ''
+      touch '${cfg.logFile}'
+      chown ${toString user.uid}:${toString user.gid} '${cfg.logFile}'
+    '';
+
+    # Trusted user allows simplified configuration and better performance
+    # when operating in a cluster.
+    nix.trustedUsers = [ "hercules-ci-agent" ];
+    services.hercules-ci-agent.settings.nixUserIsTrusted = true;
+
+    users.knownGroups = [ "hercules-ci-agent" ];
+    users.knownUsers = [ "hercules-ci-agent" ];
+
+    users.users.hercules-ci-agent = {
+      uid = mkDefault 532;
+      gid = mkDefault config.users.groups.hercules-ci-agent.gid;
+      home = mkDefault cfg.settings.baseDirectory;
+      createHome = true;
+      shell = "/bin/bash";
+      description = "System user for the Hercules CI Agent";
+    };
+    users.groups.hercules-ci-agent = {
+      gid = mkDefault 532;
+      description = "System group for the Hercules CI Agent";
+    };
+  };
+}

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -3,7 +3,7 @@
 with lib;
 let
   cfg = config.services.hercules-ci-agent;
-  user = config.users.users.hercules-ci-agent;
+  user = config.users.users._hercules-ci-agent;
 in
 {
   imports = [ ./common.nix ];
@@ -30,8 +30,8 @@ in
       serviceConfig.RunAtLoad = true;
       serviceConfig.StandardErrorPath = cfg.logFile;
       serviceConfig.StandardOutPath = cfg.logFile;
-      serviceConfig.GroupName = "hercules-ci-agent";
-      serviceConfig.UserName = "hercules-ci-agent";
+      serviceConfig.GroupName = "_hercules-ci-agent";
+      serviceConfig.UserName = "_hercules-ci-agent";
       serviceConfig.WorkingDirectory = user.home;
       serviceConfig.WatchPaths = [
         cfg.settings.staticSecretsDirectory
@@ -45,22 +45,24 @@ in
 
     # Trusted user allows simplified configuration and better performance
     # when operating in a cluster.
-    nix.trustedUsers = [ "hercules-ci-agent" ];
+    nix.trustedUsers = [ "_hercules-ci-agent" ];
     services.hercules-ci-agent.settings.nixUserIsTrusted = true;
 
-    users.knownGroups = [ "hercules-ci-agent" ];
-    users.knownUsers = [ "hercules-ci-agent" ];
+    users.knownGroups = [ "hercules-ci-agent" "_hercules-ci-agent" ];
+    users.knownUsers = [ "hercules-ci-agent" "_hercules-ci-agent" ];
 
-    users.users.hercules-ci-agent = {
-      uid = mkDefault 532;
-      gid = mkDefault config.users.groups.hercules-ci-agent.gid;
+    users.users._hercules-ci-agent = {
+      uid = mkDefault 399;
+      gid = mkDefault config.users.groups._hercules-ci-agent.gid;
       home = mkDefault cfg.settings.baseDirectory;
+      name = "_hercules-ci-agent";
       createHome = true;
       shell = "/bin/bash";
       description = "System user for the Hercules CI Agent";
     };
-    users.groups.hercules-ci-agent = {
-      gid = mkDefault 532;
+    users.groups._hercules-ci-agent = {
+      gid = mkDefault 399;
+      name = "_hercules-ci-agent";
       description = "System group for the Hercules CI Agent";
     };
   };

--- a/modules/users/group.nix
+++ b/modules/users/group.nix
@@ -15,7 +15,7 @@ with lib;
     gid = mkOption {
       type = mkOptionType {
         name = "gid";
-        check = t: isInt t && t > 501;
+        check = t: isInt t && t >= 300;
       };
       description = "The group's GID.";
     };


### PR DESCRIPTION
Source files originate from the hercules-ci-agent repository and I will make sure to keep them in sync, bidirectionally.

The module is split into two files to make maintenance of the common parts with NixOS easier.

Unlike the module that existed in the hercules-ci fork for a long time, this module reuses the hercules-ci-agent package from Nixpkgs, so it will require little maintenance in nix-darwin itself.

UPDATE: force-pushed to retry unrelated github actions failure
UPDATE 2: still fails. It seems to be a nixUnstable bug, which is unrelated to this pr.

Closes #291 