### PR TITLE
eval-config: Support passing in `pkgs`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,5 @@
       system = "x86_64-darwin";
       modules = [ self.darwinModules.simple ];
     }).system;
-
   };
 }

--- a/modules/nix/nixpkgs.nix
+++ b/modules/nix/nixpkgs.nix
@@ -109,7 +109,7 @@ in
 
   config = {
 
-    # _module.args.pkgs is defined in ../../default.nix
+    # _module.args.pkgs is defined in ../../eval-config.nix
 
   };
 }


### PR DESCRIPTION
This is useful for flake users as they will usually already have an
instantiated Nixpkgs e.g.

    let
      pkgs = import nixpkgs {
        config.allowUnfree = true;
        overlays = [ ... ];
      }
    in darwin.lib.darwinSystem {
      inherit pkgs;
    }

This change makes `nix-darwin` match the behaviour of NixOS and
`home-manager`.