### PR TITLE
Add workflow to auto-update manual

### DIFF
--- a/.github/workflows/update-manual.yml
+++ b/.github/workflows/update-manual.yml
@@ -1,0 +1,39 @@
+name: Update manual
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '**.nix'
+
+jobs:
+  update-manual:
+    runs-on: macos-10.15
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        # So that we fetch all branches, since we need to checkout the `gh-pages` branch later.
+        fetch-depth: 0
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v16
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build manual
+      run: |
+        nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.11-darwin -I darwin=. -A manualHTML
+
+    - name: Push update to manual
+      run: |
+        git checkout gh-pages
+        rm -rf manual
+        cp -R result/share/doc/darwin manual
+        rm result
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add --all
+        git commit -m "Update manual"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+result*


### PR DESCRIPTION
The current `nix-darwin` manual available online hasn't been updated in about 2 years.

This PR adds a GitHub workflow that will automatically update the manual whenever changes to `.nix` files hit `master`.

I tested this on my fork of `nix-darwin`, and it seems to be working properly:
https://malob.github.io/nix-darwin/manual/index.html

For example, you'll notice that the options for the `homebrew` module are now included.

(Closes #436)