### PR TITLE
linux-builder: default pass through protocol to nix.buildMachines

### DIFF
--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -71,6 +71,20 @@ in
       '';
     };
 
+    protocol = mkOption {
+      type = types.str;
+      default = "ssh-ng";
+      example = "ssh";
+      description = lib.mdDoc ''
+        The protocol used for communicating with the build machine.  Use
+        `ssh-ng` if your remote builder and your local Nix version support that
+        improved protocol.
+
+        Use `null` when trying to change the special localhost builder without a
+        protocol which is for example used by hydra.
+      '';
+    };
+
     supportedFeatures = mkOption {
       type = types.listOf types.str;
       default = [ "kvm" "benchmark" "big-parallel" ];
@@ -141,7 +155,7 @@ in
       sshKey = "/etc/nix/builder_ed25519";
       system = "${stdenv.hostPlatform.uname.processor}-linux";
       publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUpCV2N4Yi9CbGFxdDFhdU90RStGOFFVV3JVb3RpQzVxQkorVXVFV2RWQ2Igcm9vdEBuaXhvcwo=";
-      inherit (cfg) maxJobs supportedFeatures;
+      inherit (cfg) maxJobs protocol supportedFeatures;
     }];
 
     nix.settings.builders-use-substitutes = true;


### PR DESCRIPTION
Of note: I have another pull request (#878) which merges together the existing pull requests that add more option handling all around for `linux-builder`.  This is intended as a way to get a gist for these individualized changes.

This commit adds a protocol option for the `linux-builder` and defaults it to `ssh-ng`.  I have observed it needing this with the following:

``` sh
$ nix store ping --store ssh://linux-builder
Store URL: ssh://linux-builder

$ nix store ping --store ssh-ng://linux-builder
Store URL: ssh-ng://linux-builder
Version: 2.18.1
Trusted: 0
```

This seems to make the difference on whether or not Nix picks up `linux-builder` as an available builder.