### PR TITLE
darwin-rebuild: add `-H` to sudo for `$systemConfig/activate`

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -215,7 +215,7 @@ if [ "$action" = switch ] || [ "$action" = activate ] || [ "$action" = rollback 
   "$systemConfig/activate-user"
 
   if [ "$USER" != root ]; then
-    sudo "$systemConfig/activate"
+    sudo -H "$systemConfig/activate"
   else
     "$systemConfig/activate"
   fi


### PR DESCRIPTION
> https://github.com/LnL7/nix-darwin/pull/509#issuecomment-1232514860
> It might be nice to add `-H` to the `sudo "$systemConfig/activate"` line as well. A quick skim of the activate script doesn't show any references to `$HOME` but it's still probably a good idea for consistency, especially as someone could write a custom activation script that references this variable or invokes a command that itself consults this variable, and system activation should probably try to avoid any dependency on the initiating user.

Running `nix store diff-closure` in a activation script displays:
```
warning: $HOME ... is not owned by you, falling back to the one defined in the 'passwd' file.
```