### PR TITLE
Bundle with /opt/homebrew if brew exists in there

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -204,7 +204,9 @@ in
     system.activationScripts.homebrew.text = mkIf cfg.enable ''
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
-      if [ -f /usr/local/bin/brew ]; then
+      if [ -x /opt/homebrew/bin/brew ]; then
+        PATH=/opt/homebrew/bin:$PATH ${brew-bundle-command}
+      elif [ -f /usr/local/bin/brew ]; then
         PATH=/usr/local/bin:$PATH ${brew-bundle-command}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2


### PR DESCRIPTION
This fixes #321 - by using /opt/homebrew's brew binary first, we default to the right thing on Apple Silicon (and help anyone who may have used the same work-around as I did).

With this change, I can build&activate my system configuration with homebrew on an M1 macbook air.