### PR TITLE
Fix Tailscale module

### DIFF
--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -29,6 +29,16 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [ {
+      assertion = !cfg.magicDNS.enable || config.networking.dns != [ "100.100.100.100" ];
+      message = ''
+        When MagicDNS is enabled, fallback DNS servers need to be set with `networking.dns`.
+
+        Otherwise, Tailscale will take a long time to connect and all DNS queries
+        will fail until Tailscale has connected.
+      '';
+    } ];
+
     environment.systemPackages = [ cfg.package ];
 
     launchd.daemons.tailscaled = {


### PR DESCRIPTION
- [tailscale: fix tailscaled not running as root](https://github.com/LnL7/nix-darwin/commit/0ae311e1c74ad88a74b3ee5d897d4df4f633044f)

Run `tailscaled` using a system daemon as it does not work as a non-root
user without `userspace-networking`.

Also, remove the broken warning relating to setting the search domain.
Manually adding the search domain to `networking.search` isn't necessary
to use only machine names to refer to other machines.

- [tailscale: prevent significant DNS footgun](https://github.com/LnL7/nix-darwin/commit/bdd5d81b13cd5886eab49d23472233b9b6e7f606)