### PR TITLE
fonts: rename `fonts.enableFontDir` to `fonts.fontDir.enable` in line with NixOS

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -7,8 +7,12 @@ let
 in
 
 {
+  imports = [
+    (mkRenamedOptionModule [ "fonts" "enableFontDir" ] [ "fonts" "fontDir" "enable" ])
+  ];
+
   options = {
-    fonts.enableFontDir = mkOption {
+    fonts.fontDir.enable = mkOption {
       default = false;
       description = ''
         Whether to enable font management and install configured fonts to


### PR DESCRIPTION
since 21.05 beta:

https://github.com/NixOS/nixpkgs/blob/e22337c8707f42e21938dc729643fa8904d33aeb/nixos/modules/config/fonts/fontdir.nix#L64

https://github.com/NixOS/nixpkgs/commit/c99bd9bedf7291390c28eddb31f8ed2aeec8ea7f