### PR TITLE
Add `-H` to `sudo nix-env [...]` calls in `darwin-rebuild.sh` to deal with warning

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -160,7 +160,7 @@ fi
 
 if [ "$action" = list ] || [ "$action" = rollback ]; then
   if [ "$USER" != root ] && [ ! -w $(dirname "$profile") ]; then
-    sudo nix-env -p "$profile" "${extraProfileFlags[@]}"
+    sudo -H nix-env -p "$profile" "${extraProfileFlags[@]}"
   else
     nix-env -p "$profile" "${extraProfileFlags[@]}"
   fi
@@ -178,7 +178,7 @@ if [ -z "$systemConfig" ]; then exit 0; fi
 
 if [ "$action" = switch ]; then
   if [ "$USER" != root ] && [ ! -w $(dirname "$profile") ]; then
-    sudo nix-env -p "$profile" --set "$systemConfig"
+    sudo -H nix-env -p "$profile" --set "$systemConfig"
   else
     nix-env -p "$profile" --set "$systemConfig"
   fi


### PR DESCRIPTION
After NixOS/nix#6676, the following warning is displayed when running `darwin-rebuild switch`:
> warning: $HOME ('/Users/jamie') is not owned by you, falling back to the one defined in the 'passwd' file.

This happens because, on macOS `sudo` does not set `$HOME` by default, the `-H` flag needs to be added for it to do so.

Fixes: #481
Fixes: #477
