### PR TITLE
Add `nix.linux-builder.systems` option to set corresponding `nix.buildMachines.*.systems` option

### DIFF
--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -136,9 +136,9 @@ in
       hostName = "linux-builder";
       sshUser = "builder";
       sshKey = "/etc/nix/builder_ed25519";
-      system = "${stdenv.hostPlatform.uname.processor}-linux";
+      systems = [ "${stdenv.hostPlatform.uname.processor}-linux" ] ++ cfg.systems;
       publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
-      inherit (cfg) maxJobs supportedFeatures systems;
+      inherit (cfg) maxJobs supportedFeatures;
     }];
 
     nix.settings.builders-use-substitutes = true;

--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -57,6 +57,22 @@ in
       '';
     };
 
+    systems = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExpression ''
+        [
+          "x86_64-linux"
+          "aarch64-linux"
+        ]
+      '';
+      description = ''
+        This option specifies system types the build machine can execute derivations on.
+
+        This sets the corresponding `nix.buildMachines.*.systems` option.
+      '';
+    };
+
     maxJobs = mkOption {
       type = types.ints.positive;
       default = 1;
@@ -122,7 +138,7 @@ in
       sshKey = "/etc/nix/builder_ed25519";
       system = "${stdenv.hostPlatform.uname.processor}-linux";
       publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
-      inherit (cfg) maxJobs supportedFeatures;
+      inherit (cfg) maxJobs supportedFeatures systems;
     }];
 
     nix.settings.builders-use-substitutes = true;

--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -59,14 +59,14 @@ in
 
     systems = mkOption {
       type = types.listOf types.str;
-      default = [ ];
+      default = [ "${stdenv.hostPlatform.uname.processor}-linux" ];
       example = literalExpression ''
         [
           "x86_64-linux"
           "aarch64-linux"
         ]
       '';
-      description = ''
+      description = lib.mdDoc ''
         This option specifies system types the build machine can execute derivations on.
 
         This sets the corresponding `nix.buildMachines.*.systems` option.
@@ -136,9 +136,8 @@ in
       hostName = "linux-builder";
       sshUser = "builder";
       sshKey = "/etc/nix/builder_ed25519";
-      systems = [ "${stdenv.hostPlatform.uname.processor}-linux" ] ++ cfg.systems;
       publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
-      inherit (cfg) maxJobs supportedFeatures;
+      inherit (cfg) maxJobs supportedFeatures systems;
     }];
 
     nix.settings.builders-use-substitutes = true;


### PR DESCRIPTION
I've set up my local `linux-builder` to emulate `x86_64-linux` as well as `aarch64-linux` (jury's out as to how well that will work), but I still need to be able to set that option in `/etc/nix/machines`. I've added an option for this in `nix.linux-builder`. Potentially in the future it would be a better idea to simply allow `extraBuilderConfig` or something similar, but I stuck with convention in this PR.