### PR TITLE
fix: tests failing to build on unstable Nix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix corresponding to latest stable channel
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
       with:
-        install_url: https://github.com/nix-community/nix-unstable-installer/releases/download/nix-2.10.0pre20220822_7c3ab57/install
+        install_url: https://releases.nixos.org/nix/nix-2.13.6/install
     - run: nix-build ./release.nix -I nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }} -I darwin=. -A tests
     - run: nix-build ./release.nix -I nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }} -I darwin=. -A manpages
     - run: nix-build ./release.nix -I nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }} -I darwin=. -A examples.simple
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-unstable -I darwin=. -A tests
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-unstable -I darwin=. -A manpages
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-unstable -I darwin=. -A examples.simple
@@ -37,9 +37,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix corresponding to latest stable channel
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
       with:
-        install_url: https://github.com/nix-community/nix-unstable-installer/releases/download/nix-2.10.0pre20220822_7c3ab57/install
+        install_url: https://releases.nixos.org/nix/nix-2.13.6/install
         nix_path: nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }}
     - name: Install ${{ env.CURRENT_STABLE_CHANNEL }} channel
       run: |
@@ -82,7 +82,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
     - name: Install nixpkgs-unstable channel
@@ -126,9 +126,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix version corresponding to latest stable channel
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
       with:
-        install_url: https://github.com/nix-community/nix-unstable-installer/releases/download/nix-2.10.0pre20220822_7c3ab57/install
+        install_url: https://releases.nixos.org/nix/nix-2.13.6/install
     - name: Install nix-darwin
       run: |
         mkdir -p ~/.config/nix-darwin
@@ -209,7 +209,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v23
     - name: Install nix-darwin
       run: |
         mkdir -p ~/.config/nix-darwin


### PR DESCRIPTION
Use Nix 2.13.6 which is the default version for NixOS 23.05.