### PR TITLE
fix(modules/fonts): ignore repeated fonts

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -38,7 +38,7 @@ in
         mkdir -p $out/Library/Fonts
         for path in $paths; do
             find -L $path/share/fonts -type f -print0 | while IFS= read -rd "" f; do
-                ln -s "$f" $out/Library/Fonts
+                ln -sf "$f" $out/Library/Fonts
             done
         done
       '';


### PR DESCRIPTION
Without this, attempts to build the fonts dir with repeated font
packages in `fonts.fonts` will yield:

```
ln: failed to create symbolic link '/nix/store/6im9rm87nxc82nqbv350hfp2w7ja1z47-fonts/Library/Fonts/IBMPlexSansThai-Thin.otf': File exists
```
