### PR TITLE
defaults: add options for common defaults in the `com.apple.universalaccess` domain

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -21,6 +21,7 @@
   ./system/defaults/SoftwareUpdate.nix
   ./system/defaults/spaces.nix
   ./system/defaults/trackpad.nix
+  ./system/defaults/universalaccess.nix
   ./system/etc.nix
   ./system/keyboard.nix
   ./system/launchd.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -21,21 +21,24 @@ let
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
 
-  NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
-  GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
-  LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
-  dock = defaultsToList "com.apple.dock" cfg.dock;
-  finder = defaultsToList "com.apple.finder" cfg.finder;
+  # defaults
   alf = defaultsToList "/Library/Preferences/com.apple.alf" cfg.alf;
   loginwindow = defaultsToList "/Library/Preferences/com.apple.loginwindow" cfg.loginwindow;
   smb = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.smb.server" cfg.smb;
   SoftwareUpdate = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.SoftwareUpdate" cfg.SoftwareUpdate;
+
+  # userDefaults
+  GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
+  LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
+  NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
+  dock = defaultsToList "com.apple.dock" cfg.dock;
+  finder = defaultsToList "com.apple.finder" cfg.finder;
+  magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
+  magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
   screencapture = defaultsToList "com.apple.screencapture" cfg.screencapture;
   spaces = defaultsToList "com.apple.spaces" cfg.spaces;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
-  magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
-  magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != { }) list);
 in
@@ -60,33 +63,34 @@ in
 
     system.activationScripts.userDefaults.text = mkIfAttrs
       [
-        NSGlobalDomain
         GlobalPreferences
         LaunchServices
+        NSGlobalDomain
         dock
         finder
+        magicmouse
+        magicmouseBluetooth
         screencapture
         spaces
         trackpad
         trackpadBluetooth
-        magicmouse
-        magicmouseBluetooth
       ]
       ''
         # Set defaults
         echo >&2 "user defaults..."
 
         ${concatStringsSep "\n" NSGlobalDomain}
+
         ${concatStringsSep "\n" GlobalPreferences}
         ${concatStringsSep "\n" LaunchServices}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
+        ${concatStringsSep "\n" magicmouse}
+        ${concatStringsSep "\n" magicmouseBluetooth}
         ${concatStringsSep "\n" screencapture}
         ${concatStringsSep "\n" spaces}
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}
-        ${concatStringsSep "\n" magicmouse}
-        ${concatStringsSep "\n" magicmouseBluetooth}
       '';
 
   };

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -37,13 +37,18 @@ let
   magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
   magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
 
-  mkIfAttrs = list: mkIf (any (attrs: attrs != {}) list);
+  mkIfAttrs = list: mkIf (any (attrs: attrs != { }) list);
 in
 
 {
   config = {
 
-    system.activationScripts.defaults.text = mkIfAttrs [ alf loginwindow smb SoftwareUpdate ]
+    system.activationScripts.defaults.text = mkIfAttrs [
+      alf
+      loginwindow
+      smb
+      SoftwareUpdate
+    ]
       ''
         # Set defaults
         echo >&2 "system defaults..."
@@ -54,7 +59,19 @@ in
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
-      [ NSGlobalDomain GlobalPreferences LaunchServices dock finder screencapture spaces trackpad trackpadBluetooth magicmouse magicmouseBluetooth ]
+      [
+        NSGlobalDomain
+        GlobalPreferences
+        LaunchServices
+        dock
+        finder
+        screencapture
+        spaces
+        trackpad
+        trackpadBluetooth
+        magicmouse
+        magicmouseBluetooth
+      ]
       ''
         # Set defaults
         echo >&2 "user defaults..."

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -39,6 +39,7 @@ let
   spaces = defaultsToList "com.apple.spaces" cfg.spaces;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
+  universalaccess = defaultsToList "com.apple.universalaccess" cfg.universalaccess;
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != { }) list);
 in
@@ -74,6 +75,7 @@ in
         spaces
         trackpad
         trackpadBluetooth
+        universalaccess
       ]
       ''
         # Set defaults
@@ -91,6 +93,7 @@ in
         ${concatStringsSep "\n" spaces}
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}
+        ${concatStringsSep "\n" universalaccess}
       '';
 
   };

--- a/modules/system/defaults/universalaccess.nix
+++ b/modules/system/defaults/universalaccess.nix
@@ -1,0 +1,38 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.universalaccess.reduceTransparency = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Disable transparency in the menu bar and elsewhere.
+        Requires macOS Yosemite or later.
+        The default is false.
+      '';
+    };
+
+    system.defaults.universalaccess.closeViewScrollWheelToggle = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Use scroll gesture with the Ctrl (^) modifier key to zoom.
+        The default is false.
+      '';
+    };
+
+    system.defaults.universalaccess.closeViewZoomFollowsFocus = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Follow the keyboard focus while zoomed in.
+        Without setting `closeViewScrollWheelToggle` this has no effect.
+        The default is false.
+      '';
+    };
+
+  };
+}

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -39,6 +39,9 @@
   system.defaults.screencapture.location = "/tmp";
   system.defaults.smb.NetBIOSName = "IMAC-000000";
   system.defaults.smb.ServerDescription = ''Darwin\\\\U2019s iMac'';
+  system.defaults.universalaccess.reduceTransparency = true;
+  system.defaults.universalaccess.closeViewScrollWheelToggle = true;
+  system.defaults.universalaccess.closeViewZoomFollowsFocus = true;
 
   test = ''
     echo >&2 "checking defaults write in /activate"
@@ -82,5 +85,8 @@
     grep "defaults write com.apple.dock 'autohide-delay' -float 0.24" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'orientation' -string 'left'" ${config.out}/activate-user
     grep "defaults write com.apple.screencapture 'location' -string '/tmp'" ${config.out}/activate-user
+    grep "defaults write com.apple.universalaccess 'reduceTransparency' -bool YES" ${config.out}/activate-user
+    grep "defaults write com.apple.universalaccess 'closeViewScrollWheelToggle' -bool YES" ${config.out}/activate-user
+    grep "defaults write com.apple.universalaccess 'closeViewZoomFollowsFocus' -bool YES" ${config.out}/activate-user
   '';
 }


### PR DESCRIPTION
See https://github.com/montchr/dotfield/commit/66b90fc02417bc9a719d354f1c6aad0f1bc0eee6 for successful implementation.

## Added

- Add an option to disable transparency in system UI (especially noticeable in the menu bar).
	- **source:** https://github.com/mathiasbynens/dotfiles/blob/66ba9b3cc0ca1b29f04b8e39f84e5b034fdb24b6/.macos#L28-L29
	- **personal note:** I recently updated to Monterey and found that my menu bar appeared to be light even when I had dark mode enabled. Turns out that turning this setting on "fixes" that behavior.
- Add an option to enable screen zoom while holding the ctrl key and scrolling. Also added the related option for controlling whether the zoomed area will follow the cursor.
	- **source:** https://github.com/mathiasbynens/dotfiles/blob/66ba9b3cc0ca1b29f04b8e39f84e5b034fdb24b6/.macos#L148-L152

## Changed

- Apply formatting to `modules/system/defaults-write.nix` via `nixpkgs-fmt`. The formatting seemed necessary since one of the lists for `mkIfAttrs` was getting quite long and I had to add another value to it.
- Sort some variables alphabetically in `modules/system/defaults-write.nix`.