### PR TITLE
eval-config.nix: readd `lib.mdDoc` temporarily

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -46,6 +46,11 @@ let
     # Added in nixpkgs #136909, adds forward compatibility until 22.03 is deprecated.
     literalExpression = super.literalExpression or super.literalExample;
     literalDocBook = super.literalDocBook or super.literalExample;
+
+    # Removed in nixpkgs #237557, readded to faciliate Markdown transition.
+    mdDoc = text:
+      if ! self.isString text then throw "mdDoc expects a string."
+      else { _type = "mdDoc"; inherit text; };
   });
 
   eval = libExtended.evalModules (builtins.removeAttrs args [ "lib" "inputs" "pkgs" "system" ] // {


### PR DESCRIPTION
Fixes #701. Note that this is *not* a viable long-term solution; currently, all `mdDoc`-tagged documentation is omitted from the manual build entirely(!). We need to move over to the new NixOS Markdown-based documentation generator ASAP; the DocBook output won't live for much longer. I'm working on this and it looks like it won't be too difficult (thanks @pennae for pointing me to [nix-doc-munge](https://github.com/pennae/nix-doc-munge)!), but the changes will be more extensive and it's not going to be possible to maintain simultaneous compatibility with older nixpkgs (at least for the manual build). I'm sending this just to unbreak people's systems while I work on a longer-term solution.