### PR TITLE
nixpkgs: Allow functors.

### DIFF
--- a/modules/nix/nixpkgs.nix
+++ b/modules/nix/nixpkgs.nix
@@ -4,10 +4,10 @@ with lib;
 
 let
   isConfig = x:
-    builtins.isAttrs x || builtins.isFunction x;
+    builtins.isAttrs x || lib.isFunction x;
 
   optCall = f: x:
-    if builtins.isFunction f
+    if lib.isFunction f
     then f x
     else f;
 
@@ -41,7 +41,7 @@ let
   overlayType = mkOptionType {
     name = "nixpkgs-overlay";
     description = "nixpkgs overlay";
-    check = builtins.isFunction;
+    check = lib.isFunction;
     merge = lib.mergeOneOption;
   };
 in


### PR DESCRIPTION
Replace builtins.isFunction with lib.isFunction, which allows functors.

#374 

Not sure this is exactly what is required here, I am not 100% on the nixpkgs functor internals.