### PR TITLE
fix(wg-quick): builtins function typo

### DIFF
--- a/modules/services/wg-quick.nix
+++ b/modules/services/wg-quick.nix
@@ -142,7 +142,7 @@ let
     '' + optionalString (interfaceOpt.address != [ ]) (''
       Address = ${concatStringsSep "," interfaceOpt.address}
     '') + optionalString (interfaceOpt.dns != [ ]) ''
-      DNS = ${concatStringsep "," interfaceOpt.dns}
+      DNS = ${concatStringsSep "," interfaceOpt.dns}
     '' + optionalString (interfaceOpt.listenPort != null) ''
       ListenPort = ${toString interfaceOpt.listenPort}
     '' + optionalString (interfaceOpt.mtu != null) ''


### PR DESCRIPTION
This PR fixes a typo in the `modules/services/wg-quick.nix` implementation

`concatStringsep` -> `concatStringsSep`