### PR TITLE
security: add agenix module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -3,6 +3,7 @@
   ./documentation
   ./security/pki
   ./security/sandbox
+  ./security/age
   ./system
   ./system/checks.nix
   ./system/activation-scripts.nix

--- a/modules/security/age/default.nix
+++ b/modules/security/age/default.nix
@@ -1,0 +1,117 @@
+# adapted from https://github.com/ryantm/agenix/blob/53aa91b4170da35a96fab1577c9a34bc0da44e27/modules/age.nix
+{ config, options, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.age;
+
+  # we need at least rage 0.5.0 to support ssh keys
+  inherit (pkgs) rage;
+  ageBin = "${rage}/bin/rage";
+
+  users = config.users.users;
+
+  identities = builtins.concatStringsSep " " (map (path: "-i ${path}") cfg.sshKeyPaths);
+  installSecret = secretType: ''
+    echo "decrypting ${secretType.file} to ${secretType.path}..."
+    TMP_FILE="${secretType.path}.tmp"
+    mkdir -p $(dirname ${secretType.path})
+    (
+      umask u=r,g=,o=
+      ${ageBin} --decrypt ${identities} -o "$TMP_FILE" "${secretType.file}"
+    )
+    chmod ${secretType.mode} "$TMP_FILE"
+    chown ${secretType.owner}:${secretType.group} "$TMP_FILE"
+    mv -f "$TMP_FILE" '${secretType.path}'
+  '';
+
+  isRootSecret = st: (st.owner == "root" || st.owner == "0") && (st.group == "root" || st.group == "0");
+  isNotRootSecret = st: !(isRootSecret st);
+
+  rootOwnedSecrets = builtins.filter isRootSecret (builtins.attrValues cfg.secrets);
+  installRootOwnedSecrets = builtins.concatStringsSep "\n" ([ "echo '[agenix] decrypting root secrets...'" ] ++ (map installSecret rootOwnedSecrets));
+
+  nonRootSecrets = builtins.filter isNotRootSecret (builtins.attrValues cfg.secrets);
+  installNonRootSecrets = builtins.concatStringsSep "\n" ([ "echo '[agenix] decrypting non-root secrets...'" ] ++ (map installSecret nonRootSecrets));
+
+  secretType = types.submodule ({ config, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        default = config._module.args.name;
+        description = ''
+          Name of the file used in /run/secrets
+        '';
+      };
+      file = mkOption {
+        type = types.path;
+        description = ''
+          Age file the secret is loaded from.
+        '';
+      };
+      path = mkOption {
+        type = types.str;
+        default = "/run/secrets/${config.name}";
+        description = ''
+          Path where the decrypted secret is installed.
+        '';
+      };
+      mode = mkOption {
+        type = types.str;
+        default = "0400";
+        description = ''
+          Permissions mode of the in octal.
+        '';
+      };
+      owner = mkOption {
+        type = types.str;
+        default = "0";
+        description = ''
+          User of the file.
+        '';
+      };
+      group = mkOption {
+        type = types.str;
+        default = users.${config.owner}.group or "0";
+        description = ''
+          Group of the file.
+        '';
+      };
+    };
+  });
+in
+{
+  options.age = {
+    secrets = mkOption {
+      type = types.attrsOf secretType;
+      default = { };
+      description = ''
+        Attrset of secrets.
+      '';
+    };
+    sshKeyPaths = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      description = ''
+        Path to SSH keys to be used as identities in age decryption.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.secrets != { }) {
+    assertions = [{
+      assertion = cfg.sshKeyPaths != [ ];
+      message = "age.sshKeyPaths must be set.";
+    }];
+
+    # Secrets with root owner and group can be installed before users
+    # exist. This allows user password files to be encrypted.
+    system.activationScripts.preActivation.text = installRootOwnedSecrets;
+
+    # Other secrets need to wait for users and groups to exist.
+    system.activationScripts.users.text = lib.mkAfter installNonRootSecrets;
+
+  };
+
+}

--- a/modules/security/age/default.nix
+++ b/modules/security/age/default.nix
@@ -61,7 +61,7 @@ let
         type = types.str;
         default = "0400";
         description = ''
-          Permissions mode of the in octal.
+          Permissions mode of the decrypted secret in octal format.
         '';
       };
       owner = mkOption {


### PR DESCRIPTION
This PR adapts the [agenix NixOS module](https://github.com/ryantm/agenix/blob/main/modules/age.nix) to nix-darwin's `system.activationScripts` structure and makes it available and configurable at `config.age.{secrets,sshKeyPaths}`.