### PR TITLE
GHActions: Bump install-nix-action to v22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v22
     - run: |
         nix build ${{ github.event.client_payload.args }} -vL

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v22
     - run: |
         nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
         nix-channel --update

--- a/.github/workflows/update-manual.yml
+++ b/.github/workflows/update-manual.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v20
+      uses: cachix/install-nix-action@v22
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not all workflows were updated but some were, this fixes the inconsistency.