### PR TITLE
Use LocalHostName in darwin-rebuild with a flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,10 @@ If you don't have an existing `configuration.nix`, you can run the following com
 mkdir -p ~/.config/nix-darwin
 cd ~/.config/nix-darwin
 nix flake init -t nix-darwin
+sed -i '' "s/simple/$(scutil --get LocalHostName)/" flake.nix
 ```
 
-Make sure to replace all occurrences of `simple` with your hostname which you can find by running `scutil --get LocalHostName`.
-
-> NOTE: Make sure to change `nixpkgs.hostPlatform` to `aarch64-darwin` if you are using Apple Silicon.
+Make sure to change `nixpkgs.hostPlatform` to `aarch64-darwin` if you are using Apple Silicon.
 
 </details>
 
@@ -120,7 +119,7 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
 
 Make sure to replace `Johns-MacBook` with your hostname which you can find by running `scutil --get LocalHostName`.
 
-> NOTE: Make sure to set `nixpkgs.hostPlatform` in your `configuration.nix` to either `x86_64-darwin` (Intel) or `aarch64-darwin` (Apple Silicon).
+Make sure to set `nixpkgs.hostPlatform` in your `configuration.nix` to either `x86_64-darwin` (Intel) or `aarch64-darwin` (Apple Silicon).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cd ~/.config/nix-darwin
 nix flake init -t nix-darwin
 ```
 
-Make sure to replace all occurrences of `simple` with your short hostname which you can find by running `hostname -s`.
+Make sure to replace all occurrences of `simple` with your hostname which you can find by running `scutil --get LocalHostName`.
 
 > NOTE: Make sure to change `nixpkgs.hostPlatform` to `aarch64-darwin` if you are using Apple Silicon.
 
@@ -118,7 +118,7 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
 }
 ```
 
-Make sure to replace `Johns-MacBook` with your short hostname which you can find by running `hostname -s`.
+Make sure to replace `Johns-MacBook` with your hostname which you can find by running `scutil --get LocalHostName`.
 
 > NOTE: Make sure to set `nixpkgs.hostPlatform` in your `configuration.nix` to either `x86_64-darwin` (Intel) or `aarch64-darwin` (Apple Silicon).
 

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -132,7 +132,7 @@ if [ -n "$flake" ]; then
        flakeAttr=${fragment}
     fi
     if [ -z "$flakeAttr" ]; then
-      flakeAttr=$(hostname -s)
+      flakeAttr=$(scutil --get LocalHostName)
     fi
     flakeAttr=darwinConfigurations.${flakeAttr}
 fi


### PR DESCRIPTION
When running `darwin-rebuild switch --flake flake-uri` on other networks (like eduroam), I'm getting issues  since my hostname isn't actually what I expect in my flake config. By using the LocalHostName it won't change suddenly when being on other Wi-Fi:s.

Maybe there's a setting for this I've missed but otherwise I think this could be a reasonable change, if you agree.