### PR TITLE
Add option to pam module to use pam_reattach

### DIFF
--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -1,62 +1,91 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
+{ config
+, lib
+, pkgs
+, ...
+}:
+with lib; let
   cfg = config.security.pam;
-
-  # Implementation Notes
-  #
-  # We don't use `environment.etc` because this would require that the user manually delete
-  # `/etc/pam.d/sudo` which seems unwise given that applying the nix-darwin configuration requires
-  # sudo. We also can't use `system.patchs` since it only runs once, and so won't patch in the
-  # changes again after OS updates (which remove modifications to this file).
-  #
-  # As such, we resort to line addition/deletion in place using `sed`. We add a comment to the
-  # added line that includes the name of the option, to make it easier to identify the line that
-  # should be deleted when the option is disabled.
-  mkSudoTouchIdAuthScript = isEnabled:
-  let
-    file   = "/etc/pam.d/sudo";
-    option = "security.pam.enableSudoTouchIdAuth";
-    sed = "${pkgs.gnused}/bin/sed";
-  in ''
-    ${if isEnabled then ''
-      # Enable sudo Touch ID authentication, if not already enabled
-      if ! grep 'pam_tid.so' ${file} > /dev/null; then
-        ${sed} -i '2i\
-      auth       sufficient     pam_tid.so # nix-darwin: ${option}
-        ' ${file}
-      fi
-    '' else ''
-      # Disable sudo Touch ID authentication, if added by nix-darwin
-      if grep '${option}' ${file} > /dev/null; then
-        ${sed} -i '/${option}/d' ${file}
-      fi
-    ''}
-  '';
 in
-
 {
   options = {
-    security.pam.enableSudoTouchIdAuth = mkEnableOption ''
-      Enable sudo authentication with Touch ID
+    security.pam = {
+      enableSudoTouchIdAuth = mkEnableOption ''
+        Enable sudo authentication with Touch ID
 
-      When enabled, this option adds the following line to /etc/pam.d/sudo:
+        When enabled, this option adds the following line to /etc/pam.d/sudo:
 
-          auth       sufficient     pam_tid.so
+            auth       sufficient     pam_tid.so
 
-      (Note that macOS resets this file when doing a system update. As such, sudo
-      authentication with Touch ID won't work after a system update until the nix-darwin
-      configuration is reapplied.)
-    '';
+        (Note that macOS resets this file when doing a system update. As such, sudo
+        authentication with Touch ID won't work after a system update until the nix-darwin
+        configuration is reapplied.)
+      '';
+      enablePamReattach = mkEnableOption ''
+        Enable re-attaching a program to the user's bootstrap session.
+
+        This allows programs like tmux and screen that run in the background to
+        survive across user sessions to work with PAM services that are tied to the
+        bootstrap session.
+
+        When enabled, this option adds the following line to /etc/pam.d/sudo:
+
+            auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
+
+        (Note that macOS resets this file when doing a system update. As such, sudo
+        authentication with Touch ID won't work after a system update until the nix-darwin
+        configuration is reapplied.)
+      '';
+      sudoPamFile = mkOption {
+        type = types.path;
+        default = "/etc/pam.d/sudo";
+        description = ''
+          Defines the path to the sudo file inside pam.d directory.
+        '';
+      };
+    };
   };
 
   config = {
-    system.activationScripts.pam.text = ''
-      # PAM settings
-      echo >&2 "setting up pam..."
-      ${mkSudoTouchIdAuthScript cfg.enableSudoTouchIdAuth}
-    '';
+    environment.pathsToLink = optional cfg.enablePamReattach "/lib/pam";
+
+    system.patches =
+      if cfg.enableSudoTouchIdAuth && cfg.enablePamReattach
+      then [(pkgs.writeText "pam-reattach-tid.patch" ''
+          --- a/etc/pam.d/sudo
+          +++ b/etc/pam.d/sudo
+          @@ -1,4 +1,6 @@
+           # sudo: auth account password session
+          +auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so
+          +auth       sufficient     pam_tid.so
+           auth       sufficient     pam_smartcard.so
+           auth       required       pam_opendirectory.so
+           account    required       pam_permit.so
+        '')
+      ]
+      else if cfg.enableSudoTouchIdAuth && !cfg.enablePamReattach
+      then [(pkgs.writeText "pam-tid.patch" ''
+          --- a/etc/pam.d/sudo
+          +++ b/etc/pam.d/sudo
+          @@ -1,4 +1,5 @@
+           # sudo: auth account password session
+          +auth       sufficient     pam_tid.so
+           auth       sufficient     pam_smartcard.so
+           auth       required       pam_opendirectory.so
+           account    required       pam_permit.so
+        '')
+      ]
+      else if !cfg.enableSudoTouchIdAuth && cfg.enablePamReattach
+      then [(pkgs.writeText "pam-reattach.patch" ''
+          --- a/etc/pam.d/sudo
+          +++ b/etc/pam.d/sudo
+          @@ -1,4 +1,5 @@
+           # sudo: auth account password session
+          +auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so
+           auth       sufficient     pam_smartcard.so
+           auth       required       pam_opendirectory.so
+           account    required       pam_permit.so
+        '')
+      ]
+      else [ ];
   };
 }

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -56,7 +56,6 @@ in
       ${cfg.activationScripts.groups.text}
       ${cfg.activationScripts.users.text}
       ${cfg.activationScripts.applications.text}
-      ${cfg.activationScripts.pam.text}
       ${cfg.activationScripts.patches.text}
       ${cfg.activationScripts.etc.text}
       ${cfg.activationScripts.defaults.text}


### PR DESCRIPTION
This PR enables sudo authentication via Touch ID inside tmux as it's been described in the following [article](https://www.hein.dev/blog/2020/01/using-touchid-tmux-pam_reattach/).

I've tested it on my M1 Macbook Air, and went through a MacOS upgrade with this change.
As expected the changes to `/etc/pam.d/sudoers` was lost on the upgrade, but a quick `darwin-rebuild switch` later, things were working correctly once more.

Closes #606, and mostly derived from the code of @sestrella and @maljub01 