### PR TITLE
fix: user shell path handling

### DIFF
--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -159,19 +159,18 @@ in
 
         u=$(dscl . -read '/Users/${v.name}' UniqueID 2> /dev/null) || true
         u=''${u#UniqueID: }
-        if [ -z "$u" ]; then
-          echo "creating user ${v.name}..." >&2
-          dscl . -create '/Users/${v.name}' UniqueID ${toString v.uid}
-          dscl . -create '/Users/${v.name}' PrimaryGroupID ${toString v.gid}
-          dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
-          dscl . -create '/Users/${v.name}' RealName '${v.description}'
-          dscl . -create '/Users/${v.name}' NFSHomeDirectory '${v.home}'
-          ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
+        if [[ -n "$u" && "$u" -ne "${toString v.uid}" ]]; then
+          echo "[1;31mwarning: existing user '${v.name}' has unexpected uid $u, skipping...[0m" >&2
         else
-          if [ "$u" -ne ${toString v.uid} ]; then
-            echo "[1;31mwarning: existing user '${v.name}' has unexpected uid $u, skipping...[0m" >&2
+          if [ -z "$u" ]; then
+            echo "creating user ${v.name}..." >&2
+            dscl . -create '/Users/${v.name}' UniqueID ${toString v.uid}
+            dscl . -create '/Users/${v.name}' PrimaryGroupID ${toString v.gid}
+            dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
+            dscl . -create '/Users/${v.name}' RealName '${v.description}'
+            dscl . -create '/Users/${v.name}' NFSHomeDirectory '${v.home}'
+            ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
           fi
-
           # Always set the shell path, in case it was updated
           dscl . -create '/Users/${v.name}' UserShell ${lib.escapeShellArg (shellPath v.shell)}
         fi

--- a/tests/users-groups.nix
+++ b/tests/users-groups.nix
@@ -16,7 +16,7 @@
   users.users.foo.isHidden = false;
   users.users.foo.home = "/Users/foo";
   users.users.foo.createHome = true;
-  users.users.foo.shell = "/run/current-system/sw/bin/bash";
+  users.users.foo.shell = pkgs.bashInteractive;
 
   users.users."created.user".uid = 42001;
   users.users."unknown.user".uid = 42002;
@@ -48,6 +48,7 @@
     grep "dscl . -create '/Users/foo' NFSHomeDirectory '/Users/foo'" ${config.out}/activate
     grep "dscl . -create '/Users/foo' UserShell '/run/current-system/sw/bin/bash'" ${config.out}/activate
     grep "dscl . -create '/Users/created.user' UniqueID 42001" ${config.out}/activate
+    grep "dscl . -create '/Users/created.user' UserShell '/sbin/nologin'" ${config.out}/activate
     grep "createhomedir -cu 'foo'" ${config.out}/activate
     grep -qv "dscl . -delete '/Groups/created.user'" ${config.out}/activate
 


### PR DESCRIPTION
Properly detect the binary name (not just /nix/store/...-bash, but include the .../bin/bash), and use the symlinked name which also appears in /etc/shells.