### PR TITLE
system.defaults: enable automatic light/dark mode

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -47,6 +47,14 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain.AppleInterfaceStyleSwitchesAutomatically = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to automatically switch between light and dark mode. The default is false.
+      '';
+    };
+
     system.defaults.NSGlobalDomain.AppleKeyboardUIMode = mkOption {
       type = types.nullOr (types.enum [ 3 ]);
       default = null;


### PR DESCRIPTION
This adds support for automatic switching between light and dark mode.