### PR TITLE
Update nixpkgs-darwin version in README for flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A minimal example of using an existing configuration.nix:
   description = "John's darwin system";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-20.09-darwin";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-21.11-darwin";
     darwin.url = "github:lnl7/nix-darwin/master";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
   };


### PR DESCRIPTION
Using the example as is was previously written lead to the error:

    error: cannot coerce null to a string

       at /nix/store/v05pr9aaswlpxxpilmvmkx7qi44gsrfj-source/pkgs/stdenv/generic/make-derivation.nix:192:34:

          191|         // (lib.optionalAttrs (!(attrs ? name) && attrs ? pname && attrs ? version)) {
          192|           name = "${attrs.pname}-${attrs.version}";
             |                                  ^
          193|         } // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix && (attrs ? name || (attrs ? pname && attrs ? version)))) {