### PR TITLE
flake: use `nix-darwin` instead of `darwin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-23.05-darwin";
-    darwin.url = "github:LnL7/nix-darwin/master";
-    darwin.inputs.nixpkgs.follows = "nixpkgs";
+    nix-darwin.url = "github:LnL7/nix-darwin/master";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = inputs@{ self, darwin, nixpkgs }: {
@@ -147,7 +147,7 @@ accessible as an argument `inputs`, similar to `pkgs` and `lib`, inside the conf
 
 ```nix
 # in flake.nix
-darwin.lib.darwinSystem {
+nix-darwin.lib.darwinSystem {
   modules = [ ./configuration.nix ];
   specialArgs = { inherit inputs; };
 }
@@ -156,7 +156,7 @@ darwin.lib.darwinSystem {
 ```nix
 # in configuration.nix
 { pkgs, lib, inputs }:
-# inputs.self, inputs.darwin, and inputs.nixpkgs can be accessed here
+# inputs.self, inputs.nix-darwin, and inputs.nixpkgs can be accessed here
 ```
 
 ## Manual Install

--- a/modules/examples/flake/flake.nix
+++ b/modules/examples/flake/flake.nix
@@ -3,11 +3,11 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    darwin.url = "github:LnL7/nix-darwin";
-    darwin.inputs.nixpkgs.follows = "nixpkgs";
+    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, darwin, nixpkgs }:
+  outputs = inputs@{ self, nix-darwin, nixpkgs }:
   let
     configuration = { pkgs, ... }: {
       # List packages installed in system profile. To search by name, run:
@@ -38,7 +38,7 @@
   {
     # Build darwin flake using:
     # $ darwin-rebuild build --flake .#simple
-    darwinConfigurations."simple" = darwin.lib.darwinSystem {
+    darwinConfigurations."simple" = nix-darwin.lib.darwinSystem {
       modules = [ configuration ];
     };
 


### PR DESCRIPTION
After #723, `nix-darwin` no longer uses the name of the flake input (previously using `darwin`), which means users can use any name they like. One benefit for users using `nix-darwin` instead of `darwin` as the name of their flake input is if they generate `nix.registry` entries from `inputs` (like [`nix.generateRegistryFromInputs`](https://github.com/gytis-ivaskevicius/flake-utils-plus/blob/master/lib/options.nix) from `flake-utils-plus.darwinModules.autoGenFromInputs`), then their registry will have `nix-darwin` pointing to the version used in their configs, rather having both `darwin` and `nix-darwin` in the registry.

Closes https://github.com/NixOS/flake-registry/pull/47