### PR TITLE
homebrew: make brew path configurable

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -52,6 +52,14 @@ in
       '';
     };
 
+    brewPrefix = mkOption {
+      type = types.str;
+      default = "/usr/local/bin";
+      description = ''
+        Customize path prefix where executable of <command>brew</command> is searched for.
+      '';
+    };
+
     cleanup = mkOption {
       type = types.enum [ "none" "uninstall" "zap" ];
       default = "none";
@@ -204,8 +212,8 @@ in
     system.activationScripts.homebrew.text = mkIf cfg.enable ''
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
-      if [ -f /usr/local/bin/brew ]; then
-        PATH=/usr/local/bin:$PATH ${brew-bundle-command}
+      if [ -f "${cfg.brewPrefix}/brew" ]; then
+        PATH="${cfg.brewPrefix}":$PATH ${brew-bundle-command}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2
       fi


### PR DESCRIPTION
[x] Tested using `darwin-rebuild switch -I darwin=$(pwd)` using nix daemon
[ ] Update documentation
[ ] write an automated testcase?
...

Reason:
I am currently building a nix package for `brew` which is working in its first alpha version for installing my used "Casks".
(I am happy to share if someone is interested even though I am not sure getting it done the "nix way" 100% - means without non-deterministic side-effects).

I am happy for every comment / feedback :-)