### PR TITLE
Allow launchd serivceConfig.LimitLoadToSessionType to be a list

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -91,7 +91,7 @@ with lib;
     };
 
     LimitLoadToSessionType = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr (types.oneOf [types.str (types.listOf types.str)]);
       default = null;
       description = lib.mdDoc ''
         This configuration file only applies to sessions of the type specified. This key is used in concert


### PR DESCRIPTION
Per: https://developer.apple.com/library/archive/technotes/tn2083/_index.html#:~:text=If%20you%20want%20to%20run%20in%20more%20than%20one%20session%20type%2C%20you%20can%20set%20LimitLoadToSessionType%20to%20an%20array%2C%20where%20each%20element%20is%20a%20session%20type%20string.

LimitLoadToSessionType can also be an array if more than one session type is desired.