### PR TITLE
Fix copypasta in simple example

### DIFF
--- a/modules/examples/simple.nix
+++ b/modules/examples/simple.nix
@@ -15,7 +15,7 @@
   # services.nix-daemon.enable = true;
   # nix.package = pkgs.nix;
 
-  # Create /etc/bashrc that loads the nix-darwin environment.
+  # Create /etc/zshrc that loads the nix-darwin environment.
   programs.zsh.enable = true;  # default shell on catalina
   # programs.fish.enable = true;
 


### PR DESCRIPTION
One of the comments in the simple example config looks like it's trying to explain `programs.zsh.enable = true` on the following line, but is referring to `/etc/bashrc`. I assume it should be referring to `/etc/zshrc` instead. Hope this helps!