### PR TITLE
fonts: replace remaining reference to `enableFontDir`

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -43,7 +43,7 @@ in
         done
       '';
 
-    system.activationScripts.fonts.text = optionalString cfg.enableFontDir ''
+    system.activationScripts.fonts.text = optionalString cfg.fontDir.enable ''
       # Set up fonts.
       echo "configuring fonts..." >&2
       find -L "$systemConfig/Library/Fonts" -type f -print0 | while IFS= read -rd "" l; do


### PR DESCRIPTION
see https://github.com/LnL7/nix-darwin/pull/456#issuecomment-1105472886

props to @jared-w for spotting my mistake