### PR TITLE
Fix nix-rebuild --flake without XCode command line tools

### DIFF
--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -5,7 +5,7 @@ with lib;
 let
   inherit (pkgs) stdenv;
 
-  extraPath = lib.makeBinPath [ config.nix.package pkgs.coreutils pkgs.jq ];
+  extraPath = lib.makeBinPath [ config.nix.package pkgs.coreutils pkgs.jq pkgs.git ];
 
   writeProgram = name: env: src:
     pkgs.substituteAll ({


### PR DESCRIPTION
Fix #387. Add nixpkgs `git` to `PATH` before `/usr/bin/git` so that when `nix flake metadata` invokes git, it does not invoke the one that complains with xcode-select.

When I run `set -x; source ./result/sw/bin/darwin-rebuild switch --flake '.#myhost'`, I see that darwin-rebuild sets `PATH=/nix/store/nnn-nix:…:/usr/bin:/nix/store/nnn-git/bin:….` before running `nix --extra-experimental-features 'nix-command flakes' flake metadata --json -- .` This results in the error

```
error: getting the HEAD of the Git tree '/Users/yonran/Documents/nixdesktop' failed with exit code 1:
       xcode-select: note: no developer tools were found at '/Applications/Xcode.app', requesting install. Choose an option in the dialog to download the command line developer tools.
```

This commit puts git in `extraPath`, which is before /usr/bin.