### PR TITLE
security.sudo.extraConfig: fix default behavior

### DIFF
--- a/modules/security/sudo.nix
+++ b/modules/security/sudo.nix
@@ -12,8 +12,8 @@ in
 
   options = {
     security.sudo.extraConfig = mkOption {
-      type = types.lines;
-      default = "";
+      type = types.nullOr types.lines;
+      default = null;
       description = mdDoc ''
         Extra configuration text appended to {file}`sudoers`.
       '';
@@ -21,6 +21,10 @@ in
   };
 
   config = {
-    environment.etc."sudoers.d/10-nix-darwin-extra-config".text = lib.mkIf (cfg.extraConfig != "") cfg.extraConfig;
+    environment.etc = {
+      "sudoers.d/10-nix-darwin-extra-config" = mkIf (cfg.extraConfig != null) {
+        text = cfg.extraConfig;
+      };
+    };
   };
 }


### PR DESCRIPTION
Due to where I put the `lib.mkIf`, the file `/etc/sudoers.d/10-nix-darwin-extra-config` was generated with no content by default on every nix-darwin user's system. This PR fixes the default behavior, while not affecting any users who have set an actual value for the option.