### PR TITLE
fix dependence on apfs.util exit code

### DIFF
--- a/pkgs/darwin-installer/configuration.nix
+++ b/pkgs/darwin-installer/configuration.nix
@@ -43,15 +43,20 @@ with lib;
       case "$i" in
           y|Y)
               if ! grep -q '^run\b' /etc/synthetic.conf 2>/dev/null; then
-                  echo "setting up /etc/synthetic.conf..."
+                  echo "setting up /run via /etc/synthetic.conf..."
                   echo -e "run\tprivate/var/run" | sudo tee -a /etc/synthetic.conf >/dev/null
-                  /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B &>/dev/null \
-                      || /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t &>/dev/null \
-                      || echo "warning: failed to execute apfs.util"
+                  /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B &>/dev/null || true
+                  /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t &>/dev/null || true
+                  if ! test -L /run; then
+                    echo "warning: apfs.util failed to symlink /run"
+                  fi
               fi
               if ! test -L /run; then
                   echo "setting up /run..."
                   sudo ln -sfn private/var/run /run
+              fi
+              if ! test -L /run; then
+                echo "warning: failed to symlink /run"
               fi
               ;;
       esac


### PR DESCRIPTION
apfs.util (or at least it's newer -t flag) has bad exit code semantics
and will return non-zero codes for both success and errors.

Closes #401 and most-likely fixes #378 as well