### PR TITLE
fix zsh eating output without new line ending

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -54,7 +54,7 @@ in
 
     programs.zsh.promptInit = mkOption {
       type = types.lines;
-      default = "autoload -U promptinit && promptinit && prompt walters";
+      default = "autoload -U promptinit && promptinit && prompt walters && setopt prompt_sp";
       description = lib.mdDoc "Shell script code used to initialise the zsh prompt.";
     };
 


### PR DESCRIPTION
caught the issue described in here https://github.com/NixOS/nixpkgs/issues/30121 and feeling it is worth to patch a fix here. 

basically the issues is that when you run a command with output missing the new line ending, it will not be displayed.

```
root@nixos> echo -n "abc\ndef"
abc
```

something like this ☝️ 