### PR TITLE
Support the Apple Silicon Homebrew directory

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -204,7 +204,7 @@ in
     system.activationScripts.homebrew.text = mkIf cfg.enable ''
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
-      if [ -f /usr/local/bin/brew ]; then
+      if [ -f /usr/local/bin/brew ] || [ -f /opt/homebrew/bin/brew ]; then
         PATH=/usr/local/bin:$PATH ${brew-bundle-command}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2


### PR DESCRIPTION
Hey folks! 👋 

This is a small change allowing Homebrew to be used if installed in the new installation directory for Apple Silicon machines, as detailed in the Homebrew 3.0.0 changelogs: https://brew.sh/2021/02/05/homebrew-3.0.0/