### PR TITLE
tailscale: improve MagicDNS setup

### DIFF
--- a/doc/known-files/2c28f4fe3b4a958cd86b120e7eb799eee6976daa35b228c885f0630c55ef626c
+++ b/doc/known-files/2c28f4fe3b4a958cd86b120e7eb799eee6976daa35b228c885f0630c55ef626c
@@ -1,0 +1,2 @@
+# Added by tailscaled
+nameserver 100.100.100.100

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -140,7 +140,7 @@ in
     in
     [
       # Only ever in NixOS
-      (mkRemovedOptionModule [ "nix" "enable" ] "No `nix-darwin` equivilant to this NixOS option.")
+      (mkRemovedOptionModule [ "nix" "enable" ] "No `nix-darwin` equivalent to this NixOS option.")
       (mkRemovedOptionModule [ "nix" "daemonCPUSchedPolicy" ] (altOption "nix.daemonProcessType"))
       (mkRemovedOptionModule [ "nix" "daemonIOSchedClass" ] (altOption "nix.daemonProcessType"))
       (mkRemovedOptionModule [ "nix" "daemonIOSchedPriority" ] (altOption "nix.daemonIOLowPriority"))

--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -7,13 +7,12 @@ let
 
 in
 {
-  options.services.tailscale = {
-    domain = mkOption {
-      type = types.str;
-      default = "";
-      description = lib.mdDoc "The Tailscale domain. This is displayed at the top left of https://login.tailscale.com/admin, next to the Tailscale logo.";
-    };
+  imports = [
+    (mkRemovedOptionModule [ "services" "tailscale" "domain" ] "Tailscale no longer requires setting the search domain manually.")
+    (mkRemovedOptionModule [ "services" "tailscale" "magicDNS" ] "MagicDNS no longer requires overriding the DNS servers, if this is necessary you can use `services.tailscale.overrideLocalDns`.")
+  ];
 
+  options.services.tailscale = {
     enable = mkEnableOption (lib.mdDoc "Tailscale client daemon");
 
     package = mkOption {
@@ -23,26 +22,32 @@ in
       description = lib.mdDoc "The package to use for tailscale";
     };
 
-    magicDNS = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = lib.mdDoc "Whether to configure networking to work with Tailscale's MagicDNS.";
-      };
+    overrideLocalDns = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = lib.mdDoc ''
+        This option implements `Override local DNS` as it is not yet implemented in Tailscaled-on-macOS.
+
+        To use this option, in the Tailscale control panel:
+          1. at least one DNS server is added
+          2. `Override local DNS` is enabled
+
+        As this option sets 100.100.100.100 as your sole DNS server, if the requirements above are not met,
+        all non-MagicDNS queries WILL fail.
+      '';
     };
   };
 
   config = mkIf cfg.enable {
-    assertions = [ {
-      assertion = !cfg.magicDNS.enable || config.networking.dns != [ "100.100.100.100" ];
+    assertions = [{
+      assertion = !cfg.overrideLocalDns || config.networking.dns == [ "100.100.100.100" ];
       message = ''
-        When MagicDNS is enabled, fallback DNS servers need to be set with `networking.dns`.
+        DNS servers should be configured on the Tailscale control panel when `services.tailscale.overrideLocalDns` is enabled.
 
-        Otherwise, Tailscale will take a long time to connect and all DNS queries
-        will fail until Tailscale has connected.
+        A race condition can occur when DNS servers are set locally, leading to MagicDNS to not work.
       '';
-    } ];
+    }];
 
     environment.systemPackages = [ cfg.package ];
 
@@ -59,13 +64,21 @@ in
       };
     };
 
-    networking = mkIf cfg.magicDNS.enable {
-      dns = [ "100.100.100.100" ];
-      search =
-        if cfg.domain == "" then
-          [ ]
-        else
-          [ "${cfg.domain}.beta.tailscale.net" ];
-    };
+    networking.dns = mkIf cfg.overrideLocalDns [ "100.100.100.100" ];
+
+    # Ensures Tailscale MagicDNS always works even without adding 100.100.100.100 to DNS servers
+    environment.etc."resolver/ts.net".text = "nameserver 100.100.100.100";
+
+    # This file gets created by tailscaled when `Override local DNS` is turned off
+    environment.etc."resolver/ts.net".knownSha256Hashes = [
+      "2c28f4fe3b4a958cd86b120e7eb799eee6976daa35b228c885f0630c55ef626c"
+    ];
+
+    # Cleaning up the .orig file is necessary as any files in /etc/resolver will be used.
+    system.activationScripts.etc.text = mkAfter ''
+      if [ -e /etc/resolver/ts.net.orig ]; then
+        rm /etc/resolver/ts.net.orig
+      fi
+    '';
   };
 }


### PR DESCRIPTION
- Removed `services.tailscale.domain` as Tailscale automatically sets the search domains by creating `/etc/resolver/search.tailscale`
- Fixed MagicDNS when `Override local DNS` is enabled and `100.100.100.100` is not set as a DNS server by creating `/etc/resolver/ts.net` (https://github.com/tailscale/tailscale/issues/8436)
- Removed `services.tailscale.magicDNS` as MagicDNS now works with or without adding `100.100.100.100` as a DNS server
- Added option for implementing `Override local DNS` by setting `100.100.100.100` as the sole DNS server locally until it is implemented in tailscaled (https://github.com/tailscale/tailscale/issues/1338)

cc @sellout 