### PR TITLE
fix(gitlab-runner): deprecated literalExample

### DIFF
--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -136,7 +136,7 @@ in
     checkInterval = mkOption {
       type = types.int;
       default = 0;
-      example = literalExample "with lib; (length (attrNames config.services.gitlab-runner.services)) * 3";
+      example = literalExpression "with lib; (length (attrNames config.services.gitlab-runner.services)) * 3";
       description = ''
         Defines the interval length, in seconds, between new jobs check.
         The default value is 3;
@@ -147,7 +147,7 @@ in
     concurrent = mkOption {
       type = types.int;
       default = 1;
-      example = literalExample "config.nix.maxJobs";
+      example = literalExpression "config.nix.maxJobs";
       description = ''
         Limits how many jobs globally can be run concurrently.
         The most upper limit of jobs using all defined runners.
@@ -203,7 +203,7 @@ in
         };
       };
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           listenAddress = "0.0.0.0:8093";
         }
@@ -235,7 +235,7 @@ in
       type = types.package;
       default = pkgs.gitlab-runner;
       defaultText = "pkgs.gitlab-runner";
-      example = literalExample "pkgs.gitlab-runner_1_11";
+      example = literalExpression "pkgs.gitlab-runner_1_11";
       description = "Gitlab Runner package to use.";
     };
     extraPackages = mkOption {
@@ -248,7 +248,7 @@ in
     services = mkOption {
       description = "GitLab Runner services.";
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           # runner for building in docker via host's nix-daemon
           # nix store will be readable in runner, might be insecure


### PR DESCRIPTION
* replace all occurrence's with literalExpression
* fixes #504 