### PR TITLE
fix broken NIX_PATH if paths contain spaces

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -3,6 +3,9 @@
 with lib;
 
 let
+  # Similar to lib.escapeShellArg but escapes "s instead of 's, to allow for parameter expansion in shells
+  escapeDoubleQuote = arg: ''"${replaceStrings ["\""] ["\"\\\"\""] (toString arg)}"'';
+
   cfg = config.system.checks;
 
   darwinChanges = ''
@@ -180,7 +183,7 @@ let
   '';
 
   nixPath = ''
-    nixPath=${concatStringsSep ":" config.nix.nixPath}:$HOME/.nix-defexpr/channels
+    nixPath=${concatMapStringsSep ":" escapeDoubleQuote config.nix.nixPath}:$HOME/.nix-defexpr/channels
 
     darwinConfig=$(NIX_PATH=$nixPath nix-instantiate --find-file darwin-config) || true
     if ! test -e "$darwinConfig"; then


### PR DESCRIPTION
The generated user activation script is broken when NIX_PATH contains paths with spaces in them due to the spaces not being escaped.

The motivation for this fix is that I've set `use-xdg-base-directories` to `true` while also customizing the `XDG_*_HOME` variables to try and follow macOS conventions (i.e. `XDG_CONFIG_HOME` is `~/Library/Application Support`, hence the issue with spaces in the path). I then set one of the paths in `nix.nixPath` to `$HOME/Library/Application Support/nix/defexpr/channels` which causes the user activation script for switching to a new generation to break.