### PR TITLE
fish: simplify config guards

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -187,43 +187,27 @@ in
         etc."fish/config.fish".text = ''
         # /etc/fish/config.fish: DO NOT EDIT -- this file has been generated automatically.
 
-        # if we haven't sourced the general config, do it
-        if not set -q __fish_nix_darwin_general_config_sourced
-          ${sourceEnv "shellInit"}
+        # Only execute this file once per shell.
+        set -q __fish_nix_darwin_config_sourced; and exit
+        set -g __fish_nix_darwin_config_sourced 1
 
-          ${cfg.shellInit}
+        ${sourceEnv "shellInit"}
 
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew)
-          set -g __fish_nix_darwin_general_config_sourced 1
-        end
+        ${cfg.shellInit}
 
-        # if we haven't sourced the login config, do it
-        status --is-login; and not set -q __fish_nix_darwin_login_config_sourced
-        and begin
+        status --is-login; and begin
           ${sourceEnv "loginShellInit"}
 
           ${cfg.loginShellInit}
-
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew)
-          set -g __fish_nix_darwin_login_config_sourced 1
         end
 
-        # if we haven't sourced the interactive config, do it
-        status --is-interactive; and not set -q __fish_nix_darwin_interactive_config_sourced
-        and begin
+        status --is-interactive; and begin
           ${fishAliases}
 
           ${sourceEnv "interactiveShellInit"}
 
           ${cfg.promptInit}
           ${cfg.interactiveShellInit}
-
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew,
-          # allowing configuration changes in, e.g, aliases, to propagate)
-          set -g __fish_nix_darwin_interactive_config_sourced 1
         end
       '';
       }


### PR DESCRIPTION
Derived from nix-community/home-manager#2230

There's no need to use separate variables for each section. We only use one variable for such usage in nix-darwin's [Zsh module](https://github.com/LnL7/nix-darwin/blob/007d700e644ac588ad6668e6439950a5b6e2ff64/modules/programs/zsh/default.nix#L112-L115).