### PR TITLE
eval-config: set `class`

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -16,6 +16,7 @@ let
   };
 
   eval = lib.evalModules (builtins.removeAttrs args [ "lib" ] // {
+    class = "darwin";
     modules = modules ++ [ argsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;
   });

--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -11,9 +11,9 @@ let
   regularConfig = config;
 
   argsModule = {
-    config._module.args = regularConfig._module.args // {
+    config._module.args = lib.mkForce (regularConfig._module.args // {
       modules = [ ];
-    };
+    });
   };
 
   /* For the purpose of generating docs, evaluate options with each derivation
@@ -28,8 +28,9 @@ let
     inherit (config.system) nixpkgsRevision;
     options =
       let
-        scrubbedEval = evalModules {
-          modules = baseModules ++ [ argsModule ];
+        scrubbedEval = import ../../eval-config.nix {
+          inherit lib;
+          modules = [ argsModule ];
           specialArgs = { pkgs = scrubDerivations "pkgs" pkgs; };
         };
         scrubDerivations = namePrefix: pkgSet: mapAttrs


### PR DESCRIPTION
See [the Nixpkgs manual]. This allows modules to declare themselves as being only for NixOS or nix-darwin, reducing compatibility risks. Unmarked modules will continue to behave as before. Technically a breaking change, but any configuration importing a module explicitly marked as NixOS-specific was probably broken already.

[the Nixpkgs manual]: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-param-class