### PR TITLE
linux-builder: Pass through more options to nix.buildMachines

### DIFF
--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -65,17 +65,49 @@ in
       default = 1;
       example = 4;
       description = lib.mdDoc ''
-        This option specifies the maximum number of jobs to run on the Linux builder at once.
+        The number of concurrent jobs the Linux builder machine supports. The
+        build machine will enforce its own limits, but this allows hydra
+        to schedule better since there is no work-stealing between build
+        machines.
 
         This sets the corresponding `nix.buildMachines.*.maxJobs` option.
+      '';
+    };
+
+    speedFactor = mkOption {
+      type = types.ints.positive;
+      default = 1;
+      description = lib.mdDoc ''
+        The relative speed of the Linux builder. This is an arbitrary integer
+        that indicates the speed of this builder, relative to other
+        builders. Higher is faster.
+
+        This sets the corresponding `nix.buildMachines.*.speedFactor` option.
+      '';
+    };
+
+    mandatoryFeatures = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "big-parallel" ];
+      description = lib.mdDoc ''
+        A list of features mandatory for the Linux builder. The builder will
+        be ignored for derivations that don't require all features in
+        this list. All mandatory features are automatically included in
+        {var}`supportedFeatures`.
+
+        This sets the corresponding `nix.buildMachines.*.mandatoryFeatures` option.
       '';
     };
 
     supportedFeatures = mkOption {
       type = types.listOf types.str;
       default = [ "kvm" "benchmark" "big-parallel" ];
+      example = [ "kvm" "big-parallel" ];
       description = lib.mdDoc ''
-        This option specifies the list of features supported by the Linux builder.
+        A list of features supported by the Linux builder. The builder will
+        be ignored for derivations that require features not in this
+        list.
 
         This sets the corresponding `nix.buildMachines.*.supportedFeatures` option.
       '';
@@ -141,7 +173,7 @@ in
       sshKey = "/etc/nix/builder_ed25519";
       system = "${stdenv.hostPlatform.uname.processor}-linux";
       publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
-      inherit (cfg) maxJobs supportedFeatures;
+      inherit (cfg) maxJobs speedFactor mandatoryFeatures supportedFeatures;
     }];
 
     nix.settings.builders-use-substitutes = true;


### PR DESCRIPTION
This commit passes more options to `nix.buildMachines`. Namely the `mandatoryFeatures` and `speedFactor` settings have been missing.