### PR TITLE
time: bury confusing `systemsetup -settimezone` output

### DIFF
--- a/modules/time/default.nix
+++ b/modules/time/default.nix
@@ -11,7 +11,7 @@ let
       echo "${cfg.timeZone} is not a valid timezone. The command 'listtimezones' will show a list of valid time zones." >&2
       false
     fi
-    systemsetup -settimezone "${cfg.timeZone}" > /dev/null
+    systemsetup -settimezone "${cfg.timeZone}" 2>/dev/null 1>&2
   '';
 
 in


### PR DESCRIPTION
Fixes #359

As noted in #359, the timezone is still set correctly despite the error message. So, the message appears to be irrelevant. No one in that thread has reported observing other side effects that may relate.