### PR TITLE
fix: change user doc hint for synthetic.conf to output literal tabs

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -27,7 +27,7 @@ let
         echo "Create a symlink to /var/run with:" >&2
         if test -e /etc/synthetic.conf; then
             echo >&2
-            echo "$ echo 'run\tprivate/var/run' | sudo tee -a /etc/synthetic.conf" >&2
+            echo "$ printf 'run\tprivate/var/run\n' | sudo tee -a /etc/synthetic.conf" >&2
             echo "$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B" >&2
             echo "$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t" >&2
             echo >&2


### PR DESCRIPTION
This PR makes sure that the hint that the installer gives you when `/run` doesn't exist actually outputs a literal tab to `/etc/synthetic.conf`. The code before appended the literal string`run\tprivate/var/run` into `/etc/synthetic.conf`, which doesn't work.