### PR TITLE
add mouse scaling system setting

### DIFF
--- a/modules/system/defaults/GlobalPreferences.nix
+++ b/modules/system/defaults/GlobalPreferences.nix
@@ -2,7 +2,17 @@
 
 with lib;
 
-{
+let
+  isFloat = x: isString x && builtins.match "^[+-]?([0-9]*[.])?[0-9]+$" x != null;
+
+  float = mkOptionType {
+    name = "float";
+    description = "float";
+    check = isFloat;
+    merge = options.mergeOneOption;
+  };
+
+in {
   options = {
 
     system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" =
@@ -16,5 +26,14 @@ with lib;
         '';
       };
 
+    system.defaults.".GlobalPreferences"."com.apple.mouse.scaling" =
+      mkOption {
+        type = types.nullOr float;
+        default = null;
+        description = ''
+          Sets the mouse tracking speed. Found in the "Mouse" section of
+          "System Preferences". Set to -1 to disable mouse acceleration.
+        '';
+      };
   };
 }


### PR DESCRIPTION
Adds support for the `com.apple.mouse.scaling` GlobalPreferences setting. This is [useful for disabling mouse acceleration](https://devhints.io/macos-mouse-acceleration).