### PR TITLE
Fix manual by escaping `&quot;` as well

### DIFF
--- a/doc/manual/options-to-docbook.xsl
+++ b/doc/manual/options-to-docbook.xsl
@@ -19,7 +19,15 @@
       <title>Configuration Options</title>
       <variablelist xml:id="configuration-variable-list">
         <xsl:for-each select="attrs">
-          <xsl:variable name="id" select="concat('opt-', str:replace(str:replace(str:replace(str:replace(attr[@name = 'name']/string/@value, '*', '_'), '&lt;', '_'), '>', '_'), '?', '_'))" />
+        <xsl:variable name="id" select="
+            concat(
+                'opt-',
+                translate(
+                    attr[@name = 'name']/string/@value,
+                    '*&lt; >[]:&quot;',
+                    '________'
+                )
+            )" />
           <varlistentry>
             <term xlink:href="#{$id}">
               <xsl:attribute name="xml:id"><xsl:value-of select="$id"/></xsl:attribute>


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/196651 for context.

__NOTE__: untested because I haven't found a quick way to build the manual without building a nix-darwin configuration, so it would be cool if someone could do a sanity-check before merging!