### PR TITLE
telegraf: Initial service definition.

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -58,6 +58,7 @@
   ./services/spotifyd.nix
   ./services/synapse-bt.nix
   ./services/synergy
+  ./services/telegraf.nix
   ./services/yabai
   ./services/nextdns
   ./programs/bash

--- a/modules/services/telegraf.nix
+++ b/modules/services/telegraf.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.telegraf;
+
+  configFile = pkgs.runCommand "config.toml" {
+    buildInputs = [ pkgs.remarshal ];
+    preferLocalBuild = true;
+  } ''
+    remarshal -if json -of toml \
+      < ${pkgs.writeText "config.json" (builtins.toJSON cfg.extraConfig)} \
+      > $out
+  '';
+in {
+  options = {
+    services.telegraf = {
+      enable = lib.mkEnableOption "telegraf server";
+
+      package = lib.mkOption {
+        default = pkgs.telegraf;
+        defaultText = "pkgs.telegraf";
+        description = "Which telegraf derivation to use";
+        type = lib.types.package;
+      };
+
+      extraConfig = lib.mkOption {
+        default = {};
+        description = "Extra configuration options for telegraf";
+        type = lib.types.attrs;
+        example = {
+          outputs.influxdb = [{
+            urls = ["http://localhost:8086"];
+            database = "telegraf";
+          }];
+          inputs.statsd = [{
+            service_address = ":8125";
+            delete_timings = true;
+          }];
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf config.services.telegraf.enable {
+    launchd.daemons.telegraf = {
+      script = "${cfg.package}/bin/telegraf -config ${configFile}";
+
+      serviceConfig = {
+        Label = "telegraf";
+        RunAtLoad = true;
+        KeepAlive.NetworkState = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This provides a limited subset of the systemd service, but telegraf
does indeed "work" on darwin. It is missing the following features
present in the nixos service:

* envsubst of environment variables.

  This is because nixpkgs uses the EnvironmentFile systemd unit
  configuration to provide secrets in environment variables.

  I do not think nix-darwin supports a similar mechanism.

* Reloading the unit with SIGHUP.

  I am not sure launchd provides such a facility.

* Creation of a telegraf user.

  We can't be fully sure that the user of nix-darwin won't manage
  users outside of nix-darwin. They would be free to set UserName and
  GroupName themselves with a user they create and add to knownUsers.

* Restart on failure.

  This one I am less confident on. I am unsure how the KeepAlive
  options work. Though I think maybe nix-darwin is missing the Crashed
  value.

* multi-user.target.

  Perhaps this should be an agent?

* AmbientCapabilities = [ "CAP_NET_RAW" ]

  I am unsure this even applies on darwin, or if it is, what the
  corresponding launchd configuration would look like.