### PR TITLE
eval-config.nix: Fix args warning

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -8,10 +8,12 @@
 }@args:
 
 let
-  inputsModule = {
+  argsModule = {
     _file = ./eval-config.nix;
     config = {
-      _module.args.inputs = inputs;
+      _module.args = {
+        inherit baseModules inputs modules;
+      };
     };
   };
 
@@ -33,8 +35,7 @@ let
   });
 
   eval = libExtended.evalModules (builtins.removeAttrs args [ "inputs" "system" ] // {
-    modules = modules ++ [ inputsModule pkgsModule ] ++ baseModules;
-    args = { inherit baseModules modules; };
+    modules = modules ++ [ argsModule pkgsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;
   });
 

--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -5,6 +5,17 @@ with lib;
 let
   cfg = config.documentation;
 
+  # To reference the regular configuration from inside the docs evaluation further down.
+  # While not strictly necessary, this extra binding avoids accidental name capture in
+  # the future.
+  regularConfig = config;
+
+  argsModule = {
+    config._module.args = regularConfig._module.args // {
+      modules = [ ];
+    };
+  };
+
   /* For the purpose of generating docs, evaluate options with each derivation
     in `pkgs` (recursively) replaced by a fake with path "\${pkgs.attribute.path}".
     It isn't perfect, but it seems to cover a vast majority of use cases.
@@ -17,8 +28,7 @@ let
     options =
       let
         scrubbedEval = evalModules {
-          modules = baseModules;
-          args = (config._module.args) // { modules = [ ]; };
+          modules = baseModules ++ [ argsModule ];
           specialArgs = { pkgs = scrubDerivations "pkgs" pkgs; };
         };
         scrubDerivations = namePrefix: pkgSet: mapAttrs


### PR DESCRIPTION
Resolves
```
trace: warning: The args argument to evalModules is deprecated. Please set config._module.args instead.
```

`evalModules { args }` and `config._module.args` are equivalent and have been available for years.

Fixes #405