### PR TITLE
fish: add default for `babelfishPackage`

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -68,6 +68,7 @@ in
 
       babelfishPackage = mkOption {
         type = types.package;
+        default = pkgs.babelfish;
         description = lib.mdDoc ''
           The babelfish package to use when useBabelfish is
           set to true.

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -37,9 +37,9 @@ let
     '';
 
   babelfishTranslate = path: name:
-    pkgs.runCommand "${name}.fish" {
-      nativeBuildInputs = [ cfg.babelfishPackage ];
-    } "${cfg.babelfishPackage}/bin/babelfish < ${path} > $out;";
+    pkgs.runCommand "${name}.fish" {} ''
+      ${cfg.babelfishPackage}/bin/babelfish < ${path} > $out
+    '';
 
 in
 


### PR DESCRIPTION
This option should probably be dropped but I'd prefer to batch that with using Babelfish by default (or unconditionally, as Home Manager does) so as to avoid multiple independent breaking changes.

Fixes: #632