### PR TITLE
Disable taking control of ~/Applications folder MkII

### DIFF
--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -24,12 +24,12 @@ in
       # Set up applications.
       echo "setting up ~/Applications..." >&2
 
-      if [ ! -e ~/Applications -o -L ~/Applications ]; then
-        ln -sfn ${cfg.build.applications}/Applications ~/Applications
-      elif [ ! -e ~/Applications/Nix\ Apps -o -L ~/Applications/Nix\ Apps ]; then
+      mkdir -p ~/Applications
+
+      if [ ! -e ~/Applications/Nix\ Apps -o -L ~/Applications/Nix\ Apps ]; then
         ln -sfn ${cfg.build.applications}/Applications ~/Applications/Nix\ Apps
       else
-        echo "warning: ~/Applications and ~/Applications/Nix Apps are directories, skipping App linking..." >&2
+        echo "warning: ~/Applications/Nix Apps is not owned by nix-darwin, skipping App linking..." >&2
       fi
     '';
 

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -24,20 +24,21 @@ in
       # Set up applications.
       echo "setting up /Applications/Nix Apps..." >&2
 
+      ourLink () {
+        local link
+        link=$(readlink "$1")
+        [ -L "$1" ] && [ "''${link#*-}" = 'system-applications/Applications' ]
+      }
+
       # Clean up for links created at the old location in HOME
-      if [ -L ~/Applications
-           -a $(readlink ~/Applications | grep --quiet
-                 '/nix/store/.*-system-applications/Applications')
-         ]
+      if ourLink ~/Applications; then
         rm ~/Applications
-      elif [ -L '~/Applications/Nix Apps'
-             -a $(readlink '~/Applications/Nix Apps' | grep --quiet
-                   '/nix/store/.*-system-applications/Applications')
-           ]
-        rm '~/Applications/Nix Apps'
+      elif ourLink ~/Applications/'Nix Apps'; then
+        rm ~/Applications/'Nix Apps'
       fi
 
-      if [ ! -e '/Applications/Nix Apps' -o -L '/Applications/Nix Apps' ]; then
+      if [ ! -e '/Applications/Nix Apps' ] \
+         || ourLink '/Applications/Nix Apps'; then
         ln -sfn ${cfg.build.applications}/Applications '/Applications/Nix Apps'
       else
         echo "warning: /Applications/Nix Apps is not owned by nix-darwin, skipping App linking..." >&2

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -22,14 +22,25 @@ in
 
     system.activationScripts.applications.text = ''
       # Set up applications.
-      echo "setting up ~/Applications..." >&2
+      echo "setting up /Applications/Nix Apps..." >&2
 
-      mkdir -p ~/Applications
+      # Clean up for links created at the old location in HOME
+      if [ -L ~/Applications
+           -a $(readlink ~/Applications | grep --quiet
+                 '/nix/store/.*-system-applications/Applications')
+         ]
+        rm ~/Applications
+      elif [ -L '~/Applications/Nix Apps'
+             -a $(readlink '~/Applications/Nix Apps' | grep --quiet
+                   '/nix/store/.*-system-applications/Applications')
+           ]
+        rm '~/Applications/Nix Apps'
+      fi
 
-      if [ ! -e ~/Applications/Nix\ Apps -o -L ~/Applications/Nix\ Apps ]; then
-        ln -sfn ${cfg.build.applications}/Applications ~/Applications/Nix\ Apps
+      if [ ! -e '/Applications/Nix Apps' -o -L '/Applications/Nix Apps' ]; then
+        ln -sfn ${cfg.build.applications}/Applications '/Applications/Nix Apps'
       else
-        echo "warning: ~/Applications/Nix Apps is not owned by nix-darwin, skipping App linking..." >&2
+        echo "warning: /Applications/Nix Apps is not owned by nix-darwin, skipping App linking..." >&2
       fi
     '';
 


### PR DESCRIPTION
This PR supercedes #226.

So far application bundles were always linked to `~/Applications` or
`~/Applications/Nix Apps` if the former was an existing directory.

In nix-community/home-manager#1341 a conflict was found with suggested
new Home Manager behavior, where applications installed through Home
Manager would end up in `~/Applications/Home Manager Apps`. This was in
an attempt to make them discoverable through Spotlight but further
investigation suggest Spotlight does not pick up symlinked apps (details
in the issue).

However, there are other programs that expect to be able to write to
`~/Applications` so taking over the directory is unfortunate.

PR #226 dropped linking `~/Applications` and instead made sure the
directory exists so we can always link in `~/Applications/Nix Apps`.

After further discussion in #macos:nixos.org we came to the conclusion
that we shouldn't link applications to a user directory at all. Since we
manage packages for multiple users, application bundles should go in
`/Applications`.

Because previous code will likely leave a symlink at
`~/Applications/{,Nix Apps}`, which will become dangling once the path
it links to is garbage collected from the store we test to see if a link
exists and it conforms to the path we're expecting and if it does remove
it.

**Note**: This is a draft because I haven't had time to test it.
