### PR TITLE
Fix system.patches

### DIFF
--- a/modules/system/patches.nix
+++ b/modules/system/patches.nix
@@ -56,14 +56,14 @@ in
 
       for f in $(ls /run/current-system/patches 2> /dev/null); do
           if test ! -e "${config.system.build.patches}/patches/$f"; then
-              patch --reverse --backup -d / -p1 < "/run/current-system/patches/$f" || true
+              patch --force --reverse --backup -d / -p1 < "/run/current-system/patches/$f" || true
           fi
       done
 
       ${concatMapStringsSep "\n" (f: ''
         f="$(basename ${f})"
         if ! patch --force --reverse --dry-run -d / -p1 < '${f}' &> /dev/null; then
-            patch --forward --backup -d / -p1 < '${f}' || true
+            patch --force --forward --backup -d / -p1 < '${f}' || true
         fi
       '') cfg.patches}
     '';

--- a/modules/system/patches.nix
+++ b/modules/system/patches.nix
@@ -62,7 +62,7 @@ in
 
       ${concatMapStringsSep "\n" (f: ''
         f="$(basename ${f})"
-        if ! patch --reverse --dry-run -d / -p1 < '${f}' &> /dev/null; then
+        if ! patch --force --reverse --dry-run -d / -p1 < '${f}' &> /dev/null; then
             patch --forward --backup -d / -p1 < '${f}' || true
         fi
       '') cfg.patches}

--- a/modules/system/patches.nix
+++ b/modules/system/patches.nix
@@ -63,7 +63,7 @@ in
       ${concatMapStringsSep "\n" (f: ''
         f="$(basename ${f})"
         if ! patch --force --reverse --dry-run -d / -p1 < '${f}' &> /dev/null; then
-            patch --force --forward --backup -d / -p1 < '${f}' || true
+            patch --forward --backup -d / -p1 < '${f}' || true
         fi
       '') cfg.patches}
     '';


### PR DESCRIPTION
Currently, `system.patches` doesn't work because it will attempt to first detect if the patch has already been applied by checking if it can be applied in reverse.

However, when that happens, `patch` detects that the supplied patch is incorrectly reversed and attempts to ask the user if they want to "Ignore -R":

```
Unreversed (or previously applied) patch detected!  Ignore -R? [y]
```

Because the output is piped to `/dev/null` the user will basically see nothing and `darwin-rebuild switch` will hang until the user presses "Enter" (possibly to check if the terminal is frozen). At which point, patch will ignore the --reverse and exit successfully, preventing the patch from being applied at all.

This change fixes that bug by using `--force` when running the `patch` command with `--reverse`. This tells patch that we know what we're doing and prevents it from prompting the user if they want to ignore the `--reverse` argument. Note that this is unnecessary when using `--forward` because that already instructs `patch` to ignore patches it thinks are reversed or already applied.