### PR TITLE
Add support for system preferences that are stored as dictionaries

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -13,6 +13,7 @@ let
     if isFloat value then "-float ${strings.floatToString value}" else
     if isString value then "-string '${value}'" else
     if isList value then "-array ${concatStringsSep " " (map (v: writeValue v)value)}" else
+    if isAttrs value then "-dict " + (concatStringsSep " " (mapAttrsToList (k: v: "'${k}' ${writeValue v}")value)) else
     throw "invalid value type";
 
   writeDefault = domain: key: value:


### PR DESCRIPTION
Some plist attributes are represented by dictionaries. This PR adds support for dictionary system settings backed by attribute sets. An example custom preference that failed with `invalid value type` before but works now:

```nix
system.defaults.CustomUserPreferences = {
    "com.google.Chrome" = {
        "NSUserKeyEquivalents" = {
            "Open Location..." = "~d";
        };
    };
};
```