### PR TITLE
feat(screensaver): add support of askForPassword and askForPasswordDelay

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -19,6 +19,7 @@
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
   ./system/defaults/screencapture.nix
+  ./system/defaults/screensaver.nix
   ./system/defaults/alf.nix
   ./system/defaults/loginwindow.nix
   ./system/defaults/magicmouse.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -34,6 +34,7 @@ let
   magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
   magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
   screencapture = defaultsToList "com.apple.screencapture" cfg.screencapture;
+  screensaver = defaultsToList "com.apple.screensaver" cfg.screensaver;
   spaces = defaultsToList "com.apple.spaces" cfg.spaces;
   trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
   trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
@@ -84,6 +85,7 @@ in
         magicmouse
         magicmouseBluetooth
         screencapture
+        screensaver
         spaces
         trackpad
         trackpadBluetooth
@@ -104,6 +106,7 @@ in
         ${concatStringsSep "\n" magicmouse}
         ${concatStringsSep "\n" magicmouseBluetooth}
         ${concatStringsSep "\n" screencapture}
+        ${concatStringsSep "\n" screensaver}
         ${concatStringsSep "\n" spaces}
         ${concatStringsSep "\n" trackpad}
         ${concatStringsSep "\n" trackpadBluetooth}

--- a/modules/system/defaults/screensaver.nix
+++ b/modules/system/defaults/screensaver.nix
@@ -1,0 +1,24 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.screensaver.askForPassword = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+          If true, the user is prompted for a password when the screen saver is unlocked or stopped. The default is false.
+        '';
+    };
+
+    system.defaults.screensaver.askForPasswordDelay = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+          The number of seconds to delay before the password will be required to unlock or stop the screen saver (the grace period).
+        '';
+    };
+  };
+}

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -41,6 +41,8 @@
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";
   system.defaults.screencapture.location = "/tmp";
+  system.defaults.screensaver.askForPassword = true;
+  system.defaults.screensaver.askForPasswordDelay = 5;
   system.defaults.smb.NetBIOSName = "IMAC-000000";
   system.defaults.smb.ServerDescription = ''Darwin\\\\U2019s iMac'';
   system.defaults.universalaccess.reduceTransparency = true;
@@ -104,6 +106,8 @@
     grep "defaults write com.apple.dock 'appswitcher-all-displays' -bool NO" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'orientation' -string 'left'" ${config.out}/activate-user
     grep "defaults write com.apple.screencapture 'location' -string '/tmp'" ${config.out}/activate-user
+    grep "defaults write com.apple.screensaver 'askForPassword' -bool YES" ${config.out}/activate-user
+    grep "defaults write com.apple.screensaver 'askForPasswordDelay' -int 5" ${config.out}/activate-user
     grep "defaults write com.apple.universalaccess 'reduceTransparency' -bool YES" ${config.out}/activate-user
     grep "defaults write com.apple.universalaccess 'closeViewScrollWheelToggle' -bool YES" ${config.out}/activate-user
     grep "defaults write com.apple.universalaccess 'closeViewZoomFollowsFocus' -bool YES" ${config.out}/activate-user


### PR DESCRIPTION
Add support of two new macOS parameters.

- com.apple.screensaver.askForPassword
- com.apple.screensaver.askForPasswordDelay

https://developer.apple.com/documentation/devicemanagement/screensaver