### PR TITLE
Manage SSH authorized keys for users

### DIFF
--- a/modules/lib/write-text.nix
+++ b/modules/lib/write-text.nix
@@ -45,6 +45,14 @@ in
       '';
     };
 
+    copy = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether this file should be copied instead of symlinking.
+      '';
+    };
+
     knownSha256Hashes = mkOption {
       internal = true;
       type = types.listOf types.str;

--- a/modules/programs/ssh/default.nix
+++ b/modules/programs/ssh/default.nix
@@ -94,7 +94,7 @@ let
   {
     "ssh/sshd_config.d/101-authorized-keys.conf" = {
       copy = true;
-      text = "AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u";
+      text = "AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u\n";
     };
   };
 in

--- a/modules/programs/ssh/default.nix
+++ b/modules/programs/ssh/default.nix
@@ -47,6 +47,7 @@ let
         hostNames = mkDefault [ name ];
       };
     };
+  # Taken from: https://github.com/NixOS/nixpkgs/blob/f4aa6afa5f934ece2d1eb3157e392d056be01617/nixos/modules/services/networking/ssh/sshd.nix#L46-L93
   userOptions = {
 
     options.openssh.authorizedKeys = {

--- a/modules/programs/ssh/default.nix
+++ b/modules/programs/ssh/default.nix
@@ -80,6 +80,7 @@ let
   };
   authKeysFiles = let
     mkAuthKeyFile = u: nameValuePair "ssh/authorized_keys.d/${u.name}" {
+      copy = true;
       text = ''
         ${concatStringsSep "\n" u.openssh.authorizedKeys.keys}
         ${concatMapStrings (f: readFile f + "\n") u.openssh.authorizedKeys.keyFiles}

--- a/modules/programs/ssh/default.nix
+++ b/modules/programs/ssh/default.nix
@@ -90,6 +90,13 @@ let
       length u.openssh.authorizedKeys.keys != 0 || length u.openssh.authorizedKeys.keyFiles != 0
     ));
   in listToAttrs (map mkAuthKeyFile usersWithKeys);
+  authKeysConfiguration = 
+  {
+    "ssh/sshd_config.d/101-authorized-keys.conf" = {
+      copy = true;
+      text = "AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u";
+    };
+  };
 in
 
 {
@@ -128,7 +135,7 @@ in
       message = "knownHost ${name} must contain either a publicKey or publicKeyFile";
     });
     
-    environment.etc = authKeysFiles //
+    environment.etc = authKeysFiles // authKeysConfiguration //
       { "ssh/ssh_known_hosts".text = (flip (concatMapStringsSep "\n") knownHosts
         (h: assert h.hostNames != [];
           concatStringsSep "," h.hostNames + " "

--- a/modules/system/etc.nix
+++ b/modules/system/etc.nix
@@ -57,6 +57,10 @@ in
         if [ ! -e "$d" ]; then
           mkdir -p "$d"
         fi
+        if [ -e "$f".copy ]; then
+          cp "$f" "$l"
+          continue
+        fi
         if [ -e "$l" ]; then
           if [ "$(readlink "$l")" != "$f" ]; then
             if ! grep -q /etc/static "$l"; then
@@ -65,11 +69,7 @@ in
               for h in ''${etcSha256Hashes["$l"]}; do
                 if [ "$o" = "$h" ]; then
                   mv "$l" "$l.orig"
-                  if [ -e "$f".copy ]; then
-                    cp "$f" "$l"
-                  else
-                    ln -s "$f" "$l"
-                  fi
+                  ln -s "$f" "$l"
                   break
                 else
                   h=
@@ -83,11 +83,7 @@ in
             fi
           fi
         else
-          if [ -e "$f".copy ]; then
-            cp "$f" "$l"
-          else
-            ln -s "$f" "$l"
-          fi
+          ln -s "$f" "$l"
         fi
       done
 

--- a/tests/programs-ssh.nix
+++ b/tests/programs-ssh.nix
@@ -6,9 +6,15 @@
       publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
     };
   };
+  users.users.foo.openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAA..." ];
 
   test = ''
     echo >&2 "checking for github.com in /etc/ssh/ssh_known_hosts"
     grep 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' ${config.out}/etc/ssh/ssh_known_hosts
+
+    echo >&2 "checking for authorized keys for foo in /etc/ssh/authorized_keys.d/foo"
+    grep 'ssh-ed25519 AAAA...' ${config.out}/etc/ssh/authorized_keys.d/foo
+    echo >&2 "checking for authorized keys' path in /etc/ssh/sshd_config.d/101-authorized-keys.conf"
+    grep 'AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u' ${config.out}/etc/ssh/sshd_config.d/101-authorized-keys.conf
   '';
 }


### PR DESCRIPTION
Resolves #152 

Example configuration:
```nix
{ config, pkgs, ... }:
{
  users.users.foo.openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAA..." ];
}
```