### PR TITLE
Add nixosSystem-style extraModules args and return _module.

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -52,13 +52,13 @@ let
     modules = modules ++ [ argsModule pkgsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;
   });
+in
 
+rec {
   # Was moved in nixpkgs #82751, so both need to be handled here until 20.03 is deprecated.
   # https://github.com/NixOS/nixpkgs/commits/dcdd232939232d04c1132b4cc242dd3dac44be8c
   _module = eval._module or eval.config._module;
-in
 
-{
   inherit (_module.args) pkgs;
   inherit (eval) options config;
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,14 @@
       darwinSystem =
         { modules, inputs ? { }
         , system ? throw "darwin.lib.darwinSystem now requires 'system' to be passed explicitly"
+        , extraModules ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
+                         in if e == "" then [] else [(import e)]
         , ...
         }@args:
         self.lib.evalConfig (args // {
           inherit system;
           inputs = { inherit nixpkgs; darwin = self; } // inputs;
-          modules = modules ++ [ self.darwinModules.flakeOverrides ];
+          modules = modules ++ extraModules ++ [ self.darwinModules.flakeOverrides ];
         });
     };
 


### PR DESCRIPTION
As per the description, I made `darwinSystem` more like `nixosSystem`.

Because I use the _module attribute and extraModules in my system flake to load colmena into all nixosSystems I define, I needed the changes in the darwinSystem as well to use it once colmena adds support for darwin.