### PR TITLE
Install darwin-uninstall by default, which includes the 'empty' config it switches to

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ let
     };
   };
 
-  # The source code of this repo needed by the [un]installers.
+  # The source code of this repo needed by the installer.
   nix-darwin = lib.cleanSource (
     lib.cleanSourceWith {
       # We explicitly specify a name here otherwise `cleanSource` will use the
@@ -30,5 +30,5 @@ in
 
 eval // {
   installer = pkgs.callPackage ./pkgs/darwin-installer { inherit nix-darwin; };
-  uninstaller = pkgs.callPackage ./pkgs/darwin-uninstaller { inherit nix-darwin; };
+  uninstaller = pkgs.callPackage ./pkgs/darwin-uninstaller { };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
     overlays.default = final: prev: {
       inherit (prev.callPackage ./pkgs/nix-tools { }) darwin-rebuild darwin-option darwin-version;
 
-      darwin-uninstaller = prev.callPackage ./pkgs/darwin-uninstaller { nix-darwin = self; };
+      darwin-uninstaller = prev.callPackage ./pkgs/darwin-uninstaller { };
     };
 
     darwinModules.hydra = ./modules/examples/hydra.nix;

--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   nix-tools = pkgs.callPackage ../../pkgs/nix-tools {
@@ -7,22 +7,30 @@ let
     nixPackage = config.nix.package;
   };
 
+  darwin-uninstaller = pkgs.callPackage ../../pkgs/darwin-uninstaller { };
+
   inherit (nix-tools) darwin-option darwin-rebuild darwin-version;
 in
 
 {
-  config = {
+  options = {
+    system.includeUninstaller = lib.mkOption {
+      type = lib.types.bool;
+      internal = true;
+      default = true;
+    };
+  };
 
+  config = {
     environment.systemPackages =
       [ # Include nix-tools by default
         darwin-option
         darwin-rebuild
         darwin-version
-      ];
+      ] ++ lib.optional config.system.includeUninstaller darwin-uninstaller;
 
     system.build = {
       inherit darwin-option darwin-rebuild darwin-version;
     };
-
   };
 }

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ lib, ... }:
 
 with lib;
 


### PR DESCRIPTION
I ran `nix flake check` and that worked, and I ran `nix-build . -A uninstaller`, and that worked, but I haven't tested it beyond that yet.

Closes #804 