### PR TITLE
Add NSStatusItemSpacing and NSStatusItemSelectionPadding 

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -232,12 +232,12 @@ in {
         Whether to enable moving window by holding anywhere on it like on Linux. The default is false.
       '';
     };
-    
+
     system.defaults.NSGlobalDomain.NSStatusItemSpacing = mkOption {
       type = types.nullOr types.int;
       default = null;
       example = 12;
-      description = lib.mdDoc ''
+      description = ''
         Sets the spacing between status icons in the menu bar. The default is null.
       '';
     };
@@ -246,7 +246,7 @@ in {
       type = types.nullOr types.int;
       default = null;
       example = 6;
-      description = lib.mdDoc ''
+      description = ''
         Sets the padding around status icons in the menu bar. The default is null.
       '';
     };

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -232,6 +232,24 @@ in {
         Whether to enable moving window by holding anywhere on it like on Linux. The default is false.
       '';
     };
+    
+    system.defaults.NSGlobalDomain.NSStatusItemSpacing = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 12;
+      description = lib.mdDoc ''
+        Sets the spacing between status icons in the menu bar. The default is null.
+      '';
+    };
+
+    system.defaults.NSGlobalDomain.NSStatusItemSelectionPadding = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 6;
+      description = lib.mdDoc ''
+        Sets the padding around status icons in the menu bar. The default is null.
+      '';
+    };
 
     system.defaults.NSGlobalDomain.InitialKeyRepeat = mkOption {
       type = types.nullOr types.int;


### PR DESCRIPTION
Add `NSStatusItemSpacing` and `NSStatusItemSelectionPadding` to `NSGlobalDomain` options.

These options control the spacing between and padding inside status icons in the menu bar. With these options it's possible to squeeze more items on to menu bar, something that's especially useful on machines with a notch!