### PR TITLE
Fix nix flake info error

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -126,7 +126,7 @@ if [ -n "$flake" ]; then
 fi
 
 if [ -n "$flake" ]; then
-    flake=$(nix "${flakeFlags[@]}" flake info --json "${extraBuildFlags[@]}" "${extraLockFlags[@]}" -- "$flake" | jq -r .url)
+    flake=$(nix "${flakeFlags[@]}" flake metadata --json "${extraBuildFlags[@]}" "${extraLockFlags[@]}" -- "$flake" | jq -r .url)
 fi
 
 if [ "$action" != build ] && [ -z "$flake" ]; then

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -126,7 +126,7 @@ if [ -n "$flake" ]; then
 fi
 
 if [ -n "$flake" ]; then
-    if nix flake metadata &>/dev/null; then
+    if nix "${flakeFlags[@]}" flake metadata --version &>/dev/null; then
         cmd=metadata
     else
         cmd=info

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -126,7 +126,13 @@ if [ -n "$flake" ]; then
 fi
 
 if [ -n "$flake" ]; then
-    flake=$(nix "${flakeFlags[@]}" flake metadata --json "${extraBuildFlags[@]}" "${extraLockFlags[@]}" -- "$flake" | jq -r .url)
+    if nix flake metadata &>/dev/null; then
+        cmd=metadata
+    else
+        cmd=info
+    fi
+
+    flake=$(nix "${flakeFlags[@]}" flake "$cmd" --json "${extraBuildFlags[@]}" "${extraLockFlags[@]}" -- "$flake" | jq -r .url)
 fi
 
 if [ "$action" != build ] && [ -z "$flake" ]; then


### PR DESCRIPTION
Fixes

```
error: 'info' is not a recognised command'
```

Issue: #307