### PR TITLE
Power related options (sleep, wake-on-lan, restart after power failure, ...)

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -51,6 +51,8 @@
   ./environment
   ./fonts
   ./launchd
+  ./power
+  ./power/sleep.nix
   ./services/activate-system
   ./services/aerospace
   ./services/autossh.nix

--- a/modules/networking/default.nix
+++ b/modules/networking/default.nix
@@ -9,6 +9,8 @@ let
 
   emptyList = lst: if lst != [] then lst else ["empty"];
 
+  onOff = cond: if cond then "on" else "off";
+
   setNetworkServices = optionalString (cfg.knownNetworkServices != []) ''
     networkservices=$(networksetup -listallnetworkservices)
     ${concatMapStringsSep "\n" (srv: ''
@@ -93,6 +95,16 @@ in
       default = [];
       description = "The list of search paths used when resolving domain names.";
     };
+
+    networking.wakeOnLan.enable = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Enable Wake-on-LAN for the device.
+
+        Battery powered devices may require being connected to power.
+      '';
+    };
   };
 
   config = {
@@ -116,6 +128,10 @@ in
       ''}
 
       ${setNetworkServices}
+
+      ${optionalString (cfg.wakeOnLan.enable != null) ''
+        systemsetup -setWakeOnNetworkAccess '${onOff cfg.wakeOnLan.enable}' &> /dev/null
+      ''}
     '';
 
   };

--- a/modules/power/default.nix
+++ b/modules/power/default.nix
@@ -1,0 +1,47 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.power;
+
+  types = lib.types;
+
+  onOff = cond: if cond then "on" else "off";
+in
+
+{
+  options = {
+    power.restartAfterPowerFailure = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to restart the computer after a power failure.
+      '';
+    };
+
+    power.restartAfterFreeze = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to restart the computer after a system freeze.
+      '';
+    };
+  };
+
+  config = {
+
+    system.activationScripts.power.text = ''
+      echo "configuring power..." >&2
+
+      ${lib.optionalString (cfg.restartAfterPowerFailure != null) ''
+        systemsetup -setRestartPowerFailure \
+          '${onOff cfg.restartAfterPowerFailure}' &> /dev/null
+      ''}
+
+      ${lib.optionalString (cfg.restartAfterFreeze != null) ''
+        systemsetup -setRestartFreeze \
+          '${onOff cfg.restartAfterFreeze}' &> /dev/null
+      ''}
+    '';
+
+  };
+}

--- a/modules/power/sleep.nix
+++ b/modules/power/sleep.nix
@@ -1,0 +1,80 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.power.sleep;
+
+  types = lib.types;
+
+  onOff = cond: if cond then "on" else "off";
+in
+
+{
+  options = {
+    power.sleep.computer = lib.mkOption {
+      type = types.nullOr (types.either types.ints.positive (types.enum ["never"]));
+      default = null;
+      example = "never";
+      description = ''
+        Amount of idle time (in minutes) until the computer sleeps.
+
+        `"never"` disables computer sleeping.
+
+        The system might not be considered idle before connected displays sleep, as
+        per the `power.sleep.display` option.
+      '';
+    };
+
+    power.sleep.display = lib.mkOption {
+      type = types.nullOr (types.either types.ints.positive (types.enum ["never"]));
+      default = null;
+      example = "never";
+      description = ''
+        Amount of idle time (in minutes) until displays sleep.
+
+        `"never"` disables display sleeping.
+      '';
+    };
+
+    power.sleep.harddisk = lib.mkOption {
+      type = types.nullOr (types.either types.ints.positive (types.enum ["never"]));
+      default = null;
+      example = "never";
+      description = ''
+        Amount of idle time (in minutes) until hard disks sleep.
+
+        `"never"` disables hard disk sleeping.
+      '';
+    };
+
+    power.sleep.allowSleepByPowerButton = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether the power button can sleep the computer.
+      '';
+    };
+  };
+
+  config = {
+
+    system.activationScripts.power.text = lib.mkAfter ''
+      ${lib.optionalString (cfg.computer != null) ''
+        systemsetup -setComputerSleep '${toString cfg.computer}' &> /dev/null
+      ''}
+
+      ${lib.optionalString (cfg.display != null) ''
+        systemsetup -setDisplaySleep '${toString cfg.display}' &> /dev/null
+      ''}
+
+      ${lib.optionalString (cfg.harddisk != null) ''
+        systemsetup -setHardDiskSleep '${toString cfg.harddisk}' &> /dev/null
+      ''}
+
+      ${lib.optionalString (cfg.allowSleepByPowerButton != null) ''
+        systemsetup -setAllowPowerButtonToSleepComputer \
+          '${onOff cfg.allowSleepByPowerButton}' &> /dev/null
+      ''}
+    '';
+
+  };
+}

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -67,6 +67,7 @@ in
       ${cfg.activationScripts.nix-daemon.text}
       ${cfg.activationScripts.time.text}
       ${cfg.activationScripts.networking.text}
+      ${cfg.activationScripts.power.text}
       ${cfg.activationScripts.keyboard.text}
       ${cfg.activationScripts.fonts.text}
       ${cfg.activationScripts.nvram.text}

--- a/tests/networking-wakeonlan.nix
+++ b/tests/networking-wakeonlan.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+
+{
+  networking.wakeOnLan.enable = true;
+
+  test = ''
+    echo checking wake on network access settings in /activate >&2
+    grep "systemsetup -setWakeOnNetworkAccess 'on'" ${config.out}/activate
+  '';
+}

--- a/tests/power-restart.nix
+++ b/tests/power-restart.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, ... }:
+
+{
+  power.restartAfterPowerFailure = true;
+  power.restartAfterFreeze = true;
+
+  test = ''
+    echo checking restart power settings in /activate >&2
+    grep "systemsetup -setRestartPowerFailure 'on'" ${config.out}/activate
+    grep "systemsetup -setRestartFreeze 'on'" ${config.out}/activate
+  '';
+}

--- a/tests/power-sleep.nix
+++ b/tests/power-sleep.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, ... }:
+
+{
+  power.sleep.computer = "never";
+  power.sleep.display = 15;
+  power.sleep.harddisk = 5;
+  power.sleep.allowSleepByPowerButton = false;
+
+  test = ''
+    echo checking power sleep settings in /activate >&2
+    grep "systemsetup -setComputerSleep 'never'" ${config.out}/activate
+    grep "systemsetup -setDisplaySleep '15'" ${config.out}/activate
+    grep "systemsetup -setHardDiskSleep '5'" ${config.out}/activate
+    grep "systemsetup -setAllowPowerButtonToSleepComputer 'off'" ${config.out}/activate
+  '';
+}


### PR DESCRIPTION
Hey there, I've recently picked up nix-darwin to configure a Mac Mini M2 as a home server.
I need to configure some power related options that nix-darwin currently does not offer, so I would like to contribute them.

This pull request adds:
- `networking.wakeOnLan.enable`
- `power.restartAfterPowerFailure`
- `power.restartAfterFreeze`
- `power.sleep.computer`
- `power.sleep.display`
- `power.sleep.harddisk`
- `power.sleep.allowSleepByPowerButton`

The options are implemented by means of the `systemsetup` command that also is used for the `time.timezone` option.
I believe this is the command that System Settings uses behind the screen.

I've tried to guess where it made most sense to add the new options.
I've added a new `power` module; maybe it would make more sense to place the restartXXX and sleep options under `system` instead. I'm prepared to move them elsewhere as per your feedback.

Thanks for creating nix-darwin!