### PR TITLE
security.sudo.extraConfig: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -7,6 +7,7 @@
   ./security/pam.nix
   ./security/pki
   ./security/sandbox
+  ./security/sudo.nix
   ./system
   ./system/base.nix
   ./system/checks.nix

--- a/modules/security/sudo.nix
+++ b/modules/security/sudo.nix
@@ -1,0 +1,26 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.security.sudo;
+in
+{
+  meta.maintainers = [
+    lib.maintainers.samasaur or "samasaur"
+  ];
+
+  options = {
+    security.sudo.extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = mdDoc ''
+        Extra configuration text appended to {file}`sudoers`.
+      '';
+    };
+  };
+
+  config = {
+    environment.etc."sudoers.d/10-nix-darwin-extra-config".text = lib.mkIf (cfg.extraConfig != "") cfg.extraConfig;
+  };
+}


### PR DESCRIPTION
This adds the option `security.sudo.extraConfig`, which puts a file in `/etc/sudoers.d`. Because macOS' `/etc/sudoers` file includes these lines:
```
## Read drop-in files from /private/etc/sudoers.d
## (the '#' here does not indicate a comment)
#includedir /private/etc/sudoers.d
```
this allows extra configuration, while also matching the NixOS option and thus allowing common config across operating systems.

Closes #793 