### PR TITLE
feat: add system.screencapture module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -31,6 +31,7 @@
   ./system/keyboard.nix
   ./system/launchd.nix
   ./system/patches.nix
+  ./system/screencapture.nix
   ./system/shells.nix
   ./system/version.nix
   ./time

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -104,6 +104,7 @@ in
 
       ${cfg.activationScripts.checks.text}
       ${cfg.activationScripts.extraUserActivation.text}
+      ${cfg.activationScripts.screencapture.text}
       ${cfg.activationScripts.userDefaults.text}
       ${cfg.activationScripts.userLaunchd.text}
       ${cfg.activationScripts.homebrew.text}

--- a/modules/system/screencapture.nix
+++ b/modules/system/screencapture.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.system.screencapture;
+  screenshotsLocation = config.system.defaults.screencapture.location;
+in
+{
+  options.system.screencapture = {
+    createLocation = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Create the screencapture location if set.";
+    };
+  };
+
+  config = {
+    system.activationScripts.screencapture.text = mkIf (cfg.createLocation && screenshotsLocation != null) ''
+      if [ ! -d "${screenshotsLocation}" ]; then
+        echo "creating screenshots directory..."
+        mkdir -pv "${screenshotsLocation}"
+      fi
+    '';
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -135,6 +135,7 @@ let
     tests.system-keyboard-mapping = makeTest ./tests/system-keyboard-mapping.nix;
     tests.system-packages = makeTest ./tests/system-packages.nix;
     tests.system-path = makeTest ./tests/system-path.nix;
+    tests.system-screencapture = makeTest ./tests/system-screencapture.nix;
     tests.system-shells = makeTest ./tests/system-shells.nix;
     tests.users-groups = makeTest ./tests/users-groups.nix;
     tests.users-packages = makeTest ./tests/users-packages.nix;

--- a/tests/system-screencapture.nix
+++ b/tests/system-screencapture.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+
+{
+  system.defaults.screencapture.location = "/tmp/not-so-random/nested/directory/directory";
+  system.screencapture.createLocation = true;
+
+  test = ''
+    echo checking creation of screencapture location >&2
+    grep "mkdir -pv \"${config.system.defaults.screencapture.location}\"" ${config.out}/activate-user
+  '';
+}


### PR DESCRIPTION
Create the screencapture directory if provided similar to the `users.users.${username}.createHome`. It will do nothing if the folder already exists. Note that if the directory does not exist, screencapture will not work, hence this feature.

Notes:
- Considered asserting if the location is not present but discarded (as we can avoid user intervention).
- Not using `system.defaults.screencapture` as the attributes inside are used to generate a script that sets the keys..

I am using this inside my flakes [here](https://github.com/bphenriques/dotfiles/blob/master/modules/darwin/system/screencapture/default.nix) with `system.defaults.screencapture.location` set to `~/Pictures/screenshots`. As with everything Nix, this is a convenience way to having to create the folder automatically.