### PR TITLE
use `types.lines` for yabai.extraConfig option

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -62,7 +62,7 @@ in
     };
 
     services.yabai.extraConfig = mkOption {
-      type = str;
+      type = lines;
       default = "";
       example = literalExpression ''
         yabai -m rule --add app='System Preferences' manage=off


### PR DESCRIPTION
This closes #729 by changing the type of the `services.yabai.extraConfig` option from `str` to `lines`. This allows defining `extraConfig` in multiple places in your config, with the final value being all definitions concatenated with `\n`.