### PR TITLE
fix: incorrect default for FXPreferredViewStyle

### DIFF
--- a/modules/system/defaults/finder.nix
+++ b/modules/system/defaults/finder.nix
@@ -40,7 +40,7 @@ with lib;
 
     system.defaults.finder.FXPreferredViewStyle = mkOption {
       type = types.nullOr types.string;
-      default = "Nlsv";
+      default = null;
       description = ''
         Change the default finder view.
         "icnv" = Icon view, "Nlsv" = List view, "clmv" = Column View, "Flwv" = Gallery View


### PR DESCRIPTION
The default value seems to have been set by mistake. The default value should probably be `null` for anything under `system.defaults`, and the current value contradicts the option description.
