### PR TITLE
work around multi-user nix zsh evaluation order

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -185,6 +185,11 @@ in
     system.build.setEnvironment = pkgs.writeText "set-environment" ''
       # Prevent this file from being sourced by child shells.
       export __NIX_DARWIN_SET_ENVIRONMENT_DONE=1
+      # Work around multi-user Nix.
+      if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+          # As far as Nix is concerned, with all we set here, this is true.
+          export __ETC_PROFILE_NIX_SOURCED=1
+      fi
 
       export PATH=${config.environment.systemPath}
       ${concatStringsSep "\n" exportVariables}


### PR DESCRIPTION
Presented for consideration is a solution less intrusive than either #286 or 34e672b. I've got a branch of my own that's just this commit plus the channel added by the installer pointing to that branch, and I can confirm that it does a fine job fixing environment clobbering by `nix-daemon.sh` in the case of a multi-user install. 