### PR TITLE
Add option to use 24-hour system time

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -363,6 +363,14 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain.AppleICUForce24HourTime = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to use 24-hour or 12-hour time.  The default is based on region settings.
+      '';
+    };
+
     system.defaults.NSGlobalDomain._HIHideMenuBar = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -5,6 +5,7 @@
   system.defaults.NSGlobalDomain.AppleEnableMouseSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleEnableSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleFontSmoothing = 1;
+  system.defaults.NSGlobalDomain.AppleICUForce24HourTime = true;
   system.defaults.NSGlobalDomain.AppleKeyboardUIMode = 3;
   system.defaults.NSGlobalDomain.ApplePressAndHoldEnabled = true;
   system.defaults.NSGlobalDomain.AppleShowAllExtensions = true;
@@ -67,6 +68,7 @@
     grep "defaults write -g 'AppleEnableMouseSwipeNavigateWithScrolls' -bool NO" ${config.out}/activate-user
     grep "defaults write -g 'AppleEnableSwipeNavigateWithScrolls' -bool NO" ${config.out}/activate-user
     grep "defaults write -g 'AppleFontSmoothing' -int 1" ${config.out}/activate-user
+    grep "defaults write -g 'AppleICUForce24HourTime' -bool YES" ${config.out}/activate-user
     grep "defaults write -g 'AppleKeyboardUIMode' -int 3" ${config.out}/activate-user
     grep "defaults write -g 'ApplePressAndHoldEnabled' -bool YES" ${config.out}/activate-user
     grep "defaults write -g 'AppleShowAllExtensions' -bool YES" ${config.out}/activate-user


### PR DESCRIPTION
Normally, the system region setting determines whether the clock uses 12- or 24-hour time. This flag allows users to override this setting and use 24-hour time even if their region does not.