### PR TITLE
Transition to using native floats for option types

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -37,7 +37,7 @@ let
         if v == null then ""
         else if isInt v then toString v
         else if isBool v then boolToString v
-        else if isFloat v then floatToString v
+        else if isFloat v then strings.floatToString v
         else if isList v then toString v
         else if isDerivation v then toString v
         else if builtins.isPath v then toString v

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -5,14 +5,12 @@ with lib;
 let
   cfg = config.system.defaults;
 
-  isFloat = x: isString x && builtins.match "^[+-]?([0-9]*[.])?[0-9]+$" x != null;
-
   boolValue = x: if x then "YES" else "NO";
 
   writeValue = value:
     if isBool value then "-bool ${boolValue value}" else
     if isInt value then "-int ${toString value}" else
-    if isFloat value then "-float ${toString value}" else
+    if isFloat value then "-float ${strings.floatToString value}" else
     if isString value then "-string '${value}'" else
     throw "invalid value type";
 
@@ -47,6 +45,15 @@ in
 
 {
   config = {
+
+    # Type used for `system.defaults.<domain>.*` options that previously accepted float values as a
+    # string.
+    lib.defaults.types.floatWithDeprecationError = types.float // {
+      check = x:
+        if isString x && builtins.match "^[+-]?([0-9]*[.])?[0-9]+$" x != null
+        then throw "Using strings for `system.defaults.<domain>.*' options of type float is no longer permitted, use native float values instead."
+        else types.float.check x;
+    };
 
     system.activationScripts.defaults.text = mkIfAttrs [
       alf

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -3,15 +3,8 @@
 with lib;
 
 let
-  isFloat = x: isString x && builtins.match "^[+-]?([0-9]*[.])?[0-9]+$" x != null;
-
-  float = mkOptionType {
-    name = "float";
-    description = "float";
-    check = isFloat;
-    merge = options.mergeOneOption;
-  };
-
+  # Should only be used with options that previously used floats defined as strings.
+  inherit (config.lib.defaults.types) floatWithDeprecationError;
 in {
   options = {
 
@@ -208,9 +201,9 @@ in {
     };
 
     system.defaults.NSGlobalDomain.NSWindowResizeTime = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
-      example = "0.20";
+      example = 0.20;
       description = ''
         Sets the speed speed of window resizing. The default is given in the example.
       '';
@@ -273,14 +266,16 @@ in {
     };
 
     system.defaults.NSGlobalDomain."com.apple.sound.beep.volume" = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
       description = ''
         # Apple menu > System Preferences > Sound
         Sets the beep/alert volume level from 0.000 (muted) to 1.000 (100% volume).
 
         75% = 0.7788008
+
         50% = 0.6065307
+
         25% = 0.4723665
       '';
     };
@@ -312,7 +307,7 @@ in {
     };
 
     system.defaults.NSGlobalDomain."com.apple.trackpad.scaling" = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
       description = ''
         Configures the trackpad tracking speed (0 to 3).  The default is "1".
@@ -328,9 +323,9 @@ in {
     };
 
     system.defaults.NSGlobalDomain."com.apple.springing.delay" = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
-      example = "1.0";
+      example = 1.0;
       description = ''
         Set the spring loading delay for directories. The default is given in the example.
       '';

--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -3,15 +3,8 @@
 with lib;
 
 let
-  isFloat = x: isString x && builtins.match "^[+-]?([0-9]*[.])?[0-9]+$" x != null;
-
-  float = mkOptionType {
-    name = "float";
-    description = "float";
-    check = isFloat;
-    merge = options.mergeOneOption;
-  };
-
+  # Should only be used with options that previously used floats defined as strings.
+  inherit (config.lib.defaults.types) floatWithDeprecationError;
 in {
   options = {
 
@@ -32,18 +25,18 @@ in {
     };
 
     system.defaults.dock.autohide-delay = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
-      example = "0.24";
+      example = 0.24;
       description = ''
         Sets the speed of the autohide delay. The default is given in the example.
       '';
     };
 
     system.defaults.dock.autohide-time-modifier = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
-      example = "1.0";
+      example = 1.0;
       description = ''
         Sets the speed of the animation when hiding/showing the Dock. The default is given in the example.
       '';
@@ -66,9 +59,9 @@ in {
     };
 
     system.defaults.dock.expose-animation-duration = mkOption {
-      type = types.nullOr float;
+      type = types.nullOr floatWithDeprecationError;
       default = null;
-      example = "1.0";
+      example = 1.0;
       description = ''
         Sets the speed of the Mission Control animations. The default is given in the example.
       '';

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -23,7 +23,7 @@
   system.defaults.NSGlobalDomain.NSTextShowsControlCharacters = true;
   system.defaults.NSGlobalDomain.NSUseAnimatedFocusRing = false;
   system.defaults.NSGlobalDomain.NSScrollAnimationEnabled = true;
-  system.defaults.NSGlobalDomain.NSWindowResizeTime = "0.01";
+  system.defaults.NSGlobalDomain.NSWindowResizeTime = 0.01;
   system.defaults.NSGlobalDomain.InitialKeyRepeat = 10;
   system.defaults.NSGlobalDomain.KeyRepeat = 1;
   system.defaults.NSGlobalDomain.PMPrintingExpandedStateForPrint = true;
@@ -33,11 +33,11 @@
   system.defaults.NSGlobalDomain."com.apple.trackpad.enableSecondaryClick" = true;
   system.defaults.NSGlobalDomain."com.apple.trackpad.trackpadCornerClickBehavior" = 1;
   system.defaults.NSGlobalDomain."com.apple.springing.enabled" = true;
-  system.defaults.NSGlobalDomain."com.apple.springing.delay" = "0.0";
+  system.defaults.NSGlobalDomain."com.apple.springing.delay" = 0.0;
   system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" = true;
   system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" = "/System/Library/Sounds/Funk.aiff";
   system.defaults.dock.appswitcher-all-displays = false;
-  system.defaults.dock.autohide-delay = "0.24";
+  system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";
   system.defaults.screencapture.location = "/tmp";
   system.defaults.smb.NetBIOSName = "IMAC-000000";


### PR DESCRIPTION
This PR transitions all options that use strings to represent float values to use builtin floats. 

This change is not backwards compatible, since using string values for those options will produce and error, but to ease the transition, I've create a `floatWithDeprecationError` type, that will print a helpful error message informing users of the change.

Fixes: #454