### PR TITLE
Add option to sort folders first in Finder

### DIFF
--- a/modules/system/defaults/finder.nix
+++ b/modules/system/defaults/finder.nix
@@ -80,6 +80,14 @@ with lib;
       '';
     };
 
+    system.defaults.finder._FXSortFoldersFirst = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to keep folders on top when sorting by name. The default is false.
+      '';
+    };
+
     system.defaults.finder.FXEnableExtensionChangeWarning = mkOption {
       type = types.nullOr types.bool;
       default = null;


### PR DESCRIPTION
This change adds com.apple.finder _FXSortFoldersFirst to system.defaults.finder, which keeps folders on top when sorting by name in Finder.