### PR TITLE
Add support for dfont to the fonts module

### DIFF
--- a/modules/fonts/default.nix
+++ b/modules/fonts/default.nix
@@ -41,7 +41,7 @@ in
       { preferLocalBuild = true; }
       ''
         mkdir -p $out/Library/Fonts
-        font_regexp='.*\.\(ttf\|ttc\|otf\)'
+        font_regexp='.*\.\(ttf\|ttc\|otf\|dfont\)'
         find -L ${toString cfg.fonts} -regex "$font_regexp" -type f -print0 | while IFS= read -rd "" f; do
             ln -sf "$f" $out/Library/Fonts
         done


### PR DESCRIPTION
There aren't actually any dfont-formatted fonts in nixpkgs, but I'm using one in my personal config. This used to work, prior to bc776e4940106a2578998dd3117a76d62ec0a8c, but the font file is now ignored.

Supporting a format that isn't supported by nixpkgs feels a bit weird, but I think it's okay because nixpkgs includes a lot of formats that are not supported on darwin.