### PR TITLE
trezord: Add launchd user agent service module for configuring trezord

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -75,6 +75,7 @@
   ./services/synapse-bt.nix
   ./services/synergy
   ./services/tailscale.nix
+  ./services/trezord.nix
   ./services/wg-quick.nix
   ./services/yabai
   ./services/nextdns

--- a/modules/services/trezord.nix
+++ b/modules/services/trezord.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.trezord;
+in {
+  # Options copied from:
+  # https://github.com/NixOS/nixpkgs/blob/9d6e454b857fb472fa35fc8b098fa5ac307a0d7d/nixos/modules/services/hardware/trezord.nix#L16
+  options = {
+    services.trezord = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Enable Trezor bridge daemon, for use with Trezor hardware wallets.
+        '';
+      };
+
+      emulator.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Enable Trezor emulator support.
+        '';
+       };
+
+      emulator.port = mkOption {
+        type = types.port;
+        default = 21324;
+        description = lib.mdDoc ''
+          Listening port for the Trezor emulator.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    launchd.user.agents.trezord = {
+      serviceConfig = {
+        ProgramArguments = [ "${pkgs.trezord}/bin/trezord-go" ]
+          ++ optionals cfg.emulator.enable [ "-e" (builtins.toString cfg.emulator.port) ];
+        KeepAlive = true;
+        RunAtLoad = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This adds a small module for configuring the trezor-bridge service, trezord. This service enables users to interact with their Trezor hardware wallet through the trezor suite web interface, or to use the device for U2F auth, SSH login, GPG or password mgmt. https://trezor.io/learn/a/what-is-trezor-bridge

The options were copied directly from the nixos service module here: https://github.com/NixOS/nixpkgs/blob/9d6e454b857fb472fa35fc8b098fa5ac307a0d7d/nixos/modules/services/hardware/trezord.nix#L16

The implementation was adapted from the nixos module's systemd service to a launchd user agent.

Tested successfully locally on an Air M2.