### PR TITLE
fix shell escaping in networking config

### DIFF
--- a/modules/networking/default.nix
+++ b/modules/networking/default.nix
@@ -107,13 +107,13 @@ in
       echo "configuring networking..." >&2
 
       ${optionalString (cfg.computerName != null) ''
-        scutil --set ComputerName '${cfg.computerName}'
+        scutil --set ComputerName ${escapeShellArg cfg.computerName}
       ''}
       ${optionalString (cfg.hostName != null) ''
-        scutil --set HostName '${cfg.hostName}'
+        scutil --set HostName ${escapeShellArg cfg.hostName}
       ''}
       ${optionalString (cfg.localHostName != null) ''
-        scutil --set LocalHostName '${cfg.localHostName}'
+        scutil --set LocalHostName ${escapeShellArg cfg.localHostName}
       ''}
 
       ${setNetworkServices}

--- a/tests/networking-shell-escape.nix
+++ b/tests/networking-shell-escape.nix
@@ -1,0 +1,15 @@
+
+{ config, pkgs, ... }:
+
+{
+  networking.computerName = "\"Quotey McQuote's Macbook Pro\"";
+  networking.hostName = "\"Quotey-McQuote's-Macbook-Pro\"";
+
+  test = ''
+    echo checking hostname in /activate >&2
+    grep "scutil --set ComputerName '"\""Quotey McQuote's Macbook Pro"\""'" ${config.out}/activate
+    grep "scutil --set LocalHostName '"\""Quotey-McQuote's-Macbook-Pro"\""'" ${config.out}/activate
+    grep "scutil --set HostName "'"\""Quotey-McQuote's-Macbook-Pro"\""'"  ${config.out}/activate
+    echo checking defaults write in ${config.out}/activate-user >&2
+  '';
+}


### PR DESCRIPTION
Fix a bug where using a single quote in any of the networking names caused the following error:

```
/nix/store/8zbx7q8xxrsd46m0n0bspnjvm27ak3sr-darwin-system-24.05.20240108.317484b+darwin4.0dd382b/activate: line 264: unexpected EOF while looking for matching `''
```

Example config:

```nix
  networking.hostName = "Adams-MacBook-Pro";
  networking.computerName = "Adam's MacBook Pro";
```