### PR TITLE
enableSudoTouchIdAuth: use a separate PAM service

### DIFF
--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -4,37 +4,6 @@ with lib;
 
 let
   cfg = config.security.pam;
-
-  # Implementation Notes
-  #
-  # We don't use `environment.etc` because this would require that the user manually delete
-  # `/etc/pam.d/sudo` which seems unwise given that applying the nix-darwin configuration requires
-  # sudo. We also can't use `system.patchs` since it only runs once, and so won't patch in the
-  # changes again after OS updates (which remove modifications to this file).
-  #
-  # As such, we resort to line addition/deletion in place using `sed`. We add a comment to the
-  # added line that includes the name of the option, to make it easier to identify the line that
-  # should be deleted when the option is disabled.
-  mkSudoTouchIdAuthScript = isEnabled:
-  let
-    file   = "/etc/pam.d/sudo";
-    option = "security.pam.enableSudoTouchIdAuth";
-    sed = "${pkgs.gnused}/bin/sed";
-  in ''
-    ${if isEnabled then ''
-      # Enable sudo Touch ID authentication, if not already enabled
-      if ! grep 'pam_tid.so' ${file} > /dev/null; then
-        ${sed} -i '2i\
-      auth       sufficient     pam_tid.so # nix-darwin: ${option}
-        ' ${file}
-      fi
-    '' else ''
-      # Disable sudo Touch ID authentication, if added by nix-darwin
-      if grep '${option}' ${file} > /dev/null; then
-        ${sed} -i '/${option}/d' ${file}
-      fi
-    ''}
-  '';
 in
 
 {
@@ -42,21 +11,30 @@ in
     security.pam.enableSudoTouchIdAuth = mkEnableOption ''
       Enable sudo authentication with Touch ID
 
-      When enabled, this option adds the following line to /etc/pam.d/sudo:
+      When enabled, this option changes sudo to use a separate pam
+      service, sudo-touchid, which contains the entire "sudo" service's
+      authentication methods, plus the line:
 
           auth       sufficient     pam_tid.so
-
-      (Note that macOS resets this file when doing a system update. As such, sudo
-      authentication with Touch ID won't work after a system update until the nix-darwin
-      configuration is reapplied.)
     '';
   };
 
-  config = {
-    system.activationScripts.pam.text = ''
-      # PAM settings
-      echo >&2 "setting up pam..."
-      ${mkSudoTouchIdAuthScript cfg.enableSudoTouchIdAuth}
-    '';
+  config = lib.mkIf (cfg.enableSudoTouchIdAuth) {
+    environment.etc."sudoers.d/000-sudo-touchid" = {
+      text = ''
+        Defaults pam_service=sudo-touchid
+        Defaults pam_login_service=sudo-touchid
+      '';
+    };
+    environment.etc."pam.d/sudo-touchid" = {
+      text = ''
+        auth       sufficient     pam_tid.so
+        auth       sufficient     pam_smartcard.so
+        auth       required       pam_opendirectory.so
+        account    required       pam_permit.so
+        password   required       pam_deny.so
+        session    required       pam_permit.so
+      '';
+    };
   };
 }

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -56,7 +56,6 @@ in
       ${cfg.activationScripts.groups.text}
       ${cfg.activationScripts.users.text}
       ${cfg.activationScripts.applications.text}
-      ${cfg.activationScripts.pam.text}
       ${cfg.activationScripts.patches.text}
       ${cfg.activationScripts.etc.text}
       ${cfg.activationScripts.defaults.text}


### PR DESCRIPTION
Currently, our patching /etc/sudoers doesn't persist across macOS upgrades, which is unfortunate, and also kinda non-nix-y: Ideally, the setting could be enabled or disabled by dropping in a file managed by nix.

Thankfully, that can be done: By setting a separate (non-default) PAM service for sudo, we can redirect PAM to use a separate (nix-managed) file for its auth strategies (of which pam_tid.so is one).

Credit for discovering this fantastic trick goes to @saleemrashid, who is an expert at PAM/sudo/macOS somehow! I couldn't have found this without the marvelous knowledge he unearthed.

## Error scenarios

### /nix is unavailable (symlinks are broken)

There are two symlinks in play, `/etc/sudoers.d/000-touchid-sudo` and `/etc/pam.d/touchid-sudo`. Both point into the nix store, which might fail to mount or similar. Here's the three error scenarios that can happen:

* both broken: sudo uses the `sudo` service, which is untouched & prompt for a password.
* `/etc/sudoers.d/000-touchid-sudo` broken: sudo uses the `sudo` service, which is untouched & prompt for a password.
* `/etc/pam.d/touchid-sudo` broken: sudo can not authenticate, needs manual intervention / rebooting into rescue system.

I think most users will only ever run into the scenario where both symlinks are broken (e.g. failed /nix store mount). If they manage to break the pam.d file, that's a problem, but that is no different from before: If that file was edited by somebody and an error were introduced, it would break their system.

### Upgrade path from nix-darwin with the `security.pam.enableSudoTouchIdAuth` setting enabled

Landing this PR will cause the existing edit to remain in `/etc/pam.d/sudo`, until the admin runs a macOS upgrade again, at which point it'll neatly start using the sudo-touchid facility again. I think that should be fine... and what's more, it'll allow us to add a setting for people to customize their sudo PAM behavior in the future?