### PR TITLE
Add an option to override the Nix used by darwin-rebuild.

### DIFF
--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -5,7 +5,9 @@ with lib;
 let
   inherit (pkgs) stdenv;
 
-  extraPath = lib.makeBinPath [ config.nix.package pkgs.coreutils pkgs.jq ];
+  cfg = config.darwin-rebuild;
+
+  extraPath = lib.makeBinPath [ cfg.nixPackage pkgs.coreutils pkgs.jq ];
 
   writeProgram = name: env: src:
     pkgs.substituteAll ({
@@ -31,6 +33,18 @@ let
 in
 
 {
+  options = {
+    darwin-rebuild.nixPackage = mkOption {
+      type = types.either types.package types.path;
+      default = config.nix.package;
+      defaultText = "config.nix.package";
+      example = literalExample "pkgs.nixUnstable";
+      description = ''
+        This option specifies the package or profile that contains the version of Nix used by <literal>darwin-rebuild</literal>. The default is to use the system version of Nix.
+      '';
+    };
+  };
+
   config = {
 
     environment.systemPackages =


### PR DESCRIPTION
This is useful in particular when you want to use a stable version of Nix for the system Nix, but an unstable version (e.g., with flakes support) for darwin-rebuild.

We've encountered quite a few problems lately with nixUnstable and remote builders for CI (Hydra & Hercules CI), so we've reverted to nixStable on these builders. However, I've also gotten very accustomed to managing them with nix-darwin's flake support, so I don't want to lose that in the process.

This commit feels like a bit of a hack, but it was the most straightforward way I could come up with for supporting this scenario. It's backward compatible and shouldn't affect any existing installations.