### PR TITLE
nix: Fix registry extra attrs not being applied

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -444,13 +444,14 @@ in
             };
             config = {
               from = mkDefault { type = "indirect"; id = name; };
-              to = mkIf (config.flake != null) (mkDefault
+              to = mkIf (config.flake != null) (mkDefault (
                 {
                   type = "path";
                   path = config.flake.outPath;
                 } // filterAttrs
-                (n: _: n == "lastModified" || n == "rev" || n == "revCount" || n == "narHash")
-                config.flake);
+                  (n: _: n == "lastModified" || n == "rev" || n == "revCount" || n == "narHash")
+                  config.flake
+              ));
             };
           }
         ));


### PR DESCRIPTION
This was

    mkDefault { } // filterAttrs () x

which is interpreted as

    (mkDefault { }) // (filterAttrs () x)

but the intention is

    mkDefault ({ } // filterAttrs () x)

Resulting in lastModified, rev, etc. not being included. This is essentially just bringing this clause up-to-date with the one from NixOS.