### PR TITLE
vim: don't use deprecated vam attribute

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -28,31 +28,10 @@ in
       description = lib.mdDoc "Enable sensible configuration options for vim.";
     };
 
-    programs.vim.extraKnownPlugins = mkOption {
-      type = types.attrsOf types.package;
-      default = {};
-      example = literalExpression
-        ''
-        {
-          vim-jsx = pkgs.vimUtils.buildVimPluginFrom2Nix {
-            name = "vim-javascript-2016-07-29";
-            src = pkgs.fetchgit {
-              url = "git://github.com/mxw/vim-jsx";
-              rev = "261114c925ea81eeb4db1651cc1edced66d6b5d6";
-              sha256 = "17pffzwnvsimnnr4ql1qifdh4a0sqqsmcwfiqqzgglvsnzw5vpls";
-            };
-            dependencies = [];
-
-          };
-        }
-        '';
-      description = lib.mdDoc "Custom plugin declarations to add to VAM's knownPlugins.";
-    };
-
     programs.vim.plugins = mkOption {
-      type = types.listOf types.attrs;
+      type = types.listOf (types.either types.str types.attrs);
       default = [];
-      example = [ { names = [ "surround" "vim-nix" ]; } ];
+      example = [ pkgs.vimPlugins.vim-nix ];
       description = lib.mdDoc "VAM plugin dictionaries to use for vim_configurable.";
     };
 
@@ -95,15 +74,10 @@ in
     programs.vim.package = pkgs.vim_configurable.customize {
       name = "vim";
       vimrcConfig.customRC = config.environment.etc."vimrc".text;
-      vimrcConfig.vam = {
-        knownPlugins = pkgs.vimPlugins // cfg.extraKnownPlugins;
-        pluginDictionaries = cfg.plugins;
-      };
+      vimrcConfig.packages.nix-darwin.start = cfg.plugins;
     };
 
-    programs.vim.plugins = mkIf cfg.enableSensible [
-      { names = [ "fugitive" "surround" "vim-nix" ]; }
-    ];
+    programs.vim.plugins = mkIf cfg.enableSensible [pkgs.vimPlugins.vim-sensible];
 
     programs.vim.vimOptions.sensible.text = mkIf cfg.enableSensible ''
       set nocompatible


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/pull/179039 (~22.11), the `vam` attribute of `vimrcConfig` has been deprecated. This moves the module to the recommend `packages` attribute, removing the trace most systems will come across currently and making adding plugins a little bit easier. The default "sensible" plugins have also been replaced with the less opinionated `vim-sensible` - similar to home-manager.

***This is a breaking change***
