### PR TITLE
Fix gnupg-agent being kept alive

### DIFF
--- a/modules/programs/gnupg.nix
+++ b/modules/programs/gnupg.nix
@@ -34,7 +34,7 @@ in
         "${pkgs.gnupg}/bin/gpg-connect-agent" "/bye"
       ];
       RunAtLoad = cfg.agent.enableSSHSupport;
-      KeepAlive = true;
+      KeepAlive.SuccessfulExit = false;
     };
 
     environment.extraInit = ''


### PR DESCRIPTION
The agent is restarted automatically after it has been launched
successfully, this creates a lot of noise in the logs. This change
reloads the agent only if it has crashed, i.e. returns with a non-zero
exit code.