### PR TITLE
Create $out/darwin-version

### DIFF
--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -135,6 +135,7 @@ in
 
         echo -n "$systemConfig" > $out/systemConfig
 
+        echo -n "$darwinLabel" > $out/darwin-version
         ln -s $darwinVersionJson $out/darwin-version.json
         echo -n "$system" > $out/system
 


### PR DESCRIPTION
This fixes backwards compatibility with code that expects it.

cc @Enzime 