### PR TITLE
Use scutil to obtain the default local hostname for flake configs

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -132,7 +132,7 @@ if [ -n "$flake" ]; then
        flakeAttr=${fragment}
     fi
     if [ -z "$flakeAttr" ]; then
-      flakeAttr=$(hostname -s)
+      flakeAttr=$(scutil --get LocalHostName)
     fi
     flakeAttr=darwinConfigurations.${flakeAttr}
 fi


### PR DESCRIPTION
When a VPN is in use (Wireguard in my case), `hostname` can spuriously report the short name of the current host as a partial host name on the VPN network, e.g. `client-100-34-5-1`. Elsewhere in `nix-darwin`, the options for setting the network host name use `scutil`, so this change should ensure that the applied name is reliably used to find the config later.