### PR TITLE
Add AppleMenuBarVisibleInFullscreen

### DIFF
--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -6,6 +6,7 @@
   # system.patches = [ ./pam.patch ];
 
   system.defaults.NSGlobalDomain.AppleKeyboardUIMode = 3;
+  system.defaults.NSGlobalDomain.AppleMenuBarVisibleInFullscreen = true;
   system.defaults.NSGlobalDomain.ApplePressAndHoldEnabled = false;
   system.defaults.NSGlobalDomain.InitialKeyRepeat = 10;
   system.defaults.NSGlobalDomain.KeyRepeat = 1;

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -395,7 +395,15 @@ in {
       type = types.nullOr types.bool;
       default = null;
       description = lib.mdDoc ''
-        Whether to autohide the menu bar.  The default is false.
+        Whether to autohide the menu bar on desktop.  The default is false.
+      '';
+    };
+
+    system.defaults.NSGlobalDomain.AppleMenuBarVisibleInFullscreen = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = lib.mdDoc ''
+        Whether to show the menu bar in full screen.  The default is false.
       '';
     };
 


### PR DESCRIPTION
Add `system.defaults.NSGlobalDomain.AppleMenuBarVisibleInFullscreen` to control whether the menu bar is displayed in full screen.

<img width="554" alt="Snipaste_2023-06-20_22-46-06" src="https://github.com/LnL7/nix-darwin/assets/20698483/eee3964f-4ebc-4497-987e-a92e75f25518">
