### PR TITLE
Custom defaults writes

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -14,6 +14,7 @@
   ./system/defaults/LaunchServices.nix
   ./system/defaults/NSGlobalDomain.nix
   ./system/defaults/GlobalPreferences.nix
+  ./system/defaults/CustomPreferences.nix
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
   ./system/defaults/screencapture.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -39,6 +39,8 @@ let
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
   universalaccess = defaultsToList "com.apple.universalaccess" cfg.universalaccess;
   ActivityMonitor = defaultsToList "com.apple.ActivityMonitor" cfg.ActivityMonitor;
+  CustomUserPreferences = flatten (mapAttrsToList (name: value: defaultsToList name value) cfg.CustomUserPreferences);
+  CustomSystemPreferences = flatten (mapAttrsToList (name: value: defaultsToList name value) cfg.CustomSystemPreferences);
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != { }) list);
 in
@@ -60,6 +62,7 @@ in
       loginwindow
       smb
       SoftwareUpdate
+      CustomSystemPreferences
     ]
       ''
         # Set defaults
@@ -68,6 +71,7 @@ in
         ${concatStringsSep "\n" loginwindow}
         ${concatStringsSep "\n" smb}
         ${concatStringsSep "\n" SoftwareUpdate}
+        ${concatStringsSep "\n" CustomSystemPreferences}
       '';
 
     system.activationScripts.userDefaults.text = mkIfAttrs
@@ -85,6 +89,7 @@ in
         trackpadBluetooth
         universalaccess
         ActivityMonitor
+        CustomUserPreferences
       ]
       ''
         # Set defaults
@@ -104,6 +109,7 @@ in
         ${concatStringsSep "\n" trackpadBluetooth}
         ${concatStringsSep "\n" universalaccess}
         ${concatStringsSep "\n" ActivityMonitor}
+        ${concatStringsSep "\n" CustomUserPreferences}
       '';
 
   };

--- a/modules/system/defaults/CustomPreferences.nix
+++ b/modules/system/defaults/CustomPreferences.nix
@@ -1,0 +1,38 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+    system.defaults.CustomUserPreferences = mkOption {
+      type = types.attrs;
+      default = { };
+      example = {
+        "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
+        "com.apple.Safari" = {
+          "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
+            true;
+        };
+      };
+      description = ''
+        Sets custom user preferences
+      '';
+    };
+
+    system.defaults.CustomSystemPreferences = mkOption {
+      type = types.attrs;
+      default = { };
+      example = {
+        "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
+        "com.apple.Safari" = {
+          "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
+            true;
+        };
+      };
+      description = ''
+        Sets custom system preferences
+      '';
+    };
+
+  };
+}

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -50,7 +50,13 @@
   system.defaults.ActivityMonitor.SortColumn = "CPUUsage";
   system.defaults.ActivityMonitor.SortDirection = 0;
   system.defaults.ActivityMonitor.OpenMainWindow = true;
-
+  system.defaults.CustomUserPreferences = {
+      "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
+      "com.apple.Safari" = {
+        "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
+          true;
+      };
+    };
   test = ''
     echo >&2 "checking defaults write in /activate"
     grep "defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server 'NetBIOSName' -string 'IMAC-000000'" ${config.out}/activate
@@ -104,5 +110,6 @@
     grep "defaults write com.apple.ActivityMonitor 'SortColumn' -string 'CPUUsage'" ${config.out}/activate-user
     grep "defaults write com.apple.ActivityMonitor 'SortDirection' -int 0" ${config.out}/activate-user
     grep "defaults write com.apple.ActivityMonitor 'OpenMainWindow' -bool YES" ${config.out}/activate-user
+    grep "defaults write NSGlobalDomain 'TISRomanSwitchState' -int 1" ${config.out}/activate-user
   '';
 }


### PR DESCRIPTION
Fixes #517

Allows to specify arbitrary options to configure so custom software using `defaults` and system options not yet supported in `nix-darwin` can be configured 

```
  system.defaults = {
    CustomUserPreferences = {
      "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
      "com.apple.Safari" = {
        "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
          true;
      };
    };
}
```