### PR TITLE
Service Yabai: Use Root User for scripting addition

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -99,6 +99,7 @@ in
 
         serviceConfig.RunAtLoad = true;
         serviceConfig.KeepAlive.SuccessfulExit = false;
+        serviceConfig.UserName = "root";
       };
     })
   ];


### PR DESCRIPTION
[The yabai scripting addition must be loaded by a root user](https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(latest-release)#macos-big-sur---automatically-load-scripting-addition-on-startup). Not running as root causes the service to exit (`1`) and restart after 10 seconds, and each restart causes this awful flash on the screen.