### PR TITLE
yabai: set default package

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -27,6 +27,7 @@ in
 
     services.yabai.package = mkOption {
       type = path;
+      default = pkgs.yabai;
       description = "The yabai package to use.";
     };
 


### PR DESCRIPTION
[7 May 2020](https://github.com/LnL7/nix-darwin/pull/196#discussion_r421693792):
> This was only added recently to nixpkgs, this default shouldn't be included until 20.09 has been released for a while so people using the stable channel don't run into issues.

So, we can add default value now.