### PR TITLE
add options for configuring activity monitor

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -22,6 +22,7 @@
   ./system/defaults/spaces.nix
   ./system/defaults/trackpad.nix
   ./system/defaults/universalaccess.nix
+  ./system/defaults/ActivityMonitor.nix
   ./system/etc.nix
   ./system/keyboard.nix
   ./system/launchd.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -40,6 +40,7 @@ let
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
   universalaccess = defaultsToList "com.apple.universalaccess" cfg.universalaccess;
+  ActivityMonitor = defaultsToList "com.apple.ActivityMonitor" cfg.ActivityMonitor;
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != { }) list);
 in
@@ -76,6 +77,7 @@ in
         trackpad
         trackpadBluetooth
         universalaccess
+        ActivityMonitor
       ]
       ''
         # Set defaults
@@ -94,6 +96,7 @@ in
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}
         ${concatStringsSep "\n" universalaccess}
+        ${concatStringsSep "\n" ActivityMonitor}
       '';
 
   };

--- a/modules/system/defaults/ActivityMonitor.nix
+++ b/modules/system/defaults/ActivityMonitor.nix
@@ -1,0 +1,63 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.ActivityMonitor.ShowCategory = mkOption {
+      type = types.nullOr (types.enum [100 101 102 103 104 105 106 107]);
+      default = 100;
+      description = ''
+          Change which processes to show.
+            100: All Processes
+            101: All Processes, Hierarchally
+            102: My Processes
+            103: System Processes
+            104: Other User Processes
+            105: Active Processes
+            106: Inactive Processes
+            107: Windowed Processes
+          Default is 100.
+        '';
+    };
+
+    system.defaults.ActivityMonitor.IconType = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+          Change the icon in the dock when running.
+            0: Application Icon
+            2: Network Usage
+            3: Disk Activity
+            5: CPU Usage
+            6: CPU History
+          Default is null.
+        '';
+    };
+
+    system.defaults.ActivityMonitor.SortColumn = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+          Which column to sort the main activity page (such as "CPUUsage"). Default is null.
+        '';
+    };
+
+    system.defaults.ActivityMonitor.SortDirection = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+          The sort direction of the sort column (0 is decending). Default is null.
+        '';
+    };
+
+    system.defaults.ActivityMonitor.OpenMainWindow = mkOption {
+      type = types.nullOr types.bool;
+      default = true;
+      description = ''
+          Open the main window when opening Activity Monitor. Default is true.
+        '';
+    };
+  };
+}

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -42,6 +42,11 @@
   system.defaults.universalaccess.reduceTransparency = true;
   system.defaults.universalaccess.closeViewScrollWheelToggle = true;
   system.defaults.universalaccess.closeViewZoomFollowsFocus = true;
+  system.defaults.ActivityMonitor.ShowCategory = 103;
+  system.defaults.ActivityMonitor.IconType = 3;
+  system.defaults.ActivityMonitor.SortColumn = "CPUUsage";
+  system.defaults.ActivityMonitor.SortDirection = 0;
+  system.defaults.ActivityMonitor.OpenMainWindow = true;
 
   test = ''
     echo >&2 "checking defaults write in /activate"
@@ -88,5 +93,10 @@
     grep "defaults write com.apple.universalaccess 'reduceTransparency' -bool YES" ${config.out}/activate-user
     grep "defaults write com.apple.universalaccess 'closeViewScrollWheelToggle' -bool YES" ${config.out}/activate-user
     grep "defaults write com.apple.universalaccess 'closeViewZoomFollowsFocus' -bool YES" ${config.out}/activate-user
+    grep "defaults write com.apple.ActivityMonitor 'ShowCategory' -int 103" ${config.out}/activate-user
+    grep "defaults write com.apple.ActivityMonitor 'IconType' -int 3" ${config.out}/activate-user
+    grep "defaults write com.apple.ActivityMonitor 'SortColumn' -string 'CPUUsage'" ${config.out}/activate-user
+    grep "defaults write com.apple.ActivityMonitor 'SortDirection' -int 0" ${config.out}/activate-user
+    grep "defaults write com.apple.ActivityMonitor 'OpenMainWindow' -bool YES" ${config.out}/activate-user
   '';
 }


### PR DESCRIPTION
This PR enables nix-darwin to configure some activity monitor functionality. These options were part of my osx-setup script that I'm porting to nix and mostly taken from https://github.com/joeyhoer/starter/blob/master/apps/activity-monitor.sh.  

Specifically these options enable:
- Configuring which processes to show in the main CPU view
- Configuring the dock icon.
- Configuring the sort column and order of the main window. 

