### PR TITLE
fish: remove `promptInit` in favor of `interactiveShellInit`

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -44,6 +44,14 @@ in
 
 {
 
+  imports = [
+    (mkRemovedOptionModule [ "programs" "fish" "promptInit" ] ''
+      Prompt is now configured through the
+        programs.fish.interactiveShellInit
+      option. Please change to use that instead.
+    '')
+  ];
+
   options = {
 
     programs.fish = {
@@ -130,14 +138,6 @@ in
         type = types.lines;
       };
 
-      promptInit = mkOption {
-        default = "";
-        description = ''
-          Shell script code used to initialise fish prompt.
-        '';
-        type = types.lines;
-      };
-
     };
 
   };
@@ -217,7 +217,6 @@ in
 
           ${sourceEnv "interactiveShellInit"}
 
-          ${cfg.promptInit}
           ${cfg.interactiveShellInit}
 
           # and leave a note so we don't source this config section again from


### PR DESCRIPTION
Derived from nix-community/home-manager#2231

`promptInit` does nothing special and can already be implemented via `interactiveShellInit`, so I suggest just keep the latter.