### PR TITLE
fonts: reimplement and rename to `fonts.packages`

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -41,9 +41,14 @@ in
       ''
         mkdir -p $out/Library/Fonts
         font_regexp='.*\.\(ttf\|ttc\|otf\|dfont\)'
-        find -L ${toString cfg.fonts} -regex "$font_regexp" -type f -print0 | while IFS= read -rd "" f; do
-            ln -sf "$f" $out/Library/Fonts
-        done
+        while IFS= read -rd "" f; do
+          ln -sf "$f" "$out/Library/Fonts"
+        done < <(
+          find -L ${lib.escapeShellArgs cfg.fonts} \
+            -type f \
+            -regex "$font_regexp" \
+            -print0
+        )
       '';
 
     system.activationScripts.fonts.text = lib.optionalString cfg.fontDir.enable ''

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -7,6 +7,10 @@ in
 {
   imports = [
     (lib.mkRenamedOptionModule [ "fonts" "enableFontDir" ] [ "fonts" "fontDir" "enable" ])
+    (lib.mkRemovedOptionModule [ "fonts" "fonts" ] ''
+      This option has been renamed to `fonts.packages' for consistency with NixOS.
+
+      Note that the implementation now keeps fonts in `/Library/Fonts/Nix Fonts' to allow them to coexist with fonts not managed by nix-darwin; existing fonts will be left directly in `/Library/Fonts' without getting updates and should be manually removed.'')
   ];
 
   options = {
@@ -15,21 +19,16 @@ in
       default = false;
       description = ''
         Whether to enable font management and install configured fonts to
-        {file}`/Library/Fonts`.
-
-        NOTE: removes any manually-added fonts.
+        {file}`/Library/Fonts/Nix Fonts`.
       '';
     };
 
-    fonts.fonts = lib.mkOption {
+    fonts.packages = lib.mkOption {
       type = lib.types.listOf lib.types.path;
       default = [ ];
       example = lib.literalExpression "[ pkgs.dejavu_fonts ]";
       description = ''
         List of fonts to install.
-
-        Fonts present in later entries override those with the same filenames
-        in previous ones.
       '';
     };
   };
@@ -40,48 +39,36 @@ in
       { preferLocalBuild = true; }
       ''
         mkdir -p $out/Library/Fonts
-        font_regexp='.*\.\(ttf\|ttc\|otf\|dfont\)'
+        store_dir=${lib.escapeShellArg builtins.storeDir}
         while IFS= read -rd "" f; do
-          ln -sf "$f" "$out/Library/Fonts"
+          dest="$out/Library/Fonts/Nix Fonts/''${f#"$store_dir/"}"
+          mkdir -p "''${dest%/*}"
+          ln -sf "$f" "$dest"
         done < <(
-          find -L ${lib.escapeShellArgs cfg.fonts} \
+          find -L ${lib.escapeShellArgs cfg.packages} \
             -type f \
-            -regex "$font_regexp" \
+            -regex '.*\.\(ttf\|ttc\|otf\|dfont\)' \
             -print0
         )
       '';
 
     system.activationScripts.fonts.text = lib.optionalString cfg.fontDir.enable ''
-      # Set up fonts.
-      echo "configuring fonts..." >&2
-      find -L "$systemConfig/Library/Fonts" -type f -print0 | while IFS= read -rd "" l; do
-          font=''${l##*/}
-          f=$(readlink -f "$l")
-          if [ ! -e "/Library/Fonts/$font" ]; then
-              echo "updating font $font..." >&2
-              ln -fn -- "$f" /Library/Fonts 2>/dev/null || {
-                echo "Could not create hard link. Nix is probably on another filesystem. Copying the font instead..." >&2
-                rsync -az --inplace "$f" /Library/Fonts
-              }
-          fi
-      done
+      printf >&2 'setting up /Library/Fonts/Nix Fonts...\n'
 
-      if [[ "`sw_vers -productVersion`" < "13.0" ]]; then
-        fontrestore default -n 2>&1 | while read -r f; do
-            case $f in
-                /Library/Fonts/*)
-                    font=''${f##*/}
-                    if [ ! -e "$systemConfig/Library/Fonts/$font" ]; then
-                        echo "removing font $font..." >&2
-                        rm "/Library/Fonts/$font"
-                    fi
-                    ;;
-                /*)
-                    # ignoring unexpected fonts
-                    ;;
-            esac
-        done
-      fi
+      # rsync uses the mtime + size of files to determine whether they
+      # need to be copied by default. This is inadequate for Nix store
+      # paths, but we don't want to use `--checksum` as it makes
+      # activation consistently slow when you have large fonts
+      # installed. Instead, we ensure that fonts are linked according to
+      # their full store paths in `system.build.fonts`, so that any
+      # given font path should only ever have one possible content.
+      ${pkgs.rsync}/bin/rsync \
+        --archive \
+        --copy-links \
+        --delete-during \
+        --delete-missing-args \
+        "$systemConfig/Library/Fonts/Nix Fonts" \
+        '/Library/Fonts/'
     '';
 
   };

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -1,19 +1,17 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.fonts;
 in
 
 {
   imports = [
-    (mkRenamedOptionModule [ "fonts" "enableFontDir" ] [ "fonts" "fontDir" "enable" ])
+    (lib.mkRenamedOptionModule [ "fonts" "enableFontDir" ] [ "fonts" "fontDir" "enable" ])
   ];
 
   options = {
-    fonts.fontDir.enable = mkOption {
-      type = types.bool;
+    fonts.fontDir.enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to enable font management and install configured fonts to
@@ -23,10 +21,10 @@ in
       '';
     };
 
-    fonts.fonts = mkOption {
-      type = types.listOf types.path;
+    fonts.fonts = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
       default = [ ];
-      example = literalExpression "[ pkgs.dejavu_fonts ]";
+      example = lib.literalExpression "[ pkgs.dejavu_fonts ]";
       description = ''
         List of fonts to install.
 
@@ -48,7 +46,7 @@ in
         done
       '';
 
-    system.activationScripts.fonts.text = optionalString cfg.fontDir.enable ''
+    system.activationScripts.fonts.text = lib.optionalString cfg.fontDir.enable ''
       # Set up fonts.
       echo "configuring fonts..." >&2
       find -L "$systemConfig/Library/Fonts" -type f -print0 | while IFS= read -rd "" l; do

--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -6,7 +6,8 @@ in
 
 {
   imports = [
-    (lib.mkRenamedOptionModule [ "fonts" "enableFontDir" ] [ "fonts" "fontDir" "enable" ])
+    (lib.mkRemovedOptionModule [ "fonts" "enableFontDir" ] "No nix-darwin equivalent to this NixOS option. This is not required to install fonts.")
+    (lib.mkRemovedOptionModule [ "fonts" "fontDir" "enable" ] "No nix-darwin equivalent to this NixOS option. This is not required to install fonts.")
     (lib.mkRemovedOptionModule [ "fonts" "fonts" ] ''
       This option has been renamed to `fonts.packages' for consistency with NixOS.
 
@@ -14,21 +15,12 @@ in
   ];
 
   options = {
-    fonts.fontDir.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to enable font management and install configured fonts to
-        {file}`/Library/Fonts/Nix Fonts`.
-      '';
-    };
-
     fonts.packages = lib.mkOption {
       type = lib.types.listOf lib.types.path;
       default = [ ];
       example = lib.literalExpression "[ pkgs.dejavu_fonts ]";
       description = ''
-        List of fonts to install.
+        List of fonts to install into {file}`/Library/Fonts/Nix Fonts`.
       '';
     };
   };
@@ -52,7 +44,7 @@ in
         )
       '';
 
-    system.activationScripts.fonts.text = lib.optionalString cfg.fontDir.enable ''
+    system.activationScripts.fonts.text = ''
       printf >&2 'setting up /Library/Fonts/Nix Fonts...\n'
 
       # rsync uses the mtime + size of files to determine whether they

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -2,8 +2,8 @@
 
 let
   font = pkgs.runCommand "font-0.0.0" {} ''
-    mkdir -p $out/share/fonts
-    touch $out/share/fonts/Font.ttf
+    mkdir -p $out
+    touch $out/Font.ttf
   '';
 in
 

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -9,15 +9,13 @@ in
 
 {
   fonts.fontDir.enable = true;
-  fonts.fonts = [ font ];
+  fonts.packages = [ font ];
 
   test = ''
-    echo "checking fonts in /Library/Fonts" >&2
-    test -e ${config.out}/Library/Fonts/Font.ttf
+    echo "checking fonts in /Library/Fonts/Nix Fonts" >&2
+    test -e "${config.out}/Library/Fonts/Nix Fonts"/*/Font.ttf
 
     echo "checking activation of fonts in /activate" >&2
-    grep "fontrestore default -n 2>&1" ${config.out}/activate
-    grep 'ln -fn ".*" /Library/Fonts' ${config.out}/activate || grep 'rsync -az --inplace ".*" /Library/Fonts' ${config.out}/activate
-    grep 'rm "/Library/Fonts/.*"' ${config.out}/activate
+    grep '/Library/Fonts/Nix Fonts' ${config.out}/activate
   '';
 }

--- a/tests/fonts.nix
+++ b/tests/fonts.nix
@@ -8,7 +8,6 @@ let
 in
 
 {
-  fonts.fontDir.enable = true;
   fonts.packages = [ font ];
 
   test = ''


### PR DESCRIPTION
This uses `/Library/Fonts/Nix Fonts` as suggested by @lilyball, and copies fonts according to their full store path to avoid having to do a slow checksum when you have large fonts (some CJK font packages can be in the hundreds of mebibytes). If adding a few seconds to every activation is considered acceptable, then a simpler flat directory structure could be used instead.

An error is thrown for existing users of `fonts.fonts` that explains the need to manually clean up existing font files.

I'm not completely confident about the dropping of `fonts.fontDir.enable`, but my reading of NixOS's fontconfig code and my old laptop configuration suggest that `fonts.packages` should work even without setting that.

cc @Enzime