### PR TITLE
eval-config: Add check parameter for compatibility with nixpkgs.

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -5,6 +5,7 @@
 , inputs
 , baseModules ? import ./modules/module-list.nix
 , specialArgs ? { }
+, check ? true
 }@args:
 
 let


### PR DESCRIPTION
This allows more passthrough parameters in compatibility with nixpkgs. (See #392)