### PR TITLE
Fix unbound variable `etcProblems`

### DIFF
--- a/modules/system/etc.nix
+++ b/modules/system/etc.nix
@@ -48,7 +48,7 @@ in
           etc}
       )
 
-      declare -a etcProblems
+      declare -a etcProblems=()
 
       while IFS= read -r -d "" configFile; do
         subPath=''${configFile#"$systemConfig"/etc/}


### PR DESCRIPTION
I have another activationScript which traps errors. Currently `etcProblems` can be unbound.