### PR TITLE
Fix synthetic.conf instructions

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -27,9 +27,9 @@ let
         echo "Create a symlink to /var/run with:" >&2
         if test -e /etc/synthetic.conf; then
             echo >&2
-            echo "$ echo 'run\tprivate/var/run' | sudo tee -a /etc/synthetic.conf" >&2
-            echo "$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B" >&2
-            echo "$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t" >&2
+            echo "$ printf 'run\tprivate/var/run\n' | sudo tee -a /etc/synthetic.conf" >&2
+            echo "$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B # For Catalina" >&2
+            echo "$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t # For Big Sur and later" >&2
             echo >&2
             echo "The current contents of /etc/synthetic.conf is:" >&2
             echo >&2


### PR DESCRIPTION
Closes #451? Waiting to hear back from the OP there, but I think this should resolve it; it did for me.

This PR adds comments to the two `apfs.util` commands to explain on which versions of MacOS each should be used. This should clear up some confusion. Also, I switched the command for adding the necessary line to synthetic.conf to use printf instead because on any shell other than zsh, echo is not a builtin, and `echo '...\t...'` doesn't expand the `\t`, so we end up with a literal `\t` in synthetic.conf.