### PR TITLE
services.github-runners: init

### DIFF
--- a/modules/services/github-runners/default.nix
+++ b/modules/services/github-runners/default.nix
@@ -1,0 +1,58 @@
+{ config
+, pkgs
+, lib
+, ...
+}@args:
+
+with lib;
+
+let
+  cfg = config.services.github-runners;
+
+in
+
+{
+  options.services.github-runners = mkOption {
+    default = {};
+    type = with types; attrsOf (submodule { options = import ./github-runner/options.nix (args // {
+      # services.github-runners.${name}.name doesn't have a default; it falls back to ${name} below.
+      includeNameDefault = false;
+    }); });
+    example = {
+      runner1 = {
+        enable = true;
+        url = "https://github.com/owner/repo";
+        name = "runner1";
+        tokenFile = "/secrets/token1";
+      };
+
+      runner2 = {
+        enable = true;
+        url = "https://github.com/owner/repo";
+        name = "runner2";
+        tokenFile = "/secrets/token2";
+      };
+    };
+    description = lib.mdDoc ''
+      Multiple GitHub Runners.
+    '';
+  };
+
+  config = {
+    systemd.services = flip mapAttrs' cfg (n: v:
+      let
+        svcName = "github-runner-${n}";
+      in
+        nameValuePair svcName
+        (import ./github-runner/service.nix (args // {
+          inherit svcName;
+          cfg = v // {
+            name = if v.name != null then v.name else n;
+          };
+          systemdDir = "github-runner/${n}";
+        }))
+    );
+  };
+
+  meta.maintainers = with maintainers; [ veehaitch newam ];
+}

--- a/modules/services/github-runners/default.nix
+++ b/modules/services/github-runners/default.nix
@@ -8,51 +8,62 @@ with lib;
 
 let
   cfg = config.services.github-runners;
-
 in
 
 {
   options.services.github-runners = mkOption {
     default = {};
-    type = with types; attrsOf (submodule { options = import ./github-runner/options.nix (args // {
-      # services.github-runners.${name}.name doesn't have a default; it falls back to ${name} below.
-      includeNameDefault = false;
-    }); });
+    type = with types;
+      attrsOf (submodule { options = import ./options.nix args; });
     example = {
       runner1 = {
-        enable = true;
         url = "https://github.com/owner/repo";
         name = "runner1";
         tokenFile = "/secrets/token1";
       };
 
       runner2 = {
-        enable = true;
         url = "https://github.com/owner/repo";
         name = "runner2";
         tokenFile = "/secrets/token2";
       };
     };
     description = lib.mdDoc ''
-      Multiple GitHub Runners.
+      GitHub Actions runners.
+
+      Note: GitHub recommends using self-hosted runners with private repositories only. Learn more here:
+      [About self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
     '';
   };
 
   config = {
-    systemd.services = flip mapAttrs' cfg (n: v:
+    # create a launchd service for each gtihub runner
+    launchd.daemons = flip mapAttrs' cfg (name: runnerConfig:
       let
-        svcName = "github-runner-${n}";
+        svcName = name;
       in
         nameValuePair svcName
-        (import ./github-runner/service.nix (args // {
+        (import ./service.nix (args // {
           inherit svcName;
-          cfg = v // {
-            name = if v.name != null then v.name else n;
-          };
-          systemdDir = "github-runner/${n}";
+          cfg = runnerConfig;
         }))
     );
-  };
 
-  meta.maintainers = with maintainers; [ veehaitch newam ];
+    users.knownGroups = ["github-runner"];
+    users.knownUsers = ["github-runner"];
+    users.users.github-runner = {
+      name = "github-runner";
+      uid = mkDefault 533;
+      # gid = mkDefault config.users.groups.gitlab-runner.gid;
+      home = mkDefault "/var/lib/github-runner";
+      createHome = true;
+      shell = "/bin/bash";
+      description = "Github runner users";
+    };
+    users.groups.github-runner = {
+      name = "github-runner";
+      gid = mkDefault 533;
+      description = "Github runner user group";
+    };
+  };
 }

--- a/modules/services/github-runners/options.nix
+++ b/modules/services/github-runners/options.nix
@@ -1,0 +1,186 @@
+{ config
+, lib
+, pkgs
+, includeNameDefault
+, ...
+}:
+
+with lib;
+
+{
+  enable = mkOption {
+    default = false;
+    example = true;
+    description = lib.mdDoc ''
+      Whether to enable GitHub Actions runner.
+
+      Note: GitHub recommends using self-hosted runners with private repositories only. Learn more here:
+      [About self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
+    '';
+    type = lib.types.bool;
+  };
+
+  url = mkOption {
+    type = types.str;
+    description = lib.mdDoc ''
+      Repository to add the runner to.
+
+      Changing this option triggers a new runner registration.
+
+      IMPORTANT: If your token is org-wide (not per repository), you need to
+      provide a github org link, not a single repository, so do it like this
+      `https://github.com/nixos`, not like this
+      `https://github.com/nixos/nixpkgs`.
+      Otherwise, you are going to get a `404 NotFound`
+      from `POST https://api.github.com/actions/runner-registration`
+      in the configure script.
+    '';
+    example = "https://github.com/nixos/nixpkgs";
+  };
+
+  tokenFile = mkOption {
+    type = types.path;
+    description = lib.mdDoc ''
+      The full path to a file which contains either a runner registration token or a
+      (fine-grained) personal access token (PAT).
+      The file should contain exactly one line with the token without any newline.
+      If a registration token is given, it can be used to re-register a runner of the same
+      name but is time-limited. If the file contains a PAT, the service creates a new
+      registration token on startup as needed. Make sure the PAT has a scope of
+      `admin:org` for organization-wide registrations or a scope of
+      `repo` for a single repository. Fine-grained PATs need read and write permission
+      to the "Administration" resources.
+
+      Changing this option or the file's content triggers a new runner registration.
+    '';
+    example = "/run/secrets/github-runner/nixos.token";
+  };
+
+  name = let
+    # Same pattern as for `networking.hostName`
+    baseType = types.strMatching "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+  in mkOption {
+    type = if includeNameDefault then baseType else types.nullOr baseType;
+    description = lib.mdDoc ''
+      Name of the runner to configure. Defaults to the hostname.
+
+      Changing this option triggers a new runner registration.
+    '';
+    example = "nixos";
+  } // (if includeNameDefault then {
+    default = config.networking.hostName;
+    defaultText = literalExpression "config.networking.hostName";
+  } else {
+    default = null;
+  });
+
+  runnerGroup = mkOption {
+    type = types.nullOr types.str;
+    description = lib.mdDoc ''
+      Name of the runner group to add this runner to (defaults to the default runner group).
+
+      Changing this option triggers a new runner registration.
+    '';
+    default = null;
+  };
+
+  extraLabels = mkOption {
+    type = types.listOf types.str;
+    description = lib.mdDoc ''
+      Extra labels in addition to the default (`["self-hosted", "Linux", "X64"]`).
+
+      Changing this option triggers a new runner registration.
+    '';
+    example = literalExpression ''[ "nixos" ]'';
+    default = [ ];
+  };
+
+  replace = mkOption {
+    type = types.bool;
+    description = lib.mdDoc ''
+      Replace any existing runner with the same name.
+
+      Without this flag, registering a new runner with the same name fails.
+    '';
+    default = false;
+  };
+
+  extraPackages = mkOption {
+    type = types.listOf types.package;
+    description = lib.mdDoc ''
+      Extra packages to add to `PATH` of the service to make them available to workflows.
+    '';
+    default = [ ];
+  };
+
+  extraEnvironment = mkOption {
+    type = types.attrs;
+    description = lib.mdDoc ''
+      Extra environment variables to set for the runner, as an attrset.
+    '';
+    example = {
+      GIT_CONFIG = "/path/to/git/config";
+    };
+    default = {};
+  };
+
+  serviceOverrides = mkOption {
+    type = types.attrs;
+    description = lib.mdDoc ''
+      Modify the systemd service. Can be used to, e.g., adjust the sandboxing options.
+    '';
+    example = {
+      ProtectHome = false;
+      RestrictAddressFamilies = [ "AF_PACKET" ];
+    };
+    default = {};
+  };
+
+  package = mkOption {
+    type = types.package;
+    description = lib.mdDoc ''
+      Which github-runner derivation to use.
+    '';
+    default = pkgs.github-runner;
+    defaultText = literalExpression "pkgs.github-runner";
+  };
+
+  ephemeral = mkOption {
+    type = types.bool;
+    description = lib.mdDoc ''
+      If enabled, causes the following behavior:
+
+      - Passes the `--ephemeral` flag to the runner configuration script
+      - De-registers and stops the runner with GitHub after it has processed one job
+      - On stop, systemd wipes the runtime directory (this always happens, even without using the ephemeral option)
+      - Restarts the service after its successful exit
+      - On start, wipes the state directory and configures a new runner
+
+      You should only enable this option if `tokenFile` points to a file which contains a
+      personal access token (PAT). If you're using the option with a registration token, restarting the
+      service will fail as soon as the registration token expired.
+    '';
+    default = false;
+  };
+
+  user = mkOption {
+    type = types.nullOr types.str;
+    description = lib.mdDoc ''
+      User under which to run the service. If null, will use a systemd dynamic user.
+    '';
+    default = null;
+    defaultText = literalExpression "username";
+  };
+
+  workDir = mkOption {
+    type = with types; nullOr str;
+    description = lib.mdDoc ''
+      Working directory, available as `$GITHUB_WORKSPACE` during workflow runs
+      and used as a default for [repository checkouts](https://github.com/actions/checkout).
+      The service cleans this directory on every service start.
+
+      A value of `null` will default to the systemd `RuntimeDirectory`.
+    '';
+    default = null;
+  };
+}

--- a/modules/services/github-runners/options.nix
+++ b/modules/services/github-runners/options.nix
@@ -1,25 +1,12 @@
 { config
 , lib
 , pkgs
-, includeNameDefault
 , ...
 }:
 
 with lib;
 
 {
-  enable = mkOption {
-    default = false;
-    example = true;
-    description = lib.mdDoc ''
-      Whether to enable GitHub Actions runner.
-
-      Note: GitHub recommends using self-hosted runners with private repositories only. Learn more here:
-      [About self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
-    '';
-    type = lib.types.bool;
-  };
-
   url = mkOption {
     type = types.str;
     description = lib.mdDoc ''
@@ -55,24 +42,6 @@ with lib;
     '';
     example = "/run/secrets/github-runner/nixos.token";
   };
-
-  name = let
-    # Same pattern as for `networking.hostName`
-    baseType = types.strMatching "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
-  in mkOption {
-    type = if includeNameDefault then baseType else types.nullOr baseType;
-    description = lib.mdDoc ''
-      Name of the runner to configure. Defaults to the hostname.
-
-      Changing this option triggers a new runner registration.
-    '';
-    example = "nixos";
-  } // (if includeNameDefault then {
-    default = config.networking.hostName;
-    defaultText = literalExpression "config.networking.hostName";
-  } else {
-    default = null;
-  });
 
   runnerGroup = mkOption {
     type = types.nullOr types.str;
@@ -163,23 +132,12 @@ with lib;
     default = false;
   };
 
-  user = mkOption {
-    type = types.nullOr types.str;
-    description = lib.mdDoc ''
-      User under which to run the service. If null, will use a systemd dynamic user.
-    '';
-    default = null;
-    defaultText = literalExpression "username";
-  };
-
-  workDir = mkOption {
+  baseDir = mkOption {
     type = with types; nullOr str;
     description = lib.mdDoc ''
       Working directory, available as `$GITHUB_WORKSPACE` during workflow runs
       and used as a default for [repository checkouts](https://github.com/actions/checkout).
       The service cleans this directory on every service start.
-
-      A value of `null` will default to the systemd `RuntimeDirectory`.
     '';
     default = null;
   };

--- a/modules/services/github-runners/service.nix
+++ b/modules/services/github-runners/service.nix
@@ -1,0 +1,268 @@
+{ config
+, lib
+, pkgs
+
+, cfg ? config.services.github-runner
+, svcName
+
+, systemdDir ? "${svcName}/${cfg.name}"
+  # %t: Runtime directory root (usually /run); see systemd.unit(5)
+, runtimeDir ? "%t/${systemdDir}"
+  # %S: State directory root (usually /var/lib); see systemd.unit(5)
+, stateDir ? "%S/${systemdDir}"
+  # %L: Log directory root (usually /var/log); see systemd.unit(5)
+, logsDir ? "%L/${systemdDir}"
+  # Name of file stored in service state directory
+, currentConfigTokenFilename ? ".current-token"
+
+, ...
+}:
+
+with lib;
+
+let
+  workDir = if cfg.workDir == null then runtimeDir else cfg.workDir;
+in
+{
+  description = "GitHub Actions runner";
+
+  wantedBy = [ "multi-user.target" ];
+  wants = [ "network-online.target" ];
+  after = [ "network.target" "network-online.target" ];
+
+  environment = {
+    HOME = workDir;
+    RUNNER_ROOT = stateDir;
+  } // cfg.extraEnvironment;
+
+  path = (with pkgs; [
+    bash
+    coreutils
+    git
+    gnutar
+    gzip
+  ]) ++ [
+    config.nix.package
+  ] ++ cfg.extraPackages;
+
+  serviceConfig = mkMerge [
+    {
+      ExecStart = "${cfg.package}/bin/Runner.Listener run --startuptype service";
+
+      # Does the following, sequentially:
+      # - If the module configuration or the token has changed, purge the state directory,
+      #   and create the current and the new token file with the contents of the configured
+      #   token. While both files have the same content, only the later is accessible by
+      #   the service user.
+      # - Configure the runner using the new token file. When finished, delete it.
+      # - Set up the directory structure by creating the necessary symlinks.
+      ExecStartPre =
+        let
+          # Wrapper script which expects the full path of the state, working and logs
+          # directory as arguments. Overrides the respective systemd variables to provide
+          # unambiguous directory names. This becomes relevant, for example, if the
+          # caller overrides any of the StateDirectory=, RuntimeDirectory= or LogDirectory=
+          # to contain more than one directory. This causes systemd to set the respective
+          # environment variables with the path of all of the given directories, separated
+          # by a colon.
+          writeScript = name: lines: pkgs.writeShellScript "${svcName}-${name}.sh" ''
+            set -euo pipefail
+
+            STATE_DIRECTORY="$1"
+            WORK_DIRECTORY="$2"
+            LOGS_DIRECTORY="$3"
+
+            ${lines}
+          '';
+          runnerRegistrationConfig = getAttrs [ "name" "tokenFile" "url" "runnerGroup" "extraLabels" "ephemeral" "workDir" ] cfg;
+          newConfigPath = builtins.toFile "${svcName}-config.json" (builtins.toJSON runnerRegistrationConfig);
+          currentConfigPath = "$STATE_DIRECTORY/.nixos-current-config.json";
+          newConfigTokenPath = "$STATE_DIRECTORY/.new-token";
+          currentConfigTokenPath = "$STATE_DIRECTORY/${currentConfigTokenFilename}";
+
+          runnerCredFiles = [
+            ".credentials"
+            ".credentials_rsaparams"
+            ".runner"
+          ];
+          unconfigureRunner = writeScript "unconfigure" ''
+            copy_tokens() {
+              # Copy the configured token file to the state dir and allow the service user to read the file
+              install --mode=666 ${escapeShellArg cfg.tokenFile} "${newConfigTokenPath}"
+              # Also copy current file to allow for a diff on the next start
+              install --mode=600 ${escapeShellArg cfg.tokenFile} "${currentConfigTokenPath}"
+            }
+            clean_state() {
+              find "$STATE_DIRECTORY/" -mindepth 1 -delete
+              copy_tokens
+            }
+            diff_config() {
+              changed=0
+              # Check for module config changes
+              [[ -f "${currentConfigPath}" ]] \
+                && ${pkgs.diffutils}/bin/diff -q '${newConfigPath}' "${currentConfigPath}" >/dev/null 2>&1 \
+                || changed=1
+              # Also check the content of the token file
+              [[ -f "${currentConfigTokenPath}" ]] \
+                && ${pkgs.diffutils}/bin/diff -q "${currentConfigTokenPath}" ${escapeShellArg cfg.tokenFile} >/dev/null 2>&1 \
+                || changed=1
+              # If the config has changed, remove old state and copy tokens
+              if [[ "$changed" -eq 1 ]]; then
+                echo "Config has changed, removing old runner state."
+                echo "The old runner will still appear in the GitHub Actions UI." \
+                     "You have to remove it manually."
+                clean_state
+              fi
+            }
+            if [[ "${optionalString cfg.ephemeral "1"}" ]]; then
+              # In ephemeral mode, we always want to start with a clean state
+              clean_state
+            elif [[ "$(ls -A "$STATE_DIRECTORY")" ]]; then
+              # There are state files from a previous run; diff them to decide if we need a new registration
+              diff_config
+            else
+              # The state directory is entirely empty which indicates a first start
+              copy_tokens
+            fi
+          '';
+          configureRunner = writeScript "configure" ''
+            if [[ -e "${newConfigTokenPath}" ]]; then
+              echo "Configuring GitHub Actions Runner"
+              args=(
+                --unattended
+                --disableupdate
+                --work "$WORK_DIRECTORY"
+                --url ${escapeShellArg cfg.url}
+                --labels ${escapeShellArg (concatStringsSep "," cfg.extraLabels)}
+                --name ${escapeShellArg cfg.name}
+                ${optionalString cfg.replace "--replace"}
+                ${optionalString (cfg.runnerGroup != null) "--runnergroup ${escapeShellArg cfg.runnerGroup}"}
+                ${optionalString cfg.ephemeral "--ephemeral"}
+              )
+              # If the token file contains a PAT (i.e., it starts with "ghp_" or "github_pat_"), we have to use the --pat option,
+              # if it is not a PAT, we assume it contains a registration token and use the --token option
+              token=$(<"${newConfigTokenPath}")
+              if [[ "$token" =~ ^ghp_* ]] || [[ "$token" =~ ^github_pat_* ]]; then
+                args+=(--pat "$token")
+              else
+                args+=(--token "$token")
+              fi
+              ${cfg.package}/bin/config.sh "''${args[@]}"
+              # Move the automatically created _diag dir to the logs dir
+              mkdir -p  "$STATE_DIRECTORY/_diag"
+              cp    -r  "$STATE_DIRECTORY/_diag/." "$LOGS_DIRECTORY/"
+              rm    -rf "$STATE_DIRECTORY/_diag/"
+              # Cleanup token from config
+              rm "${newConfigTokenPath}"
+              # Symlink to new config
+              ln -s '${newConfigPath}' "${currentConfigPath}"
+            fi
+          '';
+          setupWorkDir = writeScript "setup-work-dirs" ''
+            # Cleanup previous service
+            ${pkgs.findutils}/bin/find -H "$WORK_DIRECTORY" -mindepth 1 -delete
+
+            # Link _diag dir
+            ln -s "$LOGS_DIRECTORY" "$WORK_DIRECTORY/_diag"
+
+            # Link the runner credentials to the work dir
+            ln -s "$STATE_DIRECTORY"/{${lib.concatStringsSep "," runnerCredFiles}} "$WORK_DIRECTORY/"
+          '';
+        in
+        map (x: "${x} ${escapeShellArgs [ stateDir workDir logsDir ]}") [
+          "+${unconfigureRunner}" # runs as root
+          configureRunner
+          setupWorkDir
+        ];
+
+      # If running in ephemeral mode, restart the service on-exit (i.e., successful de-registration of the runner)
+      # to trigger a fresh registration.
+      Restart = if cfg.ephemeral then "on-success" else "no";
+      # If the runner exits with `ReturnCode.RetryableError = 2`, always restart the service:
+      # https://github.com/actions/runner/blob/40ed7f8/src/Runner.Common/Constants.cs#L146
+      RestartForceExitStatus = [ 2 ];
+
+      # Contains _diag
+      LogsDirectory = [ systemdDir ];
+      # Default RUNNER_ROOT which contains ephemeral Runner data
+      RuntimeDirectory = [ systemdDir ];
+      # Home of persistent runner data, e.g., credentials
+      StateDirectory = [ systemdDir ];
+      StateDirectoryMode = "0700";
+      WorkingDirectory = workDir;
+
+      InaccessiblePaths = [
+        # Token file path given in the configuration, if visible to the service
+        "-${cfg.tokenFile}"
+        # Token file in the state directory
+        "${stateDir}/${currentConfigTokenFilename}"
+      ];
+
+      KillSignal = "SIGINT";
+
+      # Hardening (may overlap with DynamicUser=)
+      # The following options are only for optimizing:
+      # systemd-analyze security github-runner
+      AmbientCapabilities = mkBefore [ "" ];
+      CapabilityBoundingSet = mkBefore [ "" ];
+      # ProtectClock= adds DeviceAllow=char-rtc r
+      DeviceAllow = mkBefore [ "" ];
+      NoNewPrivileges = mkDefault true;
+      PrivateDevices = mkDefault true;
+      PrivateMounts = mkDefault true;
+      PrivateTmp = mkDefault true;
+      PrivateUsers = mkDefault true;
+      ProtectClock = mkDefault true;
+      ProtectControlGroups = mkDefault true;
+      ProtectHome = mkDefault true;
+      ProtectHostname = mkDefault true;
+      ProtectKernelLogs = mkDefault true;
+      ProtectKernelModules = mkDefault true;
+      ProtectKernelTunables = mkDefault true;
+      ProtectSystem = mkDefault "strict";
+      RemoveIPC = mkDefault true;
+      RestrictNamespaces = mkDefault true;
+      RestrictRealtime = mkDefault true;
+      RestrictSUIDSGID = mkDefault true;
+      UMask = mkDefault "0066";
+      ProtectProc = mkDefault "invisible";
+      SystemCallFilter = mkBefore [
+        "~@clock"
+        "~@cpu-emulation"
+        "~@module"
+        "~@mount"
+        "~@obsolete"
+        "~@raw-io"
+        "~@reboot"
+        "~capset"
+        "~setdomainname"
+        "~sethostname"
+      ];
+      RestrictAddressFamilies = mkBefore [ "AF_INET" "AF_INET6" "AF_UNIX" "AF_NETLINK" ];
+
+      BindPaths = lib.optionals (cfg.workDir != null) [ cfg.workDir ];
+
+      # Needs network access
+      PrivateNetwork = mkDefault false;
+      # Cannot be true due to Node
+      MemoryDenyWriteExecute = mkDefault false;
+
+      # The more restrictive "pid" option makes `nix` commands in CI emit
+      # "GC Warning: Couldn't read /proc/stat"
+      # You may want to set this to "pid" if not using `nix` commands
+      ProcSubset = mkDefault "all";
+      # Coverage programs for compiled code such as `cargo-tarpaulin` disable
+      # ASLR (address space layout randomization) which requires the
+      # `personality` syscall
+      # You may want to set this to `true` if not using coverage tooling on
+      # compiled code
+      LockPersonality = mkDefault false;
+
+      # Note that this has some interactions with the User setting; so you may
+      # want to consult the systemd docs if using both.
+      DynamicUser = mkDefault true;
+    }
+    (mkIf (cfg.user != null) { User = cfg.user; })
+    cfg.serviceOverrides
+  ];
+}

--- a/modules/services/github-runners/service.nix
+++ b/modules/services/github-runners/service.nix
@@ -4,15 +4,6 @@
 
 , cfg ? config.services.github-runner
 , svcName
-
-, systemdDir ? "${svcName}/${cfg.name}"
-  # %t: Runtime directory root (usually /run); see systemd.unit(5)
-, runtimeDir ? "%t/${systemdDir}"
-  # %S: State directory root (usually /var/lib); see systemd.unit(5)
-, stateDir ? "%S/${systemdDir}"
-  # %L: Log directory root (usually /var/log); see systemd.unit(5)
-, logsDir ? "%L/${systemdDir}"
-  # Name of file stored in service state directory
 , currentConfigTokenFilename ? ".current-token"
 
 , ...
@@ -21,248 +12,179 @@
 with lib;
 
 let
-  workDir = if cfg.workDir == null then runtimeDir else cfg.workDir;
-in
-{
-  description = "GitHub Actions runner";
+  baseDir = "${config.users.users.github-runner.home}/${svcName}";
+  workDir =  "${baseDir}/work";
+  stateDir = "${baseDir}/state";
+  logsDir = "${baseDir}/logs";
+  # Does the following, sequentially:
+  # - If the module configuration or the token has changed, purge the state directory,
+  #   and create the current and the new token file with the contents of the configured
+  #   token. While both files have the same content, only the later is accessible by
+  #   the service user.
+  # - Configure the runner using the new token file. When finished, delete it.
+  # - Set up the directory structure by creating the necessary symlinks.
+  setupScript =
+    let
+      # Wrapper script which expects the full path of the state, working and logs
+      # directory as arguments. Overrides the respective systemd variables to provide
+      # unambiguous directory names. This becomes relevant, for example, if the
+      # caller overrides any of the StateDirectory=, RuntimeDirectory= or LogDirectory=
+      # to contain more than one directory. This causes systemd to set the respective
+      # environment variables with the path of all of the given directories, separated
+      # by a colon.
+      writeScript = name: lines: pkgs.writeShellScript "${svcName}-${name}.sh" ''
+        set -euo pipefail
+        set -x
 
-  wantedBy = [ "multi-user.target" ];
-  wants = [ "network-online.target" ];
-  after = [ "network.target" "network-online.target" ];
+        STATE_DIRECTORY="$1"
+        WORK_DIRECTORY="$2"
+        LOGS_DIRECTORY="$3"
 
-  environment = {
-    HOME = workDir;
-    RUNNER_ROOT = stateDir;
-  } // cfg.extraEnvironment;
+        mkdir -p $STATE_DIRECTORY $WORK_DIRECTORY $LOGS_DIRECTORY
 
-  path = (with pkgs; [
-    bash
-    coreutils
-    git
-    gnutar
-    gzip
-  ]) ++ [
-    config.nix.package
-  ] ++ cfg.extraPackages;
+        ${lines}
+      '';
+      runnerRegistrationConfig = {
+        name = svcName;
+        inherit (cfg)
+          tokenFile
+          url
+          runnerGroup
+          extraLabels
+          ephemeral
+          baseDir;
+      };
+      newConfigPath = builtins.toFile "${svcName}-config.json" (builtins.toJSON runnerRegistrationConfig);
+      currentConfigPath = "$STATE_DIRECTORY/.nixos-current-config.json";
+      newConfigTokenPath = "$STATE_DIRECTORY/.new-token";
+      currentConfigTokenPath = "$STATE_DIRECTORY/${currentConfigTokenFilename}";
 
-  serviceConfig = mkMerge [
+      runnerCredFiles = [
+        ".credentials"
+        ".credentials_rsaparams"
+        ".runner"
+      ];
+      unconfigureRunner = writeScript "unconfigure" ''
+        copy_tokens() {
+          # Copy the configured token file to the state dir and allow the service user to read the file
+          install --mode=666 ${escapeShellArg cfg.tokenFile} "${newConfigTokenPath}"
+          # Also copy current file to allow for a diff on the next start
+          install --mode=600 ${escapeShellArg cfg.tokenFile} "${currentConfigTokenPath}"
+        }
+        clean_state() {
+          ${pkgs.findutils}/bin/find "$STATE_DIRECTORY/" -mindepth 1 -delete
+          copy_tokens
+        }
+        diff_config() {
+          changed=0
+          # Check for module config changes
+          [[ -f "${currentConfigPath}" ]] \
+            && ${pkgs.diffutils}/bin/diff -q '${newConfigPath}' "${currentConfigPath}" >/dev/null 2>&1 \
+            || changed=1
+          # Also check the content of the token file
+          [[ -f "${currentConfigTokenPath}" ]] \
+            && ${pkgs.diffutils}/bin/diff -q "${currentConfigTokenPath}" ${escapeShellArg cfg.tokenFile} >/dev/null 2>&1 \
+            || changed=1
+          # If the config has changed, remove old state and copy tokens
+          if [[ "$changed" -eq 1 ]]; then
+            echo "Config has changed, removing old runner state."
+            echo "The old runner will still appear in the GitHub Actions UI." \
+                  "You have to remove it manually."
+            clean_state
+          fi
+        }
+        if [[ "${optionalString cfg.ephemeral "1"}" ]]; then
+          # In ephemeral mode, we always want to start with a clean state
+          clean_state
+        elif [[ "$(ls -A "$STATE_DIRECTORY")" ]]; then
+          # There are state files from a previous run; diff them to decide if we need a new registration
+          diff_config
+        else
+          # The state directory is entirely empty which indicates a first start
+          copy_tokens
+        fi
+      '';
+      configureRunner = writeScript "configure" ''
+        if [[ -e "${newConfigTokenPath}" ]]; then
+          echo "Configuring GitHub Actions Runner"
+          args=(
+            --unattended
+            --disableupdate
+            --work "$WORK_DIRECTORY"
+            --url ${escapeShellArg cfg.url}
+            --labels ${escapeShellArg (concatStringsSep "," cfg.extraLabels)}
+            --name ${escapeShellArg svcName}
+            ${optionalString cfg.replace "--replace"}
+            ${optionalString (cfg.runnerGroup != null) "--runnergroup ${escapeShellArg cfg.runnerGroup}"}
+            ${optionalString cfg.ephemeral "--ephemeral"}
+          )
+          # If the token file contains a PAT (i.e., it starts with "ghp_" or "github_pat_"), we have to use the --pat option,
+          # if it is not a PAT, we assume it contains a registration token and use the --token option
+          token=$(<"${newConfigTokenPath}")
+          if [[ "$token" =~ ^ghp_* ]] || [[ "$token" =~ ^github_pat_* ]]; then
+            args+=(--pat "$token")
+          else
+            args+=(--token "$token")
+          fi
+          ${cfg.package}/bin/config.sh "''${args[@]}"
+          # Move the automatically created _diag dir to the logs dir
+          mkdir -p  "$STATE_DIRECTORY/_diag"
+          cp    -r  "$STATE_DIRECTORY/_diag/." "$LOGS_DIRECTORY/"
+          rm    -rf "$STATE_DIRECTORY/_diag/"
+          # Cleanup token from config
+          rm "${newConfigTokenPath}"
+          # Symlink to new config
+          ln -s '${newConfigPath}' "${currentConfigPath}"
+        fi
+      '';
+      setupWorkDir = writeScript "setup-work-dirs" ''
+        # Cleanup previous service
+        ${pkgs.findutils}/bin/find -H "$WORK_DIRECTORY" -mindepth 1 -delete
+
+        # Link _diag dir
+        ln -s "$LOGS_DIRECTORY" "$WORK_DIRECTORY/_diag"
+
+        # Link the runner credentials to the work dir
+        ln -s "$STATE_DIRECTORY"/{${lib.concatStringsSep "," runnerCredFiles}} "$WORK_DIRECTORY/"
+      '';
+    in
+      lib.concatStringsSep "\n"
+      (map (x: "${x} ${escapeShellArgs [ stateDir workDir logsDir ]}") [
+        unconfigureRunner
+        configureRunner
+        setupWorkDir
+      ]);
+in {
+  script = ''
+    set -x
+    ${setupScript}
+    ${cfg.package}/bin/Runner.Listener run --startuptype service
+  '';
+
+  path = config.environment.systemPackages;
+
+  environment =
     {
-      ExecStart = "${cfg.package}/bin/Runner.Listener run --startuptype service";
-
-      # Does the following, sequentially:
-      # - If the module configuration or the token has changed, purge the state directory,
-      #   and create the current and the new token file with the contents of the configured
-      #   token. While both files have the same content, only the later is accessible by
-      #   the service user.
-      # - Configure the runner using the new token file. When finished, delete it.
-      # - Set up the directory structure by creating the necessary symlinks.
-      ExecStartPre =
-        let
-          # Wrapper script which expects the full path of the state, working and logs
-          # directory as arguments. Overrides the respective systemd variables to provide
-          # unambiguous directory names. This becomes relevant, for example, if the
-          # caller overrides any of the StateDirectory=, RuntimeDirectory= or LogDirectory=
-          # to contain more than one directory. This causes systemd to set the respective
-          # environment variables with the path of all of the given directories, separated
-          # by a colon.
-          writeScript = name: lines: pkgs.writeShellScript "${svcName}-${name}.sh" ''
-            set -euo pipefail
-
-            STATE_DIRECTORY="$1"
-            WORK_DIRECTORY="$2"
-            LOGS_DIRECTORY="$3"
-
-            ${lines}
-          '';
-          runnerRegistrationConfig = getAttrs [ "name" "tokenFile" "url" "runnerGroup" "extraLabels" "ephemeral" "workDir" ] cfg;
-          newConfigPath = builtins.toFile "${svcName}-config.json" (builtins.toJSON runnerRegistrationConfig);
-          currentConfigPath = "$STATE_DIRECTORY/.nixos-current-config.json";
-          newConfigTokenPath = "$STATE_DIRECTORY/.new-token";
-          currentConfigTokenPath = "$STATE_DIRECTORY/${currentConfigTokenFilename}";
-
-          runnerCredFiles = [
-            ".credentials"
-            ".credentials_rsaparams"
-            ".runner"
-          ];
-          unconfigureRunner = writeScript "unconfigure" ''
-            copy_tokens() {
-              # Copy the configured token file to the state dir and allow the service user to read the file
-              install --mode=666 ${escapeShellArg cfg.tokenFile} "${newConfigTokenPath}"
-              # Also copy current file to allow for a diff on the next start
-              install --mode=600 ${escapeShellArg cfg.tokenFile} "${currentConfigTokenPath}"
-            }
-            clean_state() {
-              find "$STATE_DIRECTORY/" -mindepth 1 -delete
-              copy_tokens
-            }
-            diff_config() {
-              changed=0
-              # Check for module config changes
-              [[ -f "${currentConfigPath}" ]] \
-                && ${pkgs.diffutils}/bin/diff -q '${newConfigPath}' "${currentConfigPath}" >/dev/null 2>&1 \
-                || changed=1
-              # Also check the content of the token file
-              [[ -f "${currentConfigTokenPath}" ]] \
-                && ${pkgs.diffutils}/bin/diff -q "${currentConfigTokenPath}" ${escapeShellArg cfg.tokenFile} >/dev/null 2>&1 \
-                || changed=1
-              # If the config has changed, remove old state and copy tokens
-              if [[ "$changed" -eq 1 ]]; then
-                echo "Config has changed, removing old runner state."
-                echo "The old runner will still appear in the GitHub Actions UI." \
-                     "You have to remove it manually."
-                clean_state
-              fi
-            }
-            if [[ "${optionalString cfg.ephemeral "1"}" ]]; then
-              # In ephemeral mode, we always want to start with a clean state
-              clean_state
-            elif [[ "$(ls -A "$STATE_DIRECTORY")" ]]; then
-              # There are state files from a previous run; diff them to decide if we need a new registration
-              diff_config
-            else
-              # The state directory is entirely empty which indicates a first start
-              copy_tokens
-            fi
-          '';
-          configureRunner = writeScript "configure" ''
-            if [[ -e "${newConfigTokenPath}" ]]; then
-              echo "Configuring GitHub Actions Runner"
-              args=(
-                --unattended
-                --disableupdate
-                --work "$WORK_DIRECTORY"
-                --url ${escapeShellArg cfg.url}
-                --labels ${escapeShellArg (concatStringsSep "," cfg.extraLabels)}
-                --name ${escapeShellArg cfg.name}
-                ${optionalString cfg.replace "--replace"}
-                ${optionalString (cfg.runnerGroup != null) "--runnergroup ${escapeShellArg cfg.runnerGroup}"}
-                ${optionalString cfg.ephemeral "--ephemeral"}
-              )
-              # If the token file contains a PAT (i.e., it starts with "ghp_" or "github_pat_"), we have to use the --pat option,
-              # if it is not a PAT, we assume it contains a registration token and use the --token option
-              token=$(<"${newConfigTokenPath}")
-              if [[ "$token" =~ ^ghp_* ]] || [[ "$token" =~ ^github_pat_* ]]; then
-                args+=(--pat "$token")
-              else
-                args+=(--token "$token")
-              fi
-              ${cfg.package}/bin/config.sh "''${args[@]}"
-              # Move the automatically created _diag dir to the logs dir
-              mkdir -p  "$STATE_DIRECTORY/_diag"
-              cp    -r  "$STATE_DIRECTORY/_diag/." "$LOGS_DIRECTORY/"
-              rm    -rf "$STATE_DIRECTORY/_diag/"
-              # Cleanup token from config
-              rm "${newConfigTokenPath}"
-              # Symlink to new config
-              ln -s '${newConfigPath}' "${currentConfigPath}"
-            fi
-          '';
-          setupWorkDir = writeScript "setup-work-dirs" ''
-            # Cleanup previous service
-            ${pkgs.findutils}/bin/find -H "$WORK_DIRECTORY" -mindepth 1 -delete
-
-            # Link _diag dir
-            ln -s "$LOGS_DIRECTORY" "$WORK_DIRECTORY/_diag"
-
-            # Link the runner credentials to the work dir
-            ln -s "$STATE_DIRECTORY"/{${lib.concatStringsSep "," runnerCredFiles}} "$WORK_DIRECTORY/"
-          '';
-        in
-        map (x: "${x} ${escapeShellArgs [ stateDir workDir logsDir ]}") [
-          "+${unconfigureRunner}" # runs as root
-          configureRunner
-          setupWorkDir
-        ];
-
-      # If running in ephemeral mode, restart the service on-exit (i.e., successful de-registration of the runner)
-      # to trigger a fresh registration.
-      Restart = if cfg.ephemeral then "on-success" else "no";
-      # If the runner exits with `ReturnCode.RetryableError = 2`, always restart the service:
-      # https://github.com/actions/runner/blob/40ed7f8/src/Runner.Common/Constants.cs#L146
-      RestartForceExitStatus = [ 2 ];
-
-      # Contains _diag
-      LogsDirectory = [ systemdDir ];
-      # Default RUNNER_ROOT which contains ephemeral Runner data
-      RuntimeDirectory = [ systemdDir ];
-      # Home of persistent runner data, e.g., credentials
-      StateDirectory = [ systemdDir ];
-      StateDirectoryMode = "0700";
-      WorkingDirectory = workDir;
-
-      InaccessiblePaths = [
-        # Token file path given in the configuration, if visible to the service
-        "-${cfg.tokenFile}"
-        # Token file in the state directory
-        "${stateDir}/${currentConfigTokenFilename}"
-      ];
-
-      KillSignal = "SIGINT";
-
-      # Hardening (may overlap with DynamicUser=)
-      # The following options are only for optimizing:
-      # systemd-analyze security github-runner
-      AmbientCapabilities = mkBefore [ "" ];
-      CapabilityBoundingSet = mkBefore [ "" ];
-      # ProtectClock= adds DeviceAllow=char-rtc r
-      DeviceAllow = mkBefore [ "" ];
-      NoNewPrivileges = mkDefault true;
-      PrivateDevices = mkDefault true;
-      PrivateMounts = mkDefault true;
-      PrivateTmp = mkDefault true;
-      PrivateUsers = mkDefault true;
-      ProtectClock = mkDefault true;
-      ProtectControlGroups = mkDefault true;
-      ProtectHome = mkDefault true;
-      ProtectHostname = mkDefault true;
-      ProtectKernelLogs = mkDefault true;
-      ProtectKernelModules = mkDefault true;
-      ProtectKernelTunables = mkDefault true;
-      ProtectSystem = mkDefault "strict";
-      RemoveIPC = mkDefault true;
-      RestrictNamespaces = mkDefault true;
-      RestrictRealtime = mkDefault true;
-      RestrictSUIDSGID = mkDefault true;
-      UMask = mkDefault "0066";
-      ProtectProc = mkDefault "invisible";
-      SystemCallFilter = mkBefore [
-        "~@clock"
-        "~@cpu-emulation"
-        "~@module"
-        "~@mount"
-        "~@obsolete"
-        "~@raw-io"
-        "~@reboot"
-        "~capset"
-        "~setdomainname"
-        "~sethostname"
-      ];
-      RestrictAddressFamilies = mkBefore [ "AF_INET" "AF_INET6" "AF_UNIX" "AF_NETLINK" ];
-
-      BindPaths = lib.optionals (cfg.workDir != null) [ cfg.workDir ];
-
-      # Needs network access
-      PrivateNetwork = mkDefault false;
-      # Cannot be true due to Node
-      MemoryDenyWriteExecute = mkDefault false;
-
-      # The more restrictive "pid" option makes `nix` commands in CI emit
-      # "GC Warning: Couldn't read /proc/stat"
-      # You may want to set this to "pid" if not using `nix` commands
-      ProcSubset = mkDefault "all";
-      # Coverage programs for compiled code such as `cargo-tarpaulin` disable
-      # ASLR (address space layout randomization) which requires the
-      # `personality` syscall
-      # You may want to set this to `true` if not using coverage tooling on
-      # compiled code
-      LockPersonality = mkDefault false;
-
-      # Note that this has some interactions with the User setting; so you may
-      # want to consult the systemd docs if using both.
-      DynamicUser = mkDefault true;
+      NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      RUNNER_ROOT = stateDir;
+      USER = "github-runner";
+      HOME = baseDir;
     }
-    (mkIf (cfg.user != null) { User = cfg.user; })
-    cfg.serviceOverrides
+    // cfg.extraEnvironment;
+
+  serviceConfig.UserName = "github-runner";
+  serviceConfig.GroupName = "github-runner";
+  serviceConfig.WorkingDirectory = baseDir;
+
+  serviceConfig.KeepAlive = true;
+  serviceConfig.RunAtLoad = true;
+  serviceConfig.ThrottleInterval = 30;
+  serviceConfig.ProcessType = "Interactive";
+  serviceConfig.StandardErrorPath = "${baseDir}/runner-logs";
+  serviceConfig.StandardOutPath = "${baseDir}/runner-logs";
+  serviceConfig.WatchPaths = [
+    cfg.tokenFile
+    "/etc/resolv.conf"
+    "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
   ];
 }


### PR DESCRIPTION
The runners work fine, but there is still work left to do in order to make the runners secure, therefore opening this as a draft.
I do not intent to continue working on this, as I went with a remote builder based setup instead by now.

Whoever is interested in moving this forward, please feel free to fork and take it on from here.

In order to make github runners secure for use with public github projects, two things are important:

### 1. The github runner user must not be able to read the `tokenFile` and copies of it made during the setup
...as this would allow an attacker to open a PR, changing the workflow logic and extract the authentication token.

By porting the module from nixos (systemd) to nix-darwin, several mechanism which protected the tokenFile were removed:
  - [adding the token file and the copy of it to `InaccessiblePaths`](https://github.com/NixOS/nixpkgs/blob/d8cf9821d6b648ec11bba9f1484631a7cb5d344e/nixos/modules/services/continuous-integration/github-runner/service.nix#L194-L199)
  - running the setup logic as root via `ExecStartPre`, while the `ExecStart` will run as unprivileged user

### 2. It must be impossible to persist state between runs
On public projects, github protects workflow secrets from outside contributors by not supplying PR runs with secrets.
But if an attacker manages to persist processes or files between runs, it becomes possible to influence future runs on that same machine to reveal secrets.

The only secure mode of operation is if the entire state is wiped between runs. Without namespaces this is hard to guarantee, but at least we should try to come as close as possible to that ideal behavior.

The systemd version of that service created temporary users and directories for each run. I'm not sure if we can to something similar in darwin.

It seems to me that the safest mode of operation on a macos would be to utilize virtualization tools like tart. I stitched together a quite hacky version of the github-runners module utilizing tart here: https://github.com/holochain/holochain-infra/tree/3ad70877dc0e0ba69900375f6241284142bc4d2f/modules/modules.darwin.github-runners-tart
Though there is no tart module on nix-darwin, therefore this setup isn't entirely declarative

### Things to do
In my opinion, those things still need to be worked on:
- [ ] Generate individual users for each runner (currently they all share the `github-runner` user)
- [ ] Ensure that the runner users doesn't have access to the token (do setup in separate root service?)

@domenkozar pinging you as you indicated interest in this