### PR TITLE
Don't reset experimental features

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -112,7 +112,7 @@ done
 
 if [ -z "$action" ]; then showSyntax; fi
 
-flakeFlags=(--experimental-features 'nix-command flakes')
+flakeFlags=(--extra-experimental-features 'nix-command flakes')
 
 if [ -n "$flake" ]; then
     if [[ $flake =~ ^(.*)\#([^\#\"]*)$ ]]; then


### PR DESCRIPTION
A similar change was made in nixpkgs which prevented content addressing being used.

https://github.com/NixOS/nix/issues/4784#issuecomment-841824085
https://github.com/NixOS/nixpkgs/pull/123246