### PR TITLE
linux-builder: remove trusted user requirement

### DIFF
--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -80,14 +80,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    assertions = [ {
-      assertion = config.nix.settings.trusted-users != [ "root" ] || (config.nix.settings.extra-trusted-users or [ ]) != [ ];
-      message = ''
-        Your user or group (@admin) needs to be added to `nix.settings.trusted-users` or `nix.settings.extra-trusted-users`
-        to use the Linux builder.
-      '';
-    } ];
-
     system.activationScripts.preActivation.text = ''
       mkdir -p /var/lib/darwin-builder
     '';


### PR DESCRIPTION
If you set up a signing key for the `linux-builder` and add that as trusted public key on your machine, you won't need to be a trusted user at all.