### PR TITLE
add option to show hidden files everywhere

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -15,6 +15,14 @@ let
 in {
   options = {
 
+    system.defaults.NSGlobalDomain.AppleShowAllFiles = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to always show hidden files. The default is false.
+      '';
+    };
+
     system.defaults.NSGlobalDomain.AppleEnableMouseSwipeNavigateWithScrolls = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -1,6 +1,7 @@
 { config, pkgs, ... }:
 
 {
+  system.defaults.NSGlobalDomain.AppleShowAllFiles = true;
   system.defaults.NSGlobalDomain.AppleEnableMouseSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleEnableSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleFontSmoothing = 1;
@@ -49,6 +50,7 @@
     grep "defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server 'ServerDescription' -string 'Darwin.*s iMac'" ${config.out}/activate
 
     echo >&2 "checking defaults write in /activate-user"
+    grep "defaults write -g 'AppleShowAllFiles' -bool YES" ${config.out}/activate-user
     grep "defaults write -g 'AppleEnableMouseSwipeNavigateWithScrolls' -bool NO" ${config.out}/activate-user
     grep "defaults write -g 'AppleEnableSwipeNavigateWithScrolls' -bool NO" ${config.out}/activate-user
     grep "defaults write -g 'AppleFontSmoothing' -int 1" ${config.out}/activate-user


### PR DESCRIPTION
This global option shows hidden files everywhere (including open/save/print dialogs). The option introduced in #445 only shows it in the Main finder window.