### PR TITLE
darwin-rebuild: use --no-link for flakes too

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -135,8 +135,12 @@ if [ -n "$flake" ]; then
     flake=$(nix "${flakeFlags[@]}" flake "$cmd" --json "${extraBuildFlags[@]}" "${extraLockFlags[@]}" -- "$flake" | jq -r .url)
 fi
 
-if [ "$action" != build ] && [ -z "$flake" ]; then
-  extraBuildFlags+=("--no-out-link")
+if [ "$action" != build ]; then
+  if [ -n "$flake" ]; then
+    extraBuildFlags+=("--no-link")
+  else
+    extraBuildFlags+=("--no-out-link")
+  fi
 fi
 
 if [ "$action" = edit ]; then

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -153,8 +153,10 @@ if [ "$action" = switch ] || [ "$action" = build ] || [ "$action" = check ]; the
   if [ -z "$flake" ]; then
     systemConfig="$(nix-build '<darwin>' "${extraBuildFlags[@]}" -A system)"
   else
-    nix "${flakeFlags[@]}" build "$flake#$flakeAttr.system" "${extraBuildFlags[@]}" "${extraLockFlags[@]}"
-    systemConfig=$(readlink -f result)
+    systemConfig=$(nix "${flakeFlags[@]}" build --json \
+      "${extraBuildFlags[@]}" "${extraLockFlags[@]}" \
+      -- "$flake#$flakeAttr.system" \
+      | jq -r '.[0].outputs.out')
   fi
 fi
 


### PR DESCRIPTION
This appears to have been special‐cased because of the `readlink -f result`, but `nix path-info` gives us the same information. (Theoretically there might be an annoying race condition here where Nix refreshes the flake registry between the `build` and `path-info` errors out, but I think the consequences should be fairly harmless. Also not sure if `${extraLockFlags[@]}` should be passed along here.)