### PR TITLE
math-symbols-input: Add package

### DIFF
--- a/modules/services/math-symbols-input/commands-to-plist.nix
+++ b/modules/services/math-symbols-input/commands-to-plist.nix
@@ -1,0 +1,29 @@
+{ stdenv, callPackage, python3Packages, writers }:
+commands:
+
+let
+
+  custom-commmands-file = callPackage ./custom-commands.nix { };
+
+  generate-commands-plist =
+    python3Packages.callPackage ./generate-commands-plist {
+      inherit (writers) writePython3Bin;
+    };
+  math-symbols-input = callPackage ./package { };
+
+in stdenv.mkDerivation {
+  name = "commands-plist";
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+
+    # Call the generate_commands_plist python cli to convert the default
+    # list of replacements and a custom list of replacements to a plist file.
+    ${generate-commands-plist}/bin/generate_commands_plist \
+    ${math-symbols-input}/Math\ Symbols\ Input.app/Contents/Resources/commands.txt \
+    ${custom-commmands-file commands} \
+    $out/com.mathsymbolsinput.inputmethod.MathSymbolsInput.plist
+  '';
+}

--- a/modules/services/math-symbols-input/custom-commands.nix
+++ b/modules/services/math-symbols-input/custom-commands.nix
@@ -1,0 +1,14 @@
+# Converts an attr list to the text file format used by Math Symbols Input.
+# for example, the following command attribute set
+#
+#    {"alpha" = "α"; "beta" = "β";}
+#
+# would be converted to
+#
+#    \alpha α
+#    \beta β
+#
+{ writeText, lib }:
+commands:
+writeText "custom-commands.txt" (builtins.concatStringsSep "\n"
+  (lib.attrsets.mapAttrsToList (name: value: "\\${name} ${value}") commands))

--- a/modules/services/math-symbols-input/default.nix
+++ b/modules/services/math-symbols-input/default.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.math-symbols-input;
+  package = pkgs.callPackage ./package { };
+  commands-to-plist = pkgs.callPackage ./commands-to-plist.nix { };
+  # module = types.submoduleWith { description = "Math Symbols Input"; };
+
+in {
+
+  options.services.math-symbols-input = {
+    enable = mkEnableOption ''
+      LaTeX-style mathematical symbols input method for macOS
+    '';
+
+    symbols = mkOption {
+      type = types.attrs;
+      default = { };
+      example = literalExample ''
+        {
+          "xd" = "😆";
+        }
+      '';
+      description = "Custom symbols to add to Math Symbols Input";
+    };
+  };
+
+  # Note that this only makes sense for homebrew
+  config = mkIf cfg.enable {
+    system.activationScripts.preActivation.text = ''
+      echo "Setting up Math Symbols Input"
+
+      rm /Library/Input\ Methods/Math\ Symbols\ Input.app
+      rm ~/Library/Preferences/com.mathsymbolsinput.inputmethod.MathSymbolsInput.plist
+
+      ln -s ${package}/Math\ Symbols\ Input.app /Library/Input\ Methods/
+      ln -s ${
+        commands-to-plist cfg.symbols
+      }/com.mathsymbolsinput.inputmethod.MathSymbolsInput.plist ~/Library/Preferences/
+    '';
+  };
+}

--- a/modules/services/math-symbols-input/generate-commands-plist/default.nix
+++ b/modules/services/math-symbols-input/generate-commands-plist/default.nix
@@ -1,0 +1,6 @@
+{ lib, writePython3Bin, cytoolz }:
+
+writePython3Bin "generate_commands_plist" {
+  libraries = [ cytoolz ];
+  flakeIgnore = [ "E501" ];
+} (builtins.readFile ./generate_commands_plist.py)

--- a/modules/services/math-symbols-input/generate-commands-plist/generate_commands_plist.py
+++ b/modules/services/math-symbols-input/generate-commands-plist/generate_commands_plist.py
@@ -1,0 +1,106 @@
+from functools import reduce
+from pathlib import Path
+from collections.abc import Iterable
+from typing import TypedDict
+
+from operator import ior
+from cytoolz import compose_left
+from cytoolz.curried import filter, map
+
+###############################################################################
+#                                    Types                                    #
+###############################################################################
+
+Commands = dict[str, str]
+
+
+# This is the structure in the Math Symbols Input plist file
+class MathSymbolsPlist(TypedDict):
+    CustomCommands: Commands
+    DefaultCommands: Commands
+    PreferencesTab: str
+
+
+###############################################################################
+#                                Pure Commands                                #
+###############################################################################
+
+
+def valid_line(line: str) -> bool:
+    """Is this line a command line (true) or a comment (false)"""
+    return not line.startswith("#") and not line.isspace()
+
+
+def clean_line(line: str) -> str:
+    """Remove whitespace so commands don't have random whitespace in them"""
+    return line.strip()
+
+
+def command_line_to_commands(line: str) -> Commands:
+    """Convert a single command string line to a Commands"""
+    command, symbol = line.split(" ")
+    return {command: symbol}
+
+
+def combine_commands(commands: Iterable[Commands]) -> Commands:
+    """Combine a bunch of Commands dicts into one
+
+    Equivalent to combining a bunch of [d1, d2, ..., dn] as
+
+    d = {}
+    d |= d1
+    d |= d2
+    ...
+    d |= dn
+    """
+    return reduce(ior, commands, dict())
+
+
+# Operates on a generator, so only reads one line at a time
+def lines_to_commands(lines: Iterable[str]) -> Commands:
+    """Convert an iterable of command strings onto one Commands dict"""
+    return compose_left(
+        filter(valid_line),
+        map(compose_left(clean_line, command_line_to_commands)),
+        combine_commands,
+    )(lines)
+
+
+def commands_to_plist(custom: Commands, default: Commands) -> MathSymbolsPlist:
+    return MathSymbolsPlist(
+        CustomCommands=custom, DefaultCommands=default, PreferencesTab="custom-commands"
+    )
+
+
+###############################################################################
+#                          Stateful/Impure functions                          #
+###############################################################################
+
+
+def path_to_commands(p: Path) -> Commands:
+    with open(p, "r") as f:
+        return lines_to_commands(f)
+
+
+def command_paths_to_plist(custom_path: Path, default_path: Path) -> MathSymbolsPlist:
+    custom = path_to_commands(custom_path)
+    default = path_to_commands(default_path)
+
+    return commands_to_plist(custom, default)
+
+
+###############################################################################
+#                                     Main                                    #
+###############################################################################
+
+if __name__ == "__main__":
+    import sys
+    import plistlib
+
+    locations = sys.argv[1:4]
+    default_path, custom_path, output_path = map(Path, locations)
+
+    commands = command_paths_to_plist(custom_path, default_path)
+
+    with open(output_path, "wb") as f:
+        plistlib.dump(commands, f, fmt=plistlib.FMT_BINARY)

--- a/modules/services/math-symbols-input/package/default.nix
+++ b/modules/services/math-symbols-input/package/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, xar, zip, cpio }:
+
+let
+  patch = fetchurl {
+    url =
+      "https://github.com/knrafto/MathSymbolsInput/commit/19352edd3e181d7ff3030460b3a87bbbaef7bccc.patch";
+    sha256 = "sha256-0q0PJE3ZxaIHof5o6epgncMtgrVBWBIm+CZbkfl1Z2E=";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "MathSymbolsInput";
+  version = "v1.2";
+
+  src = fetchurl {
+    url =
+      "https://github.com/knrafto/${pname}/releases/download/${version}/${pname}.pkg";
+    sha256 = "sha256-/zQ9PEP9qO6fc77PcWeHMJa7gICyJL6UmuoZPNezDVc=";
+  };
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+  unpackPhase = "xar -xf $src";
+
+  buildInputs = [ xar zip cpio ];
+
+  buildPhase = ''
+    cat MathSymbolsInput.pkg/Payload  | gunzip -dc | cpio -i
+    patch -u Math\ Symbols\ Input.app/Contents/Resources/commands.txt -i ${patch}
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r "Math Symbols Input.app" $out
+  '';
+}


### PR DESCRIPTION
This module adds the [Math Symbols Input](https://github.com/knrafto/mathsymbolsinput) input method. The input method can then be enabled, with custom inputs, using the following 

```
  services.math-symbols-input = {
    enable = true;
    symbols = {
      "eyeroll" = "🙄"; # insert by typing \eyeroll and it will be replaced with 🙄
      "xd" = "😆";
      "emdash" = "—";
      "zany" = "🤪";
      "shrug" = "🤷";
      "wink" = "😉";
      "oops" = "😅";
      "rofl" = "🤣";
      "check" = "✓";
      "fp" = "🤦";
      "+1" = "👍";
      "lol" = "😂";
      "r" = "→";
      "skull" = "💀";
    };
  };
```

I am unfamiliar with how to write modules for nix darwin, so any help would be greatly appreciated! I have tested this on my system using an `imports` list in my configuration, but I am not sure of the best way to integrate this.

There is an included python program for handling the custom symbols (`generate-commands-plist`) since the symbols are encoded in a plist; python has a plist module in the standard library so that seemed like the simplest way to generate the configuration. I could not otherwise find a good way to access the `plutil` command found on macOS.