### PR TITLE
Add security.pki.installCACerts config

### DIFF
--- a/modules/security/pki/default.nix
+++ b/modules/security/pki/default.nix
@@ -21,6 +21,14 @@ in
 
 {
   options = {
+    security.pki.installCACerts = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Whether to enable certificate management with nix-darwin.
+      '';
+    };
+
     security.pki.certificateFiles = mkOption {
       type = types.listOf types.path;
       default = [];
@@ -71,7 +79,7 @@ in
     };
   };
 
-  config = {
+  config = mkIf cfg.installCACerts {
 
     security.pki.certificateFiles = [ "${cacertPackage}/etc/ssl/certs/ca-bundle.crt" ];
 

--- a/modules/services/nix-daemon.nix
+++ b/modules/services/nix-daemon.nix
@@ -63,7 +63,10 @@ in
 
       serviceConfig.EnvironmentVariables = mkMerge [
         config.nix.envVars
-        { NIX_SSL_CERT_FILE = mkDefault config.environment.variables.NIX_SSL_CERT_FILE;
+        {
+          NIX_SSL_CERT_FILE = mkIf
+            (config.environment.variables ? NIX_SSL_CERT_FILE)
+            (mkDefault config.environment.variables.NIX_SSL_CERT_FILE);
           TMPDIR = mkIf (cfg.tempDir != null) cfg.tempDir;
           # FIXME: workaround for https://github.com/NixOS/nix/issues/2523
           OBJC_DISABLE_INITIALIZE_FORK_SAFETY = mkDefault "YES";


### PR DESCRIPTION
Made is possible to disable the management of /etc/ssl/certs/ca-certificates.crt by nix-darwin.

Use case: we distribute corporate CA certificates through our MDM. Keeping them in sync with our shared nix config is a hassle. Instead, we plan on adding a nix-darwin module that sets up a daemon that will periodically export the bundle of certificates from macOS keychain into /etc/ssl/certs/ca-certificates.crt. To make this possible, we need to put /etc/ssl/certs/ca-certificates.crt out of the control of nix-darwin.