### PR TITLE
darwin-[un]installer: Don't reference deprecated stdenv.lib

### DIFF
--- a/pkgs/darwin-installer/default.nix
+++ b/pkgs/darwin-installer/default.nix
@@ -7,7 +7,7 @@ let
     filter = name: _type: name != toString ./default.nix;
   };
 
-  nixPath = stdenv.lib.concatStringsSep ":" [
+  nixPath = pkgs.lib.concatStringsSep ":" [
     "darwin-config=${configuration}/configuration.nix"
     "darwin=${nix-darwin}"
     "nixpkgs=${pkgs.path}"

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -7,7 +7,7 @@ let
     filter = name: _type: name != toString ./default.nix;
   };
 
-  nixPath = stdenv.lib.concatStringsSep ":" [
+  nixPath = pkgs.lib.concatStringsSep ":" [
     "darwin-config=${configuration}/configuration.nix"
     "darwin=${nix-darwin}"
     "nixpkgs=${pkgs.path}"


### PR DESCRIPTION
`stdenv.lib` has been deprecated, and the correct approach is to use `lib` directly through `pkgs.lib`.