### PR TITLE
fix: add '://' to built flake uri

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,3 +114,7 @@ jobs:
         darwin-rebuild build \
           --flake /tmp/test-nix-darwin-submodules?submodules=1#simple \
           --override-input darwin .
+        # Should also succeed
+        darwin-rebuild build \
+          --flake git+file:///tmp/test-nix-darwin-submodules?submodules=1#simple \
+          --override-input darwin .

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -123,13 +123,13 @@ flakeFlags=(--extra-experimental-features 'nix-command flakes')
 if [ -n "$flake" ]; then
     # Offical regex from https://www.rfc-editor.org/rfc/rfc3986#appendix-B
     if [[ "${flake}" =~ ^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))? ]]; then
-       scheme=${BASH_REMATCH[2]}
-       authority=${BASH_REMATCH[4]}
-       path=${BASH_REMATCH[5]}
+       scheme=${BASH_REMATCH[2]} # eg. http
+       authority=${BASH_REMATCH[4]} # eg. www.ics.uci.edu
+       path=${BASH_REMATCH[5]} # eg. /pub/ietf/uri/
        queryWithQuestion=${BASH_REMATCH[6]}
        fragment=${BASH_REMATCH[9]}
 
-       flake=${scheme}${authority}${path}${queryWithQuestion}
+       flake=${scheme}://${authority}${path}${queryWithQuestion}
        flakeAttr=${fragment}
     fi
     if [ -z "$flakeAttr" ]; then

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -123,13 +123,13 @@ flakeFlags=(--extra-experimental-features 'nix-command flakes')
 if [ -n "$flake" ]; then
     # Offical regex from https://www.rfc-editor.org/rfc/rfc3986#appendix-B
     if [[ "${flake}" =~ ^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))? ]]; then
-       scheme=${BASH_REMATCH[2]} # eg. http
-       authority=${BASH_REMATCH[4]} # eg. www.ics.uci.edu
+       scheme=${BASH_REMATCH[1]} # eg. http:
+       authority=${BASH_REMATCH[3]} # eg. //www.ics.uci.edu
        path=${BASH_REMATCH[5]} # eg. /pub/ietf/uri/
        queryWithQuestion=${BASH_REMATCH[6]}
        fragment=${BASH_REMATCH[9]}
 
-       flake=${scheme}://${authority}${path}${queryWithQuestion}
+       flake=${scheme}${authority}${path}${queryWithQuestion}
        flakeAttr=${fragment}
     fi
     if [ -z "$flakeAttr" ]; then


### PR DESCRIPTION
Fixes #597. Tested on my mac.

Problem - from that same RFC that is quoted:
```
For example, matching the above expression to

      http://www.ics.uci.edu/pub/ietf/uri/#Related

   results in the following subexpression matches:

      $1 = http:
      $2 = http
      $3 = //www.ics.uci.edu
      $4 = www.ics.uci.edu
      $5 = /pub/ietf/uri/
      $6 = <undefined>
      $7 = <undefined>
      $8 = #Related
      $9 = Related
```
and when building the URI, we concatenated:
```
flake=${group 2}${group 4}${group 5}${group 6}
```
Which results (for the URL example in question) in:
```
flake=httpwww.ics.uci.edu/pub/ietf/url/
```

Thus, this MR adds the missing `://`. 

I could've also just used group 1 instead of 2 and group 3 instead of 4, but I think the current way is more clear and readable and there are no problems with naming (how to name `scheme` with `:` included? and how to name `authority` with `//` included?).

EDIT: Actually we need to use groups instead of hardcoding `://` due to local relative paths.