### PR TITLE
Add additional options to configure Finder

### DIFF
--- a/modules/system/defaults/finder.nix
+++ b/modules/system/defaults/finder.nix
@@ -5,6 +5,14 @@ with lib;
 {
   options = {
 
+    system.defaults.finder.AppleShowAllFiles = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to always show hidden files. The default is false.
+      '';
+    };
+
     system.defaults.finder.AppleShowAllExtensions = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/modules/system/defaults/finder.nix
+++ b/modules/system/defaults/finder.nix
@@ -13,6 +13,41 @@ with lib;
       '';
     };
 
+    system.defaults.finder.ShowStatusBar = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show status bar at bottom of finder windows with item/disk space stats. The default is false.
+      '';
+    };
+
+    system.defaults.finder.ShowPathbar = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show path breadcrumbs in finder windows. The default is false.
+      '';
+    };
+
+    system.defaults.finder.FXDefaultSearchScope = mkOption {
+      type = types.nullOr types.string;
+      default = null;
+      description = ''
+        Change the default search scope. Use "SCcf" to default to current folder.
+        The default is unset ("This Mac").
+      '';
+    };
+
+    system.defaults.finder.FXPreferredViewStyle = mkOption {
+      type = types.nullOr types.string;
+      default = "Nlsv";
+      description = ''
+        Change the default finder view.
+        "icnv" = Icon view, "Nlsv" = List view, "clmv" = Column View, "Flwv" = Gallery View
+        The default is icnv.
+      '';
+    };
+
     system.defaults.finder.AppleShowAllExtensions = mkOption {
       type = types.nullOr types.bool;
       default = null;


### PR DESCRIPTION
These additional `defaults write com.apple.finder *` options were part of my osx-setup script that I'm porting to nix. These options:
- control whether Finder shows hidden files like `~/.zhsrc`
- control whether to show a bottom status bar (https://snipboard.io/S1agOv.jpg)
- control whether to show UI for path breadcrumbs (https://snipboard.io/Hs2W3M.jpg)
- control the default search scope when searching inside finder
- control the default view style (icons, list, columns, ...) 