### PR TITLE
buildkite-agent: fix launchd daemon environment

### DIFF
--- a/modules/services/buildkite-agents.nix
+++ b/modules/services/buildkite-agents.nix
@@ -228,7 +228,8 @@ in
       { path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils pkgs.darwin.DarwinTools ];
         environment = {
           HOME = cfg.dataDir;
-        }// (if config.nix.useDaemon then { NIX_REMOTE = "daemon"; } else {});
+          inherit (config.environment.variables) NIX_SSL_CERT_FILE;
+        } // (if config.nix.useDaemon then { NIX_REMOTE = "daemon"; } else {});
 
         ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
         ##     don't end up in the Nix store.


### PR DESCRIPTION
Add missing 'NIX_SSL_CERT_FILE'