### PR TITLE
rename runCommandNoCC

### DIFF
--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -34,7 +34,8 @@
   system.keyboard.remapCapsLockToControl = true;
 
   environment.systemPackages =
-    [ config.programs.vim.package
+    [
+      config.programs.vim.package
 
       pkgs.awscli
       pkgs.brotli
@@ -144,13 +145,18 @@
   # programs.vim.enable = true;
   # programs.vim.enableSensible = true;
   programs.vim.package = pkgs.neovim.override {
-      configure = {
-        packages.darwin.start = with pkgs.vimPlugins; [
-          vim-sensible vim-surround ReplaceWithRegister
-          polyglot fzfWrapper ale deoplete-nvim
-        ];
+    configure = {
+      packages.darwin.start = with pkgs.vimPlugins; [
+        vim-sensible
+        vim-surround
+        ReplaceWithRegister
+        polyglot
+        fzfWrapper
+        ale
+        deoplete-nvim
+      ];
 
-        customRC = ''
+      customRC = ''
         set completeopt=menuone
         set encoding=utf-8
         set hlsearch
@@ -302,7 +308,7 @@
 
   nixpkgs.overlays = [
     (self: super: {
-      darwin-zsh-completions = super.runCommandNoCC "darwin-zsh-completions-0.0.0"
+      darwin-zsh-completions = super.runCommand "darwin-zsh-completions-0.0.0"
         { preferLocalBuild = true; }
         ''
           mkdir -p $out/share/zsh/site-functions

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -24,7 +24,7 @@ in
 
     fonts.fonts = mkOption {
       type = types.listOf types.path;
-      default = [];
+      default = [ ];
       example = literalExpression "[ pkgs.dejavu_fonts ]";
       description = "List of fonts to install.";
     };
@@ -32,7 +32,7 @@ in
 
   config = {
 
-    system.build.fonts = pkgs.runCommandNoCC "fonts"
+    system.build.fonts = pkgs.runCommand "fonts"
       { paths = cfg.fonts; preferLocalBuild = true; }
       ''
         mkdir -p $out/Library/Fonts

--- a/modules/security/sandbox/default.nix
+++ b/modules/security/sandbox/default.nix
@@ -12,7 +12,7 @@ let
         profile = mkOption {
           type = types.lines;
           internal = true;
-          apply = text: pkgs.runCommandNoCC "sandbox.sb" {} ''
+          apply = text: pkgs.runCommand "sandbox.sb" { } ''
             for f in $(< ${config.closure}/store-paths); do
                 storePaths+="(subpath \"$f\")"
             done
@@ -25,20 +25,20 @@ let
 
         closure = mkOption {
           type = types.listOf types.package;
-          default = [];
+          default = [ ];
           apply = paths: pkgs.closureInfo { rootPaths = paths; };
           description = "List of store paths to make accessible.";
         };
 
         readablePaths = mkOption {
           type = types.listOf types.path;
-          default = [];
+          default = [ ];
           description = "List of paths that should be read-only inside the sandbox.";
         };
 
         writablePaths = mkOption {
           type = types.listOf types.path;
-          default = [];
+          default = [ ];
           description = "List of paths that should be read/write inside the sandbox.";
         };
 
@@ -132,11 +132,10 @@ in
   options = {
     security.sandbox.profiles = mkOption {
       type = types.attrsOf (types.submodule profile);
-      default = {};
+      default = { };
       description = "Definition of sandbox profiles.";
     };
   };
 
-  config = {
-  };
+  config = { };
 }

--- a/modules/system/etc.nix
+++ b/modules/system/etc.nix
@@ -21,7 +21,7 @@ in
 
     environment.etc = mkOption {
       type = types.attrsOf (types.submodule text);
-      default = {};
+      default = { };
       description = ''
         Set of files that have to be linked in <filename>/etc</filename>.
       '';
@@ -31,7 +31,7 @@ in
 
   config = {
 
-    system.build.etc = pkgs.runCommandNoCC "etc"
+    system.build.etc = pkgs.runCommand "etc"
       { preferLocalBuild = true; }
       ''
         mkdir -p $out/etc

--- a/modules/system/launchd.nix
+++ b/modules/system/launchd.nix
@@ -58,7 +58,7 @@ in
 
     environment.launchAgents = mkOption {
       type = types.attrsOf (types.submodule text);
-      default = {};
+      default = { };
       description = ''
         Set of files that have to be linked in <filename>/Library/LaunchAgents</filename>.
       '';
@@ -66,7 +66,7 @@ in
 
     environment.launchDaemons = mkOption {
       type = types.attrsOf (types.submodule text);
-      default = {};
+      default = { };
       description = ''
         Set of files that have to be linked in <filename>/Library/LaunchDaemons</filename>.
       '';
@@ -74,7 +74,7 @@ in
 
     environment.userLaunchAgents = mkOption {
       type = types.attrsOf (types.submodule text);
-      default = {};
+      default = { };
       description = ''
         Set of files that have to be linked in <filename>~/Library/LaunchAgents</filename>.
       '';
@@ -84,7 +84,7 @@ in
 
   config = {
 
-    system.build.launchd = pkgs.runCommandNoCC "launchd"
+    system.build.launchd = pkgs.runCommand "launchd"
       { preferLocalBuild = true; }
       ''
         mkdir -p $out/Library/LaunchAgents $out/Library/LaunchDaemons $out/user/Library/LaunchAgents

--- a/modules/system/patches.nix
+++ b/modules/system/patches.nix
@@ -11,7 +11,7 @@ in
 
     system.patches = mkOption {
       type = types.listOf types.path;
-      default = [];
+      default = [ ];
       example = literalExpression ''
         [
           (pkgs.writeText "bashrc.patch" ''''
@@ -42,7 +42,7 @@ in
 
   config = {
 
-    system.build.patches = pkgs.runCommandNoCC "patches"
+    system.build.patches = pkgs.runCommand "patches"
       { preferLocalBuild = true; }
       ''
         mkdir -p $out/patches


### PR DESCRIPTION
Following the merge of https://github.com/NixOS/nixpkgs/pull/134225 , `runCommandNoCC` has been renamed `runCommand`. This PR updates all references to `runCommandNoCC`.