### PR TITLE
List the configuration file location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ nix-build https://github.com/LnL7/nix-darwin/archive/master.tar.gz -A uninstalle
 
 ## Example configuration
 
-Check out [modules/examples](https://github.com/LnL7/nix-darwin/tree/master/modules/examples) for some example configurations.
+Configuration lives in `~/.nixpkgs/darwin-configuration.nix`. Check out
+[modules/examples](https://github.com/LnL7/nix-darwin/tree/master/modules/examples) for some example configurations.
 
 ```nix
 { pkgs, ... }:


### PR DESCRIPTION
I don't have unlimited time to read through the manual installation instructions just to see where the config file goes when I forget. It's not great either that the first line of the README has a path that means nothing at all on macOS. That could be better too but I'm not going to update the project's top tagline in a PR.