### PR TITLE
checks: disable `nixGarbageCollector` for multi-user

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -240,7 +240,7 @@ in
       (mkIf (config.nix.useDaemon && cfg.verifyBuildUsers) buildUsers)
       (mkIf (!config.nix.useDaemon) singleUser)
       nixStore
-      (mkIf (config.nix.gc.automatic && config.nix.gc.user == null) nixGarbageCollector)
+      (mkIf (!config.nix.useDaemon && config.nix.gc.automatic && config.nix.gc.user == null) nixGarbageCollector)
       (mkIf (config.nix.optimise.automatic && config.nix.optimise.user == null) nixStoreOptimiser)
       (mkIf cfg.verifyNixChannels nixChannels)
       nixInstaller


### PR DESCRIPTION
Currently if you run activation as root you need to set `nix.gc.user = "root";` or `nix.gc.user = "";`.

https://github.com/LnL7/nix-darwin/blob/4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d/modules/system/checks.nix#L184-L192

