### PR TITLE
Document font overriding behaviour

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -26,7 +26,12 @@ in
       type = types.listOf types.path;
       default = [ ];
       example = literalExpression "[ pkgs.dejavu_fonts ]";
-      description = "List of fonts to install.";
+      description = ''
+        List of fonts to install.
+
+        Fonts present in later entries override those with the same filenames
+        in previous ones.
+      '';
     };
   };
 


### PR DESCRIPTION
This just adds the description —  #624 allows font packages with conflicting font file names to coexist, and through the use of `ln -f` selects the latter.

(I've had a patch to apply the `ln -sf` change for a while, but I didn't realize others were hitting this issue, too — I'll work on pushing my improvements up stream.)
