### PR TITLE
Revert "eval-config: set `class`"

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -16,7 +16,6 @@ let
   };
 
   eval = lib.evalModules (builtins.removeAttrs args [ "lib" ] // {
-    class = "darwin";
     modules = modules ++ [ argsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;
   });

--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -11,9 +11,9 @@ let
   regularConfig = config;
 
   argsModule = {
-    config._module.args = lib.mkForce (regularConfig._module.args // {
+    config._module.args = regularConfig._module.args // {
       modules = [ ];
-    });
+    };
   };
 
   /* For the purpose of generating docs, evaluate options with each derivation
@@ -28,9 +28,8 @@ let
     inherit (config.system) nixpkgsRevision;
     options =
       let
-        scrubbedEval = import ../../eval-config.nix {
-          inherit lib;
-          modules = [ argsModule ];
+        scrubbedEval = evalModules {
+          modules = baseModules ++ [ argsModule ];
           specialArgs = { pkgs = scrubDerivations "pkgs" pkgs; };
         };
         scrubDerivations = namePrefix: pkgSet: mapAttrs


### PR DESCRIPTION
Reverts LnL7/nix-darwin#744

22.11 doesn't have this, sigh; should have double-checked. cc @Enzime