### PR TITLE
Fix doc revision eval error

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,9 +10,14 @@ let
 
   eval = evalConfig {
     inherit system;
-    modules = [ configuration ];
+    modules = [ configuration nixpkgsRevisionModule ];
     inputs = { inherit nixpkgs; };
   };
+
+  nixpkgsRevisionModule =
+    if nixpkgs?rev && lib.isString nixpkgs.rev
+    then { system.nixpkgsRevision = nixpkgs.rev; }
+    else { };
 
   # The source code of this repo needed by the [un]installers.
   nix-darwin = lib.cleanSource (

--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, baseModules, modules, ... }:
+toplevel@{ config, lib, pkgs, baseModules, modules, ... }:
 
 with lib;
 
@@ -25,7 +25,15 @@ let
     inherit pkgs config;
     version = config.system.darwinVersion;
     revision = config.system.darwinRevision;
-    nixpkgsRevision = config.system.nixpkgsRevision;
+    nixpkgsRevision =
+      if toplevel.options.system.nixpkgsRevision.isDefined
+        then config.system.nixpkgsRevision
+
+        # If user does not use flakes and does not add rev to nixpkgs, we don't
+        # know which revision or even branch they're on. In this case we still want
+        # to link somewhere, so we hope that master hasn't changed too much.
+        else "master";
+
     options =
       let
         scrubbedEval = evalModules {


### PR DESCRIPTION
This fixes

    error: The option `system.nixpkgsRevision' is used but not defined.

While also giving non-flakes users the possibility to pick up a `.rev` from their nixpkgs source automatically if it exists.

`system.nixpkgsRevision` did not get an option default because how bad the missing data is depends on the use case. This might be a little paranoid, admittedly.