### PR TITLE
darwin-installer: fix `/run` not getting created

### DIFF
--- a/pkgs/darwin-installer/installer.nix
+++ b/pkgs/darwin-installer/installer.nix
@@ -40,8 +40,8 @@ with lib;
               if ! grep -q '^run\b' /etc/synthetic.conf 2>/dev/null; then
                   echo "setting up /run via /etc/synthetic.conf..."
                   echo -e "run\tprivate/var/run" | sudo tee -a /etc/synthetic.conf >/dev/null
-                  /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B &>/dev/null || true
-                  /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t &>/dev/null || true
+                  sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B &>/dev/null || true
+                  sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t &>/dev/null || true
                   if ! test -L /run; then
                     echo "warning: apfs.util failed to symlink /run"
                   fi


### PR DESCRIPTION
Fixes #648