### PR TITLE
nix/linux-builder: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -39,6 +39,7 @@
   ./time
   ./networking
   ./nix
+  ./nix/linux-builder.nix
   ./nix/nix-darwin.nix
   ./nix/nixpkgs.nix
   ./environment

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -175,7 +175,7 @@ in
         default = false;
         description = lib.mdDoc ''
           If set, Nix will use the daemon to perform operations.
-          Use this instead of services.nix-daemon.enable if you don't wan't the
+          Use this instead of services.nix-daemon.enable if you don't want the
           daemon service to be managed for you.
         '';
       };
@@ -790,9 +790,9 @@ in
       ]);
     users.knownGroups = mkIf cfg.configureBuildUsers [ "nixbld" ];
 
-    # Unreladed to use in NixOS module
+    # Unrelated to use in NixOS module
     system.activationScripts.nix-daemon.text = mkIf cfg.useDaemon ''
-      if ! diff /etc/nix/nix.conf /run/current-system/etc/nix/nix.conf &> /dev/null; then
+      if ! diff /etc/nix/nix.conf /run/current-system/etc/nix/nix.conf &> /dev/null || ! diff /etc/nix/machines /run/current-system/etc/nix/machines &> /dev/null; then
           echo "reloading nix-daemon..." >&2
           launchctl kill HUP system/org.nixos.nix-daemon
       fi

--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs) stdenv;
+
+  cfg = config.nix.linux-builder;
+
+  builderWithOverrides = cfg.package.override {
+    modules = [ cfg.modules ];
+  };
+in
+
+{
+  options.nix.linux-builder = {
+    enable = mkEnableOption (lib.mdDoc "Linux builder");
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.darwin.linux-builder;
+      defaultText = "pkgs.darwin.linux-builder";
+      description = lib.mdDoc ''
+        This option specifies the Linux builder to use.
+      '';
+    };
+
+    modules = mkOption {
+      type = types.listOf types.anything;
+      default = [ ];
+      example = literalExpression ''
+        [
+          ({ config, ... }:
+
+          {
+            virtualisation.darwin-builder.hostPort = 22;
+          })
+        ]
+      '';
+      description = lib.mdDoc ''
+        This option specifies extra NixOS modules and configuration for the builder. You should first run the Linux builder
+        without changing this option otherwise you may not be able to build the Linux builder.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [ {
+      assertion = config.nix.settings.trusted-users != [ "root" ] || config.nix.settings.extra-trusted-users != [ ];
+      message = ''
+        Your user or group (@admin) needs to be added to `nix.settings.trusted-users` or `nix.settings.extra-trusted-users`
+        to use the Linux builder.
+      '';
+    } ];
+
+    system.activationScripts.preActivation.text = ''
+      mkdir -p /var/lib/darwin-builder
+    '';
+
+    launchd.daemons.linux-builder = {
+      environment = {
+        inherit (config.environment.variables) NIX_SSL_CERT_FILE;
+      };
+      serviceConfig = {
+        ProgramArguments = [
+          "/bin/sh" "-c"
+          "/bin/wait4path /nix/store &amp;&amp; exec ${builderWithOverrides}/bin/create-builder"
+        ];
+        KeepAlive = true;
+        RunAtLoad = true;
+        WorkingDirectory = "/var/lib/darwin-builder";
+      };
+    };
+
+    environment.etc."ssh/ssh_config.d/100-linux-builder.conf".text = ''
+      Host linux-builder
+        Hostname localhost
+        HostKeyAlias linux-builder
+        Port 31022
+    '';
+
+    nix.distributedBuilds = true;
+
+    nix.buildMachines = [{
+      hostName = "linux-builder";
+      sshUser = "builder";
+      sshKey = "/etc/nix/builder_ed25519";
+      system = "${stdenv.hostPlatform.uname.processor}-linux";
+      supportedFeatures = [ "kvm" "benchmark" "big-parallel" ];
+      publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
+    }];
+
+    nix.settings.builders-use-substitutes = true;
+  };
+}


### PR DESCRIPTION
This PR adds `darwin.builder` as a `launchd` service :tada: 

Depends on https://github.com/NixOS/nixpkgs/pull/236389 as it expects `darwin.builder` to run on port 31022 by default