### PR TITLE
skhd: add more options

### DIFF
--- a/modules/services/skhd/default.nix
+++ b/modules/services/skhd/default.nix
@@ -4,42 +4,101 @@ with lib;
 
 let
   cfg = config.services.skhd;
+
+  validateKeybinding = binding:
+    let
+      matched = builtins.match "([a-z|0-9]+( [+] [a-z|0-9]+){0,} - [a-z|0-9]+)" binding;
+
+      isCorrect =
+        # Some groups are optional
+        if isList matched then
+          builtins.any (group: isString group) matched
+        else matched != null;
+    in
+    if isCorrect then isCorrect
+    # Throw here to show the name of the faulty attribute
+    else throw "attribute with name '${binding}' in 'services.skhd.keybindings' is incorrectly formatted";
+
+  mkKeyBindings = concatStrings
+    (mapAttrsToList (name: value: "${name} : ${value}\n") cfg.keybindings);
+
+  mkBlacklist = ".blacklist [\n  \"${concatStringsSep "\"\n  \"" cfg.blacklist}\"\n]";
+
+  configFile = optionalString (cfg.keybindings != [ ]) mkKeyBindings
+    + optionalString (cfg.blacklist != [ ]) mkBlacklist
+    + cfg.extraConfig;
 in
-
 {
-  options = {
-    services.skhd.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to enable the skhd hotkey daemon.";
-    };
+  imports = [
+    (mkRenamedOptionModule [ "services" "skhd" "skhdConfig" ] [ "services" "skhd" "extraConfig" ])
+  ];
 
-    services.skhd.package = mkOption {
+  options.services.skhd = {
+    enable = mkEnableOption "skhd hotkey daemon";
+
+    package = mkOption {
       type = types.package;
       default = pkgs.skhd;
-      description = "This option specifies the skhd package to use.";
+      description = "The skhd package to use.";
+      example = literalExpression "pkgs.skhd";
     };
 
-    services.skhd.skhdConfig = mkOption {
+    blacklist = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Prevent skhd from monitoring events for specific applications.
+      '';
+      example = literalExpression ''
+        [
+          "firefox"
+          "kitty"
+        ]
+      '';
+    };
+
+    keybindings = mkOption {
+      type = with types; addCheck (attrsOf (either str path)) (attrs:
+        builtins.all (name: validateKeybinding name) (attrNames attrs)
+      );
+      default = { };
+      description = ''
+        A list of keybindings to add to shkd. See the
+        <link xlink:href="https://github.com/koekeishiya/skhd/blob/master/examples/skhdrc">example configuration</link>
+        for more information and examples on how to use this. The generated file
+        will get written to <filename>/etc/skhdrc</filename>.
+      '';
+      example = literalExpression ''
+        {
+          "ctl + alt - h" = "echo foo";
+          "shift - f" = "echo bar";
+        }
+      '';
+    };
+
+    extraConfig = mkOption {
       type = types.lines;
       default = "";
-      example = "alt + shift - r   :   chunkc quit";
-      description = "Config to use for <filename>skhdrc</filename>.";
+      example = "alt + shift - r : chunkc quit";
+      description = ''
+        Extra configuration to append to the generated <filename>skhdrc</filename>.
+      '';
     };
   };
 
   config = mkIf cfg.enable {
-
-    environment.etc."skhdrc".text = cfg.skhdConfig;
+    environment.systemPackages = [ cfg.package ];
+    environment.etc."skhdrc".text = configFile;
 
     launchd.user.agents.skhd = {
       path = [ config.environment.systemPath ];
 
-      serviceConfig.ProgramArguments = [ "${cfg.package}/bin/skhd" ]
-        ++ optionals (cfg.skhdConfig != "") [ "-c" "/etc/skhdrc" ];
-      serviceConfig.KeepAlive = true;
-      serviceConfig.ProcessType = "Interactive";
+      serviceConfig = {
+        ProgramArguments = toList "${cfg.package}/bin/skhd"
+          ++ optionals (configFile != "") [ "-c" "/etc/skhdrc" ];
+        KeepAlive = true;
+        ProcessType = "Interactive";
+      };
     };
-
   };
 }


### PR DESCRIPTION
This adds more configuration options to the `services.skhd` module, before it only had an option to generate a config file from a string which wasn't the user experience.

Usage now looks something like this:
```nix
  services.skhd = {
    enable = true;

    keybindings = {
      "alt - h" = "yabai -m window --focus west";
      "alt - j" = "yabai -m window --focus south";
      "alt - k" = "yabai -m window --focus north";
      "alt - l" = "yabai -m window --focus east";
    };
  };
```

The `keybindings` are validated against a regex which will complain if the entry is not valid, and because these are defined in an attribute set you also cannot define the same keybinding twice. This validation is very useful because skhd will just not do anything if one of the options in the configuration file is not valid.