### PR TITLE
Guard against double-sourcing of set-environment

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -184,6 +184,7 @@ in
 
     system.build.setEnvironment = pkgs.writeText "set-environment" ''
       # Prevent this file from being sourced by child shells.
+      if [ -n "${__NIX_DARWIN_SET_ENVIRONMENT_DONE:-}" ]; then return; fi
       export __NIX_DARWIN_SET_ENVIRONMENT_DONE=1
 
       export PATH=${config.environment.systemPath}


### PR DESCRIPTION
The current setup of nix bootstrapping is complicated and brittle - it often breaks on updates (both macOS and, apparently, nix). At present, the nix 2.4 beta breaks `programs.zsh.enable`, and disabling it disabled nix functionality on my system.

Therefore I've moved source statements into a ~/.profile like so:

```
# Setup nix
test -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' && source-sh '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
test -e /etc/static/bashrc && source-sh "$(cat /etc/static/bashrc | grep -o '/nix/store/[0-9a-z]\{32\}-set-environment')"
test -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" && source-sh "${HOME}/.nix-profile/etc/profile.d/nix.sh"
```

In the process, I noticed that the nix-darwin set-environment does not have an internal guard - it relies on the generated code in /etc/static/bashrc or /etc/static/zshrc. This change would add the internal guard, which while currently redundant, should have negligible performance impact but improve robustness. I do not remove the existing external guards, as these could prevent the need for a disk access.

The precise syntax used is identical to nix-daemon.sh, to maintain consistent shell compatibility.