### PR TITLE
Provide 'supportedFeatures' option to the linux builder module

### DIFF
--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -53,6 +53,16 @@ in
         This sets the corresponding `nix.buildMachines.*.maxJobs` option.
       '';
     };
+
+    supportedFeatures = mkOption {
+      type = types.listOf types.str;
+      default = [ "kvm" "benchmark" "big-parallel" ];
+      description = lib.mdDoc ''
+        This option specifies the list of features supported by the Linux builder.
+
+        This sets the corresponding `nix.buildMachines.*.supportedFeatures` option.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -97,9 +107,8 @@ in
       sshUser = "builder";
       sshKey = "/etc/nix/builder_ed25519";
       system = "${stdenv.hostPlatform.uname.processor}-linux";
-      supportedFeatures = [ "kvm" "benchmark" "big-parallel" ];
       publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
-      inherit (cfg) maxJobs;
+      inherit (cfg) maxJobs supportedFeatures;
     }];
 
     nix.settings.builders-use-substitutes = true;


### PR DESCRIPTION
Hello!

My mac m2 is configured with this project using this configuration:
```nix
  # ...
  nix.linux-builder.enable = true;
  # ...
```
this linux builder is super easy to setup and has been tremendously useful, however I am unable to run nixos tests configured like this:
```nix
# random project flake.nix
{
  inputs = {
    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
  };

  outputs = {
    self,
    nixpkgs-unstable,
    ...
  }: {
    checks.aarch64-darwin = let
      pkgs = nixpkgs-unstable.legacyPackages.aarch64-linux;
    in {
      simple = pkgs.nixosTest {
        name = "simple-test";
        nodes.default = {};
        testScript = ''
          start_all()
          default.wait_for_unit("multi-user.target")
        '';
      };
    };
  };
}
```

due to this error:
```sh
$> nix flake check
error: a 'aarch64-linux' with features {kvm, nixos-test} is required to build '/nix/store/$hash-vm-test-run-simple-tests.drv', but I am a 'aarch64-darwin' with features {benchmark, big-parallel, nixos-test}
```

 By having the ability to change the previous configuration to
 ```nix
  # ...
  nix.linux-builder = {
      enable = true;
      supportedFeatures = ["kvm" "benchmark" "big-parallel" "nixos-test"];
  };
  # ...
```
it would allow me to run the previous command without error.

As a workaround I updated my configuration by duplicating the linux builder
```nix
  nix = {
    linux-builder.enable = true;
    buildMachines = [
      {
        hostName = "linux-builder";
        protocol = "ssh";
        publicHostKey = "pubkey-copied-from-/etc/nix/machines-file";
        sshKey = "/etc/nix/builder_ed25519";
        sshUser = "builder";
        supportedFeatures = ["kvm" "benchmark" "big-parallel" "nixos-test"];
        system = "aarch64-linux";
      }
    ];
  };
```
and it work as expected.

/!\ I didnt test the changes provided in this pull request /!\

Thank you for the project, I hope this help.