### PR TITLE
docs: clarify how to use inputs with flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,30 @@ A minimal example of using an existing configuration.nix:
 }
 ```
 
-Inputs from the flake can also be passed to `darwinSystem`, these inputs are then
-accessible as an argument, similar to pkgs and lib inside the configuration.
+Inputs from the flake can also be passed to `darwinSystem`. These inputs are then
+accessible as an argument `inputs`, similar to `pkgs` and `lib`, inside the configuration.
 
 ```nix
 darwin.lib.darwinSystem {
   system = "x86_64-darwin";
-  modules = [ ... ];
+  modules = [ ./configuration.nix ];
   inputs = { inherit darwin dotfiles nixpkgs; };
 }
+# in configuration.nix:
+{ pkgs, lib, inputs }:
+# inputs.darwin, inputs.dotfiles, and inputs.nixpkgs can be accessed here
+```
+
+Alternatively, `specialArgs` could be used:
+
+```nix
+darwin.lib.darwinSystem {
+  system = "x86_64-darwin";
+  modules = [ ./configuration.nix ];
+  specialArgs = { inherit darwin dotfiles nixpkgs; };
+}
+# in configuration.nix:
+{ pkgs, lib, darwin, dotfiles, nixpkgs }:
 ```
 
 Since the installer doesn't work with flakes out of the box yet, nix-darwin will need to


### PR DESCRIPTION
I was pretty confused on how to use `inputs`, and thanks to the [help of some people on #macos:nixos.org](https://matrix.to/#/!lheuhImcToQZYTQTuI:nixos.org/$tYXRDztoqBWcLVHmSSaFuAO4NTVhHz_EZmSsJ5FvLUI?via=nixos.org&via=matrix.org&via=nixos.dev) I was able to get my configuration working using `specialArgs`.

This PR updates the readme to better document how to use `inputs` when using nix-darwin with flakes. It also documents how `specialArgs` could be used to also access things from `configuration.nix`.