### PR TITLE
Add support for persistent-apps in dock

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -1,22 +1,13 @@
 { config, lib, ... }:
 
+with import ../launchd/lib.nix { inherit lib; };
 with lib;
 
 let
   cfg = config.system.defaults;
 
-  boolValue = x: if x then "YES" else "NO";
-
-  writeValue = value:
-    if isBool value then "-bool ${boolValue value}" else
-    if isInt value then "-int ${toString value}" else
-    if isFloat value then "-float ${strings.floatToString value}" else
-    if isString value then "-string '${value}'" else
-    if isList value then "-array ${concatStringsSep " " (map (v: writeValue v)value)}" else
-    throw "invalid value type";
-
   writeDefault = domain: key: value:
-    "defaults write ${domain} '${key}' ${writeValue value}";
+    "defaults write ${domain} '${key}' '${pprExpr "" value}'";
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
 

--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -123,6 +123,19 @@ in {
       '';
     };
 
+    system.defaults.dock.persistent-apps = mkOption {
+      type = types.nullOr (types.listOf (types.either types.path types.str));
+      default = null;
+      example = [ "/Applications/Safari.app" "/System/Applications/Utilities/Terminal.app" ];
+      description = lib.mdDoc ''
+        Persistent applications in the dock.
+      '';
+      apply = value:
+        if !(isList value)
+        then value
+        else map (app: { tile-data = { file-data = { _CFURLString = app; _CFURLStringType = 0; }; }; }) value;
+    };
+
     system.defaults.dock.show-process-indicators = mkOption {
       type = types.nullOr types.bool;
       default = null;


### PR DESCRIPTION
Applications added to the dock point to an old derivation when a new derivation of an application is added to the Nix store. This allows configuring the persistent applications to display system apps or apps in the Nix store.

Updates require re-login or restarting the Dock process e.g. `killall Dock`.

Dependent on:
#790

Related / supersedes:
https://github.com/LnL7/nix-darwin/issues/590
https://github.com/LnL7/nix-darwin/pull/616