### PR TITLE
Correct typos and use the same case style

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -18,14 +18,14 @@ in
     programs.vim.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "Whether to configure vim.";
+      description = "Whether to configure Vim.";
     };
 
     programs.vim.enableSensible = mkOption {
       type = types.bool;
       default = false;
       example = true;
-      description = "Enable sensible configuration options for vim.";
+      description = "Enable sensible configuration options for Vim.";
     };
 
     programs.vim.extraKnownPlugins = mkOption {
@@ -46,14 +46,14 @@ in
           };
         }
         '';
-      description = "Custom plugin declarations to add to VAM's knownPlugins.";
+      description = "Custom plugin declarations to add to Vim's knownPlugins.";
     };
 
     programs.vim.plugins = mkOption {
       type = types.listOf types.attrs;
       default = [];
       example = [ { names = [ "surround" "vim-nix" ]; } ];
-      description = "VAM plugin dictionaries to use for vim_configurable.";
+      description = "Vim plugin dictionaries to use for vim_configurable.";
     };
 
     programs.vim.package = mkOption {


### PR DESCRIPTION
1. change "VAM" to "Vim", which I believe is a typo;
2. use "**Vim**" instead of vim or VIM in the description strings, because "Vim" is the official spelling of the editor's name. See https://github.com/vim/vim

- if `master` branch is not the right branch to merge such a PR, please let me know the correct one;
- if this PR is wrong or not acceptable, please close it safely. Thank you for reviewing this and the awesome work on nix-darwin.