### PR TITLE
finder: `types.string` -> `types.str`

### DIFF
--- a/modules/system/defaults/finder.nix
+++ b/modules/system/defaults/finder.nix
@@ -30,7 +30,7 @@ with lib;
     };
 
     system.defaults.finder.FXDefaultSearchScope = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       description = lib.mdDoc ''
         Change the default search scope. Use "SCcf" to default to current folder.
@@ -39,7 +39,7 @@ with lib;
     };
 
     system.defaults.finder.FXPreferredViewStyle = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       description = lib.mdDoc ''
         Change the default finder view.


### PR DESCRIPTION
`string` was changed from deprecation warning to error in https://github.com/NixOS/nixpkgs/commit/c59c6b1c57da542b6b4af5d2ac27d1b99e7f0c5e