### PR TITLE
feat: add serviceConfig.LaunchEvents configuration option

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -708,6 +708,31 @@ with lib;
       });
     };
 
+    LaunchEvents = mkOption {
+      type = types.nullOr (types.attrs);
+      default = null;
+      description = ''
+        Specifies higher-level event types to be used as launch-on-demand event
+        sources.  Each sub-dictionary defines events for a particular event
+        subsystem, such as "com.apple.iokit.match-ing", which can be used to
+        launch jobs based on the appearance of nodes in the IORegistry. Each
+        dictionary within the sub-dictionary specifies an event descriptor that
+        is specified to each event subsystem. With this key, the job promises to
+        use the xpc_set_event_stream_handler(3) API to consume events. See
+        xpc_events(3) for more details on event sources.
+      '';
+      example = {
+        "com.apple.iokit.matching" = {
+          "com.apple.usb.device" = {
+            IOMatchLaunchStream = true;
+            IOProviderClass = "IOUSBDevice";
+            idProduct = "*";
+            idVendor = "*";
+          };
+        };
+      };
+    };
+
     Sockets = mkOption {
       default = null;
       description = ''


### PR DESCRIPTION
This is required if you want to register an "xpc event stream handler". Check out the README for https://github.com/snosrap/xpc_set_event_stream_handler for more info.

I also did this in https://github.com/LnL7/nix-darwin/pull/210 before giving up and making it a local module. This is the only part that has to be upstreamed and I don't want to keep rebasing 😛 so if it's OK, please let me add this!