### PR TITLE
Link /Applications to ~/Applications/Nix\ Darwin

### DIFF
--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -23,14 +23,15 @@ in
     system.activationScripts.applications.text = ''
       # Set up applications.
       echo "setting up ~/Applications..." >&2
+      mkdir -p ~/Applications
 
-      if [ ! -e ~/Applications -o -L ~/Applications ]; then
-        ln -sfn ${cfg.build.applications}/Applications ~/Applications
-      elif [ ! -e ~/Applications/Nix\ Apps -o -L ~/Applications/Nix\ Apps ]; then
-        ln -sfn ${cfg.build.applications}/Applications ~/Applications/Nix\ Apps
-      else
-        echo "warning: ~/Applications and ~/Applications/Nix Apps are directories, skipping App linking..." >&2
+      nix_apps=~/Applications/Nix\ Darwin
+      if [ -d  "$nix_apps" ]; then
+        # If there's already a folder, delete it in order to create a symlink
+        rm -rf "$nix_apps"
       fi
+
+      ln -sfn ${cfg.build.applications}/Applications "$nix_apps"
     '';
 
   };

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -31,7 +31,7 @@ in
       nix_apps=~/Applications/Nix\ Apps
       if [ -d  "$nix_apps" ]; then
         # If there's already a folder, delete it in order to create a symlink
-        rm -rf "$nix_apps"
+        sudo rm -rf "$nix_apps"
       fi
 
       ln -sfn ${cfg.build.applications}/Applications "$nix_apps"

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -25,9 +25,6 @@ in
       echo "setting up ~/Applications..." >&2
       mkdir -p ~/Applications
 
-      echo "TODO: REMOVE THIS"
-      ls -la ~/Applications
-
       nix_apps=~/Applications/Nix\ Apps
       if [ -d  "$nix_apps" ]; then
         # If there's already a folder, delete it in order to create a symlink

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -25,7 +25,7 @@ in
       echo "setting up ~/Applications..." >&2
       mkdir -p ~/Applications
 
-      nix_apps=~/Applications/Nix\ Darwin
+      nix_apps=~/Applications/Nix\ Apps
       if [ -d  "$nix_apps" ]; then
         # If there's already a folder, delete it in order to create a symlink
         rm -rf "$nix_apps"

--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -25,6 +25,9 @@ in
       echo "setting up ~/Applications..." >&2
       mkdir -p ~/Applications
 
+      echo "TODO: REMOVE THIS"
+      ls -la ~/Applications
+
       nix_apps=~/Applications/Nix\ Apps
       if [ -d  "$nix_apps" ]; then
         # If there's already a folder, delete it in order to create a symlink

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -14,9 +14,7 @@ with lib;
   launchd.user.agents = mkForce {};
 
   system.activationScripts.postUserActivation.text = mkAfter ''
-    if test -L ~/Applications; then
-        rm ~/Applications
-    elif test -L ~/Applications/Nix\ Apps; then
+    if test -L ~/Applications/Nix\ Apps; then
         rm ~/Applications/Nix\ Apps
     fi
 

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     echo >&2
     echo >&2 "Uninstalling nix-darwin, this will:"
     echo >&2
-    echo >&2 "    - remove ~/Applications link."
+    echo >&2 "    - remove ~/Applications/Nix\ Apps link."
     echo >&2 "    - cleanup static /etc files."
     echo >&2 "    - disable and remove all launchd services managed by nix-darwin."
     echo >&2 "    - restore daemon service from nix installer (only when this is a multi-user install)."


### PR DESCRIPTION
Step 1: try to resolve conflicts between nix-darwin and home-manager regarding linking in ~/Applications.
Currently, [home-manager has disabled linking to ~/Applications](https://github.com/nix-community/home-manager/blob/db00b39a9abec04245486a01b236b8d9734c9ad0/modules/targets/darwin/linkapps.nix) because nix-darwin is behaving inconsistently and sometimes creating a race:
- If there's no ~/Applications folder on the system, nix-darwin will symlink it's apps directly to ~/Applications. This is bad because home-manager can't symlink under ~/Applications/Home Manager Apps
- If there is ~/Applications folder already on the system, nix-darwin will symlink into ~/Applications/Nix Apps.

This PR ensures that there's an ~/Applications folder, and always uses ~/Applications/Nix Apps for symlinks.

Related issue: https://github.com/nix-community/home-manager/issues/1341