### PR TITLE
Fix type error

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -342,7 +342,7 @@ with lib;
 
     StartCalendarInterval = mkOption {
       default = null;
-      example = { Hour = 2; Minute = 30; };
+      example = [{ Hour = 2; Minute = 30; }];
       description = lib.mdDoc ''
         This optional key causes the job to be started every calendar interval as specified. Missing arguments
         are considered to be wildcard. The semantics are much like `crontab(5)`.  Unlike cron which skips job


### PR DESCRIPTION
Not sure if this is intended but looks like `serviceConfig.StartCalendarInterval` has to wrapped in a list so would be good if the example follows that assumption as well.

```
error: A definition for option `launchd.user.agents.[...].serviceConfig.StartCalendarInterval' is not of type `null or (list of (submodule))'. Definition values:
       - In `<unknown-file>':
           {
             Hour = 0;
             Minute = 0;
           }
```