### PR TITLE
feat(system.defaults.dock): add springboard-columns and springboard-rows

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -255,5 +255,22 @@ in {
       '';
     };
 
+    system.defaults.dock.springboard-columns = mkOption {
+      type = types.nullOr types.ints.positive;
+      default = null;
+      example = 5;
+      description = ''
+        Sets the column count for Launchpad. The default is given in the example.
+      '';
     };
+
+    system.defaults.dock.springboard-rows = mkOption {
+      type = types.nullOr types.ints.positive;
+      default = null;
+      example = 7;
+      description = ''
+        Sets the row count for Launchpad. The default is given in the example.
+      '';
+    };
+  };
 }


### PR DESCRIPTION
Add `springboard-columns` and `springboard-rows` to set Launchpad columns and rows.

Currently it requires rebooting or running `killall Dock`; what would be the best way to proceed before marking this as ready? Should I add a note in the description, add a check if the option is enabled and append `killall Dock` to the activation script, or just do nothing?