### PR TITLE
Add top-level `lib` option based on NixOS

### DIFF
--- a/modules/misc/lib.nix
+++ b/modules/misc/lib.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+
+{
+  options = {
+    lib = lib.mkOption {
+      default = { };
+
+      type = lib.types.attrsOf lib.types.attrs;
+
+      description = ''
+        This option allows modules to define helper functions, constants, etc.
+      '';
+    };
+  };
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -1,6 +1,7 @@
 [
   ./alias.nix
   ./documentation
+  ./misc/lib.nix
   ./security/pki
   ./security/sandbox
   ./system


### PR DESCRIPTION
I'm working on https://github.com/divnix/digga/pull/438. The project expects a top level `lib` option in system configuration, which is declared in NixOS, but not in nix-darwin.

https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/misc/lib.nix

Description from the option declaration:

> This option allows modules to define helper functions, constants, etc.