### PR TITLE
feat: provide option to display the appswitcher on all displays

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -15,6 +15,14 @@ let
 in {
   options = {
 
+    system.defaults.dock.appswitcher-all-displays = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to display the appswitcher on all displays or only the main one. The default is false.
+      '';
+    };
+
     system.defaults.dock.autohide = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -36,6 +36,7 @@
   system.defaults.NSGlobalDomain."com.apple.springing.delay" = "0.0";
   system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" = true;
   system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" = "/System/Library/Sounds/Funk.aiff";
+  system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = "0.24";
   system.defaults.dock.orientation = "left";
   system.defaults.screencapture.location = "/tmp";
@@ -92,6 +93,7 @@
     grep "defaults write -g 'com.apple.swipescrolldirection' -bool YES" ${config.out}/activate-user
     grep "defaults write .GlobalPreferences 'com.apple.sound.beep.sound' -string '/System/Library/Sounds/Funk.aiff'" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'autohide-delay' -float 0.24" ${config.out}/activate-user
+    grep "defaults write com.apple.dock 'appswitcher-all-displays' -bool NO" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'orientation' -string 'left'" ${config.out}/activate-user
     grep "defaults write com.apple.screencapture 'location' -string '/tmp'" ${config.out}/activate-user
     grep "defaults write com.apple.universalaccess 'reduceTransparency' -bool YES" ${config.out}/activate-user


### PR DESCRIPTION
add an option to make the appswitcher being displayed on all available monitors