### PR TITLE
feat(services.skhd): improve skhd performance by setting SHELL to dash

### DIFF
--- a/modules/services/skhd/default.nix
+++ b/modules/services/skhd/default.nix
@@ -34,6 +34,7 @@ in
 
     launchd.user.agents.skhd = {
       path = [ config.environment.systemPath ];
+      environment."SHELL" = "${pkgs.dash}/bin/dash";
 
       serviceConfig.ProgramArguments = [ "${cfg.package}/bin/skhd" ]
         ++ optionals (cfg.skhdConfig != "") [ "-c" "/etc/skhdrc" ];


### PR DESCRIPTION
Ensure fast performance by setting the skhd shell to `dash`<sup>[[1]](https://wiki.archlinux.org/title/Dash)</sup>.

I was experiencing very slow performance from `skhd` (moving between windows time ~= 1 sec), but I tried the solution [outlined in this GitHub issue](https://github.com/koekeishiya/skhd/issues/42#issuecomment-401880327) in the `skhd` repo, and it significantly improved performance (no noticeable delay).

Tested on Macbook Pro, M1 Max, OS v.12.6.5 (Monterey).