### PR TITLE
fix synergy client with screenName

### DIFF
--- a/modules/services/synergy/default.nix
+++ b/modules/services/synergy/default.nix
@@ -92,8 +92,12 @@ in
       launchd.user.agents."synergy-client" = {
         path = [ config.environment.systemPath ];
         serviceConfig.ProgramArguments = [
-          "${cfg.package}/bin/synergyc" "-f" "${cfg.client.serverAddress}"
-        ] ++ optionals (cfg.client.screenName != "") [ "-n" cfg.client.screenName ];
+          "${cfg.package}/bin/synergyc" "-f"
+        ] ++ optionals (cfg.client.screenName != "") [
+           "-n" cfg.client.screenName 
+        ] ++ [
+          "${cfg.client.serverAddress}"
+        ];
         serviceConfig.KeepAlive = true;
         serviceConfig.RunAtLoad = cfg.client.autoStart;
         serviceConfig.ProcessType = "Interactive";


### PR DESCRIPTION
Without having the address as the final argument, `synergyc` results in this error:

```
synergyc: unrecognized option `$IP'
Try `synergyc --help' for more information.
```