### PR TITLE
Allow `AppleKeyboardUIMode` to be `2`

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -57,7 +57,7 @@ in {
     };
 
     system.defaults.NSGlobalDomain.AppleKeyboardUIMode = mkOption {
-      type = types.nullOr (types.enum [ 3 ]);
+      type = types.nullOr (types.enum [ 2 3 ]);
       default = null;
       description = lib.mdDoc ''
         Configures the keyboard control behavior.  Mode 3 enables full keyboard control.


### PR DESCRIPTION
This is the value of the following setting, when enabled:

![image](https://github.com/LnL7/nix-darwin/assets/921609/4846046f-ea59-4bc1-85ef-c908267c2466)
