### PR TITLE
Add name, include-date options

### DIFF
--- a/modules/system/defaults/screencapture.nix
+++ b/modules/system/defaults/screencapture.nix
@@ -4,6 +4,13 @@ with lib;
 
 {
   options = {
+    system.defaults.screencapture.name = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+          The filename which screencaptures should be written. The default is "Screenshot"
+        '';
+    };
 
     system.defaults.screencapture.location = mkOption {
       type = types.nullOr types.str;
@@ -26,6 +33,14 @@ with lib;
       default = null;
       description = ''
           Disable drop shadow border around screencaptures. The default is false.
+        '';
+    };
+
+    system.defaults.screencapture.include-date = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+          Include date and time in screenshot filenames. The default is true.
         '';
     };
   };


### PR DESCRIPTION
- `include-date` see https://macos-defaults.com/screenshots/include-date.html
- For the `name` option, I can't find any docs, but it works after testing. 😄