### PR TITLE
eternal-terminal: add module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -53,6 +53,7 @@
   ./services/cachix-agent.nix
   ./services/dnsmasq.nix
   ./services/emacs.nix
+  ./services/eternal-terminal.nix
   ./services/gitlab-runner.nix
   ./services/hercules-ci-agent
   ./services/ipfs.nix

--- a/modules/services/eternal-terminal.nix
+++ b/modules/services/eternal-terminal.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.eternal-terminal;
+in {
+  options = {
+    services.eternal-terminal = {
+
+      enable = mkEnableOption (lib.mdDoc "Eternal Terminal server");
+
+      package = mkOption {
+        type = types.path;
+        default = pkgs.eternal-terminal;
+        defaultText = "pkgs.eternal-terminal";
+        description = lib.mdDoc
+          "This option specifies the eternal-terminal package to use.";
+      };
+
+      port = mkOption {
+        default = 2022;
+        type = types.port;
+        description = lib.mdDoc ''
+          The port the server should listen on. Will use the server's default (2022) if not specified.
+
+          Make sure to open this port in the firewall if necessary.
+        '';
+      };
+
+      verbosity = mkOption {
+        default = 0;
+        type = types.enum (lib.range 0 9);
+        description = lib.mdDoc ''
+          The verbosity level (0-9).
+        '';
+      };
+
+      silent = mkOption {
+        default = false;
+        type = types.bool;
+        description = lib.mdDoc ''
+          If enabled, disables all logging.
+        '';
+      };
+
+      logSize = mkOption {
+        default = 20971520;
+        type = types.int;
+        description = lib.mdDoc ''
+          The maximum log size.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    # We need to ensure the et package is fully installed because
+    # the (remote) et client runs the `etterminal` binary when it
+    # connects.
+    environment.systemPackages = [ cfg.package ];
+
+    launchd.daemons.eternal-terminal = {
+      path = [ cfg.package ];
+      serviceConfig = {
+        ProgramArguments = [
+          "${cfg.package}/bin/etserver"
+          "--daemon"
+          "--cfgfile=${
+            pkgs.writeText "et.cfg" ''
+              ; et.cfg : Config file for Eternal Terminal
+              ;
+
+              [Networking]
+              port = ${toString cfg.port}
+
+              [Debug]
+              verbose = ${toString cfg.verbosity}
+              silent = ${if cfg.silent then "1" else "0"}
+              logsize = ${toString cfg.logSize}
+            ''
+          }"
+        ];
+        KeepAlive = true;
+        RunAtLoad = true;
+        HardResourceLimits.NumberOfFiles = 4096;
+        SoftResourceLimits.NumberOfFiles = 4096;
+      };
+    };
+  };
+  meta.maintainers = [ lib.maintainers.ryane or "ryane" ];
+}

--- a/modules/services/eternal-terminal.nix
+++ b/modules/services/eternal-terminal.nix
@@ -65,7 +65,6 @@ in {
       serviceConfig = {
         ProgramArguments = [
           "${cfg.package}/bin/etserver"
-          "--daemon"
           "--cfgfile=${
             pkgs.writeText "et.cfg" ''
               ; et.cfg : Config file for Eternal Terminal
@@ -81,7 +80,7 @@ in {
             ''
           }"
         ];
-        KeepAlive = true;
+        KeepAlive = false;
         RunAtLoad = true;
         HardResourceLimits.NumberOfFiles = 4096;
         SoftResourceLimits.NumberOfFiles = 4096;

--- a/release.nix
+++ b/release.nix
@@ -118,6 +118,7 @@ let
     tests.services-nix-daemon = makeTest ./tests/services-nix-daemon.nix;
     tests.sockets-nix-daemon = makeTest ./tests/sockets-nix-daemon.nix;
     tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
+    tests.services-eternal-terminal = makeTest ./tests/services-eternal-terminal.nix;
     tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
     tests.services-nextdns = makeTest ./tests/services-nextdns.nix;
     tests.services-ofborg = makeTest ./tests/services-ofborg.nix;

--- a/tests/services-eternal-terminal.nix
+++ b/tests/services-eternal-terminal.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  eternal-terminal = pkgs.runCommand "eternal-terminal-0.0.0" { } "mkdir $out";
+
+in {
+  services.eternal-terminal.enable = true;
+  services.eternal-terminal.package = eternal-terminal;
+  services.eternal-terminal.port = 2222;
+  services.eternal-terminal.silent = true;
+
+  test = ''
+    echo >&2 "checking eternal-terminal service in /Library/LaunchDaemons"
+    grep "org.nixos.eternal-terminal" ${config.out}/Library/LaunchDaemons/org.nixos.eternal-terminal.plist
+    grep "${eternal-terminal}/bin/etserver" ${config.out}/Library/LaunchDaemons/org.nixos.eternal-terminal.plist
+  '';
+}


### PR DESCRIPTION
Adds an eternal-terminal module. Much of the implementation is borrowed from the corresponding nixos module:
https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/networking/eternal-terminal.nix