### PR TITLE
services/yabai: Remove --check-sa and --install-sa flags

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -90,14 +90,7 @@ in
     # TODO: [@cmacrae] Handle removal of yabai scripting additions
     (mkIf (cfg.enableScriptingAddition) {
       launchd.daemons.yabai-sa = {
-        script = ''
-          if [ ! $(${cfg.package}/bin/yabai --check-sa) ]; then
-            ${cfg.package}/bin/yabai --install-sa
-          fi
-
-          ${cfg.package}/bin/yabai --load-sa
-        '';
-
+        script = "${cfg.package}/bin/yabai --load-sa";
         serviceConfig.RunAtLoad = true;
         serviceConfig.KeepAlive.SuccessfulExit = false;
       };


### PR DESCRIPTION
The --check-sa and --install-sa flags were removed in favor of --load-sa as of version 5.0.0 of Yabai.

https://github.com/koekeishiya/yabai/blob/ee0137f37ded4309cb40b7f38817b5abd90fb592/CHANGELOG.md?plain=1#L83