### PR TITLE
[github] Use macos-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v9
+    - uses: cachix/install-nix-action@v17
     - run: |
         nix build ${{ github.event.client_payload.args }} -vL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
         - build
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v9

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -10,7 +10,7 @@ on:
         - debug
 jobs:
   debug:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v15

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v17
     - run: |
         nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
         nix-channel --update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
 jobs:
   tests:
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
@@ -13,7 +13,7 @@ jobs:
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.05-darwin -I darwin=. -A manpages
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.05-darwin -I darwin=. -A examples.simple
   install:
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       with:
         limit-access-to-actor: true
   install-flake:
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,18 +8,18 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v15
-    - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.05-darwin -I darwin=. -A tests
-    - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.05-darwin -I darwin=. -A manpages
-    - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.05-darwin -I darwin=. -A examples.simple
+    - uses: cachix/install-nix-action@v17
+    - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-22.05-darwin -I darwin=. -A tests
+    - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-22.05-darwin -I darwin=. -A manpages
+    - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-22.05-darwin -I darwin=. -A examples.simple
   install:
     runs-on: macos-12
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v17
     - run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-21.05-darwin nixpkgs
+        nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
         nix-channel --update
     - run: |
         export NIX_PATH=$HOME/.nix-defexpr/channels
@@ -45,9 +45,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v17
       with:
-         install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210207_fd6eaa1/install
+         install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.10.0pre20220808_73fde9e/install
          extra_nix_config: |
            experimental-features = nix-command flakes
            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-manual.yml
+++ b/.github/workflows/update-manual.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-manual:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/update-manual.yml
+++ b/.github/workflows/update-manual.yml
@@ -17,14 +17,14 @@ jobs:
         fetch-depth: 0
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
     - name: Build manual
       run: |
-        nix-build ./release.nix -I nixpkgs=channel:nixpkgs-21.11-darwin -I darwin=. -A manualHTML
+        nix-build ./release.nix -I nixpkgs=channel:nixpkgs-22.05-darwin -I darwin=. -A manualHTML
 
     - name: Push update to manual
       run: |


### PR DESCRIPTION
It might be beneficial to set up a matrix ([docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-multi-dimension-matrix)) and run all major supported macOS versions in parallel.

Reason: macos-10.15 is [being deprecated](https://github.com/actions/runner-images/issues/5583) and will be fully unsupported by Aug 30 2022.