### PR TITLE
cachix-agent: literalExample -> literalExpression

### DIFF
--- a/modules/services/cachix-agent.nix
+++ b/modules/services/cachix-agent.nix
@@ -30,7 +30,7 @@ in {
       '';
       type = types.package;
       default = pkgs.cachix;
-      defaultText = literalExample "pkgs.cachix";
+      defaultText = literalExpression "pkgs.cachix";
     };
 
     credentialsFile = mkOption {


### PR DESCRIPTION
Fixes a scary red deprecation notice.