### PR TITLE
GlobalPreferences: fix mouse scaling example

### DIFF
--- a/modules/system/defaults/GlobalPreferences.nix
+++ b/modules/system/defaults/GlobalPreferences.nix
@@ -22,10 +22,10 @@ in {
       mkOption {
         type = types.nullOr floatWithDeprecationError;
         default = null;
-        example = -1;
+        example = -1.0;
         description = lib.mdDoc ''
           Sets the mouse tracking speed. Found in the "Mouse" section of
-          "System Preferences". Set to -1 to disable mouse acceleration.
+          "System Preferences". Set to -1.0 to disable mouse acceleration.
         '';
       };
   };


### PR DESCRIPTION
Follow up to https://github.com/LnL7/nix-darwin/pull/838 . 

The change requires a float number but example is integer and will not build. 