### PR TITLE
defaults: magic mouse option

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -16,6 +16,7 @@
   ./system/defaults/screencapture.nix
   ./system/defaults/alf.nix
   ./system/defaults/loginwindow.nix
+  ./system/defaults/magicmouse.nix
   ./system/defaults/smb.nix
   ./system/defaults/SoftwareUpdate.nix
   ./system/defaults/spaces.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -34,6 +34,8 @@ let
   spaces = defaultsToList "com.apple.spaces" cfg.spaces;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
+  magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
+  magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != {}) list);
 in
@@ -52,7 +54,7 @@ in
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
-      [ NSGlobalDomain GlobalPreferences LaunchServices dock finder screencapture spaces trackpad trackpadBluetooth ]
+      [ NSGlobalDomain GlobalPreferences LaunchServices dock finder screencapture spaces trackpad trackpadBluetooth magicmouse magicmouseBluetooth ]
       ''
         # Set defaults
         echo >&2 "user defaults..."
@@ -66,6 +68,8 @@ in
         ${concatStringsSep "\n" spaces}
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}
+        ${concatStringsSep "\n" magicmouse}
+        ${concatStringsSep "\n" magicmouseBluetooth}
       '';
 
   };

--- a/modules/system/defaults/magicmouse.nix
+++ b/modules/system/defaults/magicmouse.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.magicmouse.MouseButtonMode = mkOption {
+      type = types.nullOr (types.enum [
+        "OneButton"
+        "TwoButton"
+      ]);
+      default = null;
+      description = ''
+        "OneButton": any tap is a left click.  "TwoButton": allow left-
+        and right-clicking.
+      '';
+    };
+
+  };
+}


### PR DESCRIPTION
This allows setting the magic mouse to "one button" or "two button" mode.

There are other options, but I'm not familiar with them and don't use them.  Also, maybe `magicmouse` is not the right name?