### PR TITLE
uninstaller: also remove `~/Applications/Nix Apps`

### DIFF
--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -16,6 +16,8 @@ with lib;
   system.activationScripts.postUserActivation.text = mkAfter ''
     if test -L ~/Applications; then
         rm ~/Applications
+    elif test -L ~/Applications/Nix\ Apps; then
+        rm ~/Applications/Nix\ Apps
     fi
 
     if test -L ~/.nix-defexpr/channels/darwin; then


### PR DESCRIPTION
`~/Applications/Nix Apps` was added in #31 but the uninstaller was not updated.