### PR TITLE
Pass system to darwinSystem rather than eval-config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A minimal example of using an existing configuration.nix:
 
   outputs = { self, darwin, nixpkgs }: {
     darwinConfigurations."Johns-MacBook" = darwin.lib.darwinSystem {
+      system = "x86_64-darwin";
       modules = [ ./configuration.nix ];
     };
   };
@@ -90,6 +91,7 @@ accessible as an argument, similar to pkgs and lib inside the configuration.
 
 ```nix
 darwin.lib.darwinSystem {
+  system = "x86_64-darwin";
   modules = [ ... ];
   inputs = { inherit darwin dotfiles nixpkgs; };
 }

--- a/default.nix
+++ b/default.nix
@@ -6,9 +6,10 @@
 }:
 
 let
-  evalConfig = import ./eval-config.nix { inherit lib system; };
+  evalConfig = import ./eval-config.nix { inherit lib; };
 
   eval = evalConfig {
+    inherit system;
     modules = [ configuration ];
     inputs = { inherit nixpkgs; };
   };

--- a/eval-config.nix
+++ b/eval-config.nix
@@ -1,9 +1,10 @@
-{ lib, system ? builtins.currentSystem or "x86_64-darwin" }:
+{ lib }:
 
-{ modules
+{ system ? builtins.currentSystem or "x86_64-darwin"
+, modules
 , inputs
 , baseModules ? import ./modules/module-list.nix
-, specialArgs ? {}
+, specialArgs ? { }
 }@args:
 
 let
@@ -18,11 +19,14 @@ let
     _file = ./eval-config.nix;
     config = {
       _module.args.pkgs = import inputs.nixpkgs config.nixpkgs;
-      nixpkgs.system = system;
+
+      # This permits the configuration to override the passed-in
+      # system.
+      nixpkgs.system = lib.mkDefault system;
     };
   };
 
-  eval = lib.evalModules (builtins.removeAttrs args ["inputs"] // {
+  eval = lib.evalModules (builtins.removeAttrs args [ "inputs" "system" ] // {
     modules = modules ++ [ inputsModule pkgsModule ] ++ baseModules;
     args = { inherit baseModules modules; };
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,8 @@
       # TODO handle multiple architectures.
       evalConfig = import ./eval-config.nix { inherit (nixpkgs) lib; };
 
-      darwinSystem = { modules, inputs ? {}, ... }@args: self.lib.evalConfig (args // {
+      darwinSystem = { modules, system, inputs ? { }, ... }@args: self.lib.evalConfig (args // {
+        inherit system;
         inputs = { inherit nixpkgs; darwin = self; } // inputs;
         modules = modules ++ [ self.darwinModules.flakeOverrides ];
       });
@@ -20,6 +21,7 @@
     darwinModules.simple = ./modules/examples/simple.nix;
 
     checks.x86_64-darwin.simple = (self.lib.darwinSystem {
+      system = "x86_64-darwin";
       modules = [ self.darwinModules.simple ];
     }).system;
 

--- a/modules/examples/flake.nix
+++ b/modules/examples/flake.nix
@@ -21,6 +21,7 @@
     # $ darwin-rebuild build --flake ./modules/examples#darwinConfigurations.simple.system \
     #       --override-input darwin .
     darwinConfigurations."simple" = darwin.lib.darwinSystem {
+      system = "x86_64-darwin";
       modules = [ configuration darwin.darwinModules.simple ];
     };
 


### PR DESCRIPTION
This allows us to specify what kind of darwinSystem we want to build, rather than determining it at evaluation time.