### PR TITLE
Fix homebrew.brewPrefix default value on Apple Silicon

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -54,7 +54,7 @@ in
 
     brewPrefix = mkOption {
       type = types.str;
-      default = if pkgs.stdenv.hostPlatform.darwinArch == "aarch64" then "/opt/homebrew/bin" else "/usr/local/bin";
+      default = if pkgs.stdenv.hostPlatform.isAarch64 then "/opt/homebrew/bin" else "/usr/local/bin";
       description = ''
         Customize path prefix where executable of <command>brew</command> is searched for.
       '';


### PR DESCRIPTION
Turns out that #418, has a small bug:`pkgs.stdenv.hostPlatform.darwinArch` returns `"arm64"` on `aarch64-darwin` systems not `"aarch64"`.

Instead of changing to code to check whether the value is `"arm64"`, I've changed the predicate to use `pkgs.stdenv.hostPlatform.isAarch64`.

I've tested on my own system and this works properly for both Intel and Apple Silicon Macs now.