### PR TITLE
feat: defaults write com.apple.menuextra.clock

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -16,6 +16,7 @@
   ./system/defaults/NSGlobalDomain.nix
   ./system/defaults/GlobalPreferences.nix
   ./system/defaults/CustomPreferences.nix
+  ./system/defaults/clock.nix
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
   ./system/defaults/screencapture.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -29,7 +29,7 @@ let
   GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
   NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
-  clock = defaultsToList "com.apple.menuextra.clock" cfg.clock;
+  menuExtraClock = defaultsToList "com.apple.menuextra.clock" cfg.menuExtraClock;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
   magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
@@ -81,7 +81,7 @@ in
         GlobalPreferences
         LaunchServices
         NSGlobalDomain
-        clock
+        menuExtraClock
         dock
         finder
         magicmouse
@@ -103,7 +103,7 @@ in
 
         ${concatStringsSep "\n" GlobalPreferences}
         ${concatStringsSep "\n" LaunchServices}
-        ${concatStringsSep "\n" clock}
+        ${concatStringsSep "\n" menuExtraClock}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
         ${concatStringsSep "\n" magicmouse}

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -29,6 +29,7 @@ let
   GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
   NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
+  clock = defaultsToList "com.apple.menuextra.clock" cfg.clock;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
   magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
@@ -80,6 +81,7 @@ in
         GlobalPreferences
         LaunchServices
         NSGlobalDomain
+        clock
         dock
         finder
         magicmouse
@@ -101,6 +103,7 @@ in
 
         ${concatStringsSep "\n" GlobalPreferences}
         ${concatStringsSep "\n" LaunchServices}
+        ${concatStringsSep "\n" clock}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
         ${concatStringsSep "\n" magicmouse}

--- a/modules/system/defaults/clock.nix
+++ b/modules/system/defaults/clock.nix
@@ -5,7 +5,7 @@ with lib;
 {
   options = {
 
-    system.defaults.clock.IsAnalog = mkOption {
+    system.defaults.menuExtraClock.IsAnalog = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
@@ -13,7 +13,7 @@ with lib;
       '';
     };
 
-    system.defaults.clock.Show24Hour = mkOption {
+    system.defaults.menuExtraClock.Show24Hour = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
@@ -21,7 +21,7 @@ with lib;
       '';
     };
 
-    system.defaults.clock.ShowAMPM = mkOption {
+    system.defaults.menuExtraClock.ShowAMPM = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
@@ -29,7 +29,7 @@ with lib;
       '';
     };
 
-    system.defaults.clock.ShowDayOfMonth = mkOption {
+    system.defaults.menuExtraClock.ShowDayOfMonth = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
@@ -37,7 +37,7 @@ with lib;
       '';
     };
 
-    system.defaults.clock.ShowDayOfWeek = mkOption {
+    system.defaults.menuExtraClock.ShowDayOfWeek = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
@@ -45,7 +45,7 @@ with lib;
       '';
     };
 
-    system.defaults.clock.ShowDate = mkOption {
+    system.defaults.menuExtraClock.ShowDate = mkOption {
       type = types.nullOr (types.enum [ 0 1 2 ]);
       default = null;
       description = ''
@@ -59,7 +59,7 @@ with lib;
       '';
     };
 
-    system.defaults.clock.ShowSeconds = mkOption {
+    system.defaults.menuExtraClock.ShowSeconds = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''

--- a/modules/system/defaults/clock.nix
+++ b/modules/system/defaults/clock.nix
@@ -1,0 +1,71 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+
+    system.defaults.clock.IsAnalog = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show an analog clock instead of a digital one. Default is null.
+      '';
+    };
+
+    system.defaults.clock.Show24Hour = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show a 24-hour clock, instead of a 12-hour clock. Default is null.
+      '';
+    };
+
+    system.defaults.clock.ShowAMPM = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show the AM/PM label. Useful if Show24Hour is false. Default is null.
+      '';
+    };
+
+    system.defaults.clock.ShowDayOfMonth = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show the day of the month. Default is null.
+      '';
+    };
+
+    system.defaults.clock.ShowDayOfWeek = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show the day of the week. Default is null.
+      '';
+    };
+
+    system.defaults.clock.ShowDate = mkOption {
+      type = types.nullOr (types.enum [ 0 1 2 ]);
+      default = null;
+      description = ''
+        Show the full date. Default is null.
+
+        0 = Show the date
+        1 = Don't show
+        2 = Don't show
+
+        TODO: I don't know what the difference is between 1 and 2.
+      '';
+    };
+
+    system.defaults.clock.ShowSeconds = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show the clock with second precision, instead of minutes. Default is null.
+      '';
+    };
+
+  };
+}

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -37,9 +37,9 @@
   system.defaults.NSGlobalDomain."com.apple.springing.delay" = 0.0;
   system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" = true;
   system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" = "/System/Library/Sounds/Funk.aiff";
-  system.defaults.clock.Show24Hour = false;
-  system.defaults.clock.ShowDayOfWeek = true;
-  system.defaults.clock.ShowDate = 2;
+  system.defaults.menuExtraClock.Show24Hour = false;
+  system.defaults.menuExtraClock.ShowDayOfWeek = true;
+  system.defaults.menuExtraClock.ShowDate = 2;
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -37,6 +37,9 @@
   system.defaults.NSGlobalDomain."com.apple.springing.delay" = 0.0;
   system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" = true;
   system.defaults.".GlobalPreferences"."com.apple.sound.beep.sound" = "/System/Library/Sounds/Funk.aiff";
+  system.defaults.clock.Show24Hour = false;
+  system.defaults.clock.ShowDayOfWeek = true;
+  system.defaults.clock.ShowDate = 2;
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";
@@ -102,6 +105,9 @@
     grep "defaults write -g 'com.apple.springing.delay' -float 0.0" ${config.out}/activate-user
     grep "defaults write -g 'com.apple.swipescrolldirection' -bool YES" ${config.out}/activate-user
     grep "defaults write .GlobalPreferences 'com.apple.sound.beep.sound' -string '/System/Library/Sounds/Funk.aiff'" ${config.out}/activate-user
+    grep "defaults write com.apple.menuextra.clock 'Show24Hour' -bool NO" ${config.out}/activate-user
+    grep "defaults write com.apple.menuextra.clock 'ShowDayOfWeek' -bool YES" ${config.out}/activate-user
+    grep "defaults write com.apple.menuextra.clock 'ShowDate' -int 2" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'autohide-delay' -float 0.24" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'appswitcher-all-displays' -bool NO" ${config.out}/activate-user
     grep "defaults write com.apple.dock 'orientation' -string 'left'" ${config.out}/activate-user


### PR DESCRIPTION
Expose menubar clock preferences through nix-darwin.

Works locally (apple silicon, Mac 13.3.1).

## Questions

1. Does anyone know what the difference is between
```
defaults write com.apple.menuextra.clock ShowDate -int 1
```
and
```
defaults write com.apple.menuextra.clock ShowDate -int 2
```
?
2. Is this the expected way to organise the nix-darwin namespace (`system.defaults.clock.xyz`) vs the actual namespace (`com.apple.menuextra.clock.xyz`)?

Edit: Technically, from the name "clock" it's not clear that this is about the clock in the menubar. That's an argument against the hierarchy I chose.