### PR TITLE
users: fix `forceRecreate` bash comparison

### DIFF
--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -92,7 +92,7 @@ in
         ${optionalString cfg.forceRecreate ''
           g=$(dscl . -read '/Groups/${v.name}' PrimaryGroupID 2> /dev/null) || true
           g=''${g#PrimaryGroupID: }
-          if [ "$g" -eq ${toString v.gid} ]; then
+          if [[ "$g" -eq ${toString v.gid} ]]; then
             echo "deleting group ${v.name}..." >&2
             dscl . -delete '/Groups/${v.name}' 2> /dev/null
           else
@@ -141,7 +141,7 @@ in
         ${optionalString cfg.forceRecreate ''
           u=$(dscl . -read '/Users/${v.name}' UniqueID 2> /dev/null) || true
           u=''${u#UniqueID: }
-          if [ "$u" -eq ${toString v.uid} ]; then
+          if [[ "$u" -eq ${toString v.uid} ]]; then
             echo "deleting user ${v.name}..." >&2
             dscl . -delete '/Users/${v.name}' 2> /dev/null
           else


### PR DESCRIPTION
Fixes an issue when the group or user doesn't already exist.

```
/nix/store/nbnhpscrj78yfpv0537acjzsi8blkvva-darwin-system-24.05pre-git+darwin4.4b9b83d/activate: line 733: [: : integer expression expected
```
https://github.com/nix-community/infra/actions/runs/7079905777/job/19267084113#step:5:184
