### PR TITLE
services/yabai: Remove IFD

### DIFF
--- a/modules/services/yabai/default.nix
+++ b/modules/services/yabai/default.nix
@@ -96,11 +96,13 @@ in
         serviceConfig.KeepAlive.SuccessfulExit = false;
       };
 
-      environment.etc."sudoers.d/yabai".text =
-        let
-          sha = builtins.hashFile "sha256" "${cfg.package}/bin/yabai";
-        in
-        "%admin ALL=(root) NOPASSWD: sha256:${sha} ${cfg.package}/bin/yabai --load-sa";
+      environment.etc."sudoers.d/yabai".source = pkgs.runCommand "sudoers-yabai" {} ''
+        YABAI_BIN="${cfg.package}/bin/yabai"
+        SHASUM=$(sha256sum "$YABAI_BIN" | cut -d' ' -f1)
+        cat <<EOF >"$out"
+        %admin ALL=(root) NOPASSWD: sha256:$SHASUM $YABAI_BIN --load-sa
+        EOF
+      '';
     })
   ];
 }


### PR DESCRIPTION
`enableScriptingAddition` no longer triggers IFD by using runCommand to generate `sudoers.d/yabai`, instead of `builtins.hashFile` and interpolating the string in nix.