### PR TITLE
zsh: _nix collision from nix-zsh-completions on >=2.4pre

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -96,12 +96,24 @@ in
   };
 
   config = mkIf cfg.enable {
-
     environment.systemPackages =
-      [ # Include zsh package
+      let
+        completions =
+          if lib.versionAtLeast (lib.getVersion config.nix.package) "2.4pre"
+          then
+            pkgs.nix-zsh-completions.overrideAttrs
+              (oldAttrs: {
+                installPhase = oldAttrs.installPhase + ''
+                  rm $out/share/zsh/site-functions/_nix
+                '';
+              })
+          else pkgs.nix-zsh-completions;
+      in
+      [
+        # Include zsh package
         pkgs.zsh
-      ] ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
-        ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting;
+      ] ++ optional cfg.enableCompletion completions
+      ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting;
 
     environment.pathsToLink = [ "/share/zsh" ];
 


### PR DESCRIPTION
This ports over a conditional from nixpkgs, which prevents a collision between zsh completion files when nix >=2.4pre (and consequently, 2.4 release) is in use: Remove the _nix definitions from nix-zsh-completions.

This PR fixes #373.