### PR TITLE
Use literalExpression instead of literalExample in cachix-agent

### DIFF
--- a/modules/services/cachix-agent.nix
+++ b/modules/services/cachix-agent.nix
@@ -30,7 +30,7 @@ in {
       '';
       type = types.package;
       default = pkgs.cachix;
-      defaultText = literalExample "pkgs.cachix";
+      defaultText = literalExpression "pkgs.cachix";
     };
 
     credentialsFile = mkOption {


### PR DESCRIPTION
Because nixpkgs warns `literalExample has been deprecated, please use literalExpression instead`

## Related
- https://github.com/LnL7/nix-darwin/pull/438
- https://github.com/LnL7/nix-darwin/issues/367