### PR TITLE
Add yubikey-agent module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -59,6 +59,7 @@
   ./services/synapse-bt.nix
   ./services/synergy
   ./services/yabai
+  ./services/yubikey-agent.nix
   ./services/nextdns
   ./programs/bash
   ./programs/fish.nix

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options = {
+    services.yubikey-agent.enable = mkEnableOption "yubikey-agent";
+
+    services.yubikey-agent.package = mkOption {
+      default = pkgs.yubikey-agent;
+      defaultText = "pkgs.yubikey-agent";
+      description = "Which yubikey-agent derivation to use";
+      type = types.package;
+    };
+  };
+
+  config = mkIf config.services.yubikey-agent.enable {
+    environment.systemPackages = [ config.services.yubikey-agent.package ];
+
+    launchd.user.agents.yubikey-agent = {
+      path = [ config.environment.systemPath ];
+      command =
+        "${config.services.yubikey-agent.package}/bin/yubikey-agent -l /tmp/yubikey-agent.sock";
+      serviceConfig.KeepAlive = true;
+    };
+
+    environment.extraInit = ''
+      export SSH_AUTH_SOCK="/tmp/yubikey-agent.sock"
+    '';
+  };
+}


### PR DESCRIPTION
This adds a module for [yubikey-agent](https://github.com/FiloSottile/yubikey-agent), a yubikey-based ssh-agent.

It's the equivalent of this nixos module: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/security/yubikey-agent.nix