### PR TITLE
Remove inaccurate notice that the uninstaller uninstalls Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ nix-build https://github.com/LnL7/nix-darwin/archive/master.tar.gz -A uninstalle
 ./result/bin/darwin-uninstaller
 ```
 
-> NOTE: This will also uninstall Nix alongside nix-darwin.
-
 ## Example configuration
 
 Configuration lives in `~/.nixpkgs/darwin-configuration.nix`. Check out


### PR DESCRIPTION
Removes the inaccurate notice in the README that says the uninstaller will uninstall Nix alongside nix-darwin.