### PR TITLE
Fix zsh Emacs TRAMP connection

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -185,6 +185,14 @@ in
       ${optionalString cfg.enableFzfCompletion "source ${fzfCompletion}"}
       ${optionalString cfg.enableFzfGit "source ${fzfGit}"}
       ${optionalString cfg.enableFzfHistory "source ${fzfHistory}"}
+      
+      # Disable some features to support TRAMP.
+      if [ "$TERM" = dumb ]; then
+          unsetopt zle prompt_cr prompt_subst
+          unset RPS1 RPROMPT
+          PS1='$ '
+          PROMPT='$ '
+      fi
 
       # Read system-wide modifications.
       if test -f /etc/zshrc.local; then


### PR DESCRIPTION
Copied from [NixOS/nixpkgs/blob/nixos/modules/programs/zsh/zsh.nix#L272](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/zsh/zsh.nix#L272)

Temporary workaround is to insert into `/etc/zshrc.local`, since there is no configurable section after `promptInit`