### PR TITLE
darwin-rebuild: use `hostname -s` for flakeAttr

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -120,9 +120,9 @@ if [ -n "$flake" ]; then
        flakeAttr="${BASH_REMATCH[2]}"
     fi
     if [ -z "$flakeAttr" ]; then
-      flakeAttr=$(hostname)
+      flakeAttr=$(hostname -s)
     fi
-    flakeAttr=darwinConfigurations.${flakeAttr%.local}
+    flakeAttr=darwinConfigurations.${flakeAttr}
 fi
 
 if [ -n "$flake" ]; then


### PR DESCRIPTION
Previously this would fail to strip the domain if you set a different FQDN in the macOS interface or with `networking.hostName`.

Another alternative would be to use the full domain unconditionally if it doesn’t end in `.local`, but that’d require at least fixing the quoting.