### PR TITLE
fix: move fpath autocomplete setup from zshrc to zshenv

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -121,6 +121,11 @@ in
         . ${config.system.build.setEnvironment}
       fi
 
+      # Tell zsh how to find installed completions
+      for p in ''${(z)NIX_PROFILES}; do
+        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
+      done
+
       ${cfg.shellInit}
 
       # Read system-wide modifications.
@@ -167,11 +172,6 @@ in
 
       ${config.environment.interactiveShellInit}
       ${cfg.interactiveShellInit}
-
-      # Tell zsh how to find installed completions
-      for p in ''${(z)NIX_PROFILES}; do
-        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
-      done
 
       ${cfg.promptInit}
 


### PR DESCRIPTION
This moves the code for setting up `fpath` for zsh's autocomplete from /etc/zshrc to /etc/zshenv, which keeps compatibility with NixOS.

I got very confused why my setup had autocomplete on NixOS but not on Darwin despite sharing most of the same Nix code. It turns out that I had `setopt no_global_rcs` in my `~/.zshenv` because I didn't want the default NixOS prompt, and in this prevented autocomplete in nix-darwin due to the fact that the autocomplete-fpath code was in /etc/zshrc, not /etc/zshenv. I think it makes more sense to put the autocomplete-fpath code in /etc/zshenv, since it's expected of practically all shell sessions, and needs to be manually enabled with `compinit` anyway.