### PR TITLE
add escape to shell aliases

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -9,7 +9,8 @@ let
     mapAttrsToList (n: v: ''export ${n}="${v}"'') cfg.variables;
 
   aliasCommands =
-    mapAttrsFlatten (n: v: ''alias ${n}="${v}"'') cfg.shellAliases;
+    mapAttrsFlatten (n: v: ''alias ${n}=${escapeShellArg v}'')
+      (filterAttrs (k: v: v != null) cfg.shellAliases);
 
   makeDrvBinPath = concatMapStringsSep ":" (p: if isDerivation p then "${p}/bin" else p);
 in

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -9,7 +9,8 @@ let
   cfg = config.programs.fish;
 
   fishAliases = concatStringsSep "\n" (
-    mapAttrsFlatten (k: v: "alias ${k} '${v}'") cfg.shellAliases
+    mapAttrsFlatten (k: v: "alias ${k} ${escapeShellArg v}")
+      (filterAttrs (k: v: v != null) cfg.shellAliases)
   );
 
   envShellInit = pkgs.writeText "shellInit" cfge.shellInit;

--- a/tests/programs-zsh.nix
+++ b/tests/programs-zsh.nix
@@ -43,6 +43,6 @@
      echo >&2 "checking zsh variables in /etc/zprofile"
      grep 'FOO="42"' ${config.out}/etc/zprofile
      echo >&2 "checking shell aliases in /etc/zprofile"
-     grep 'alias ls="ls -G"' ${config.out}/etc/zprofile
+     grep "alias ls='ls -G'" ${config.out}/etc/zprofile
    '';
 }


### PR DESCRIPTION
Aliases should be escaped.

I only ran into problem with aliases. Is there anything else that should be escaped?🤔