### PR TITLE
fix writing values with containers

### DIFF
--- a/modules/launchd/lib.nix
+++ b/modules/launchd/lib.nix
@@ -21,6 +21,7 @@ rec {
     if isNull x then "" else
     if isBool x then pprBool ind x else
     if isInt x then pprInt ind x else
+    if isFloat x then pprFloat ind x else
     if isString x then pprStr ind x else
     if isList x then pprList ind x else
     if isAttrs x then pprAttrs ind x else
@@ -30,6 +31,7 @@ rec {
 
   pprBool = ind: x: pprLiteral ind  (if x then "<true/>" else "<false/>");
   pprInt = ind: x: pprLiteral ind "<integer>${toString x}</integer>";
+  pprFloat = ind: x: pprLiteral ind "<real>${strings.floatToString x}</real>";
   pprStr = ind: x: pprLiteral ind "<string>${x}</string>";
   pprKey = ind: x: pprLiteral ind "<key>${x}</key>";
 

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -1,22 +1,13 @@
 { config, lib, ... }:
 
+with import ../launchd/lib.nix { inherit lib; };
 with lib;
 
 let
   cfg = config.system.defaults;
 
-  boolValue = x: if x then "YES" else "NO";
-
-  writeValue = value:
-    if isBool value then "-bool ${boolValue value}" else
-    if isInt value then "-int ${toString value}" else
-    if isFloat value then "-float ${strings.floatToString value}" else
-    if isString value then "-string '${value}'" else
-    if isList value then "-array ${concatStringsSep " " (map (v: writeValue v)value)}" else
-    throw "invalid value type";
-
   writeDefault = domain: key: value:
-    "defaults write ${domain} '${key}' ${writeValue value}";
+    "defaults write ${domain} '${key}' '${pprExpr "" value}'";
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
 


### PR DESCRIPTION
Currently, the `-array` value for `writeValue` produces incorrect arguments for `defaults` like so

```ts
-array -string 'blah' -string 'blah'
```

Complex container values like `-array` and `-dict` have their own DSL which does not allow specifying all data types. Instead of using the DSL use plist fragments instead. 

The man page for `defaults` writes the following, below. This doesn't give much guidance on passing values with containers, but there's an undocumented feature to pass plist fragments for much more complex use-cases:
https://shadowfile.inode.link/blog/2018/06/advanced-defaults1-usage/#container-types

```
...
     write domain key 'value'
                  Writes value as the value for key in domain.  value must be a property list, and must be enclosed in single quotes.  For example:

                        defaults write com.companyname.appname "Default Color" '(255, 0, 0)'

                  sets the value for Default Color to an array containing the strings 255, 0, 0 (the red, green, and blue components). Note that the key is enclosed in quotation marks because it contains a space.

     write domain 'plist'
                  Overwrites the defaults information in domain with that given as plist.  plist must be a property list representation of a dictionary, and must be enclosed in single quotes.  For example:

                        defaults write com.companyname.appname '{ "Default Color" = (255, 0, 0);
                                                        "Default Font" = Helvetica; }';

                  erases any previous defaults for com.companyname.appname and writes the values for the two names into the defaults system.
...
     -array      Allows the user to specify an array as the value for the given preference key:

                       defaults write somedomain preferenceKey -array element1 element2 element3

                 The specified array overwrites the value of the key if the key was present at the time of the write. If the key was not present, it is created with the new value.

     -array-add  Allows the user to add new elements to the end of an array for a key which has an array as its value. Usage is the same as -array above. If the key was not present, it is created with the specified
                 array as its value.
```

Depended on by:
#619