### PR TITLE
fonts: fontDir: only warn once about hard links

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -46,13 +46,14 @@ in
     system.activationScripts.fonts.text = optionalString cfg.fontDir.enable ''
       # Set up fonts.
       echo "configuring fonts..." >&2
+      warning_str="Could not create hard link. Nix is probably on another filesystem. Copying the font instead..."
       find -L "$systemConfig/Library/Fonts" -type f -print0 | while IFS= read -rd "" l; do
           font=''${l##*/}
           f=$(readlink -f "$l")
           if [ ! -e "/Library/Fonts/$font" ]; then
               echo "updating font $font..." >&2
               ln -fn -- "$f" /Library/Fonts 2>/dev/null || {
-                echo "Could not create hard link. Nix is probably on another filesystem. Copying the font instead..." >&2
+	      	[[ "$warning_str" != "" ]] && echo "$warning_str" >&2 && unset warning_str
                 rsync -az --inplace "$f" /Library/Fonts
               }
           fi


### PR DESCRIPTION
/nix being on another filesystem is more common than not, so avoid excessively warning for something that is generally expected, and print only once. This warning should not be removed entirely as it provides a useful hint to the user that a file is being duplicated and copied outside of /nix.