### PR TITLE
`system.startup.chime`: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -35,6 +35,7 @@
   ./system/etc.nix
   ./system/keyboard.nix
   ./system/launchd.nix
+  ./system/nvram.nix
   ./system/patches.nix
   ./system/shells.nix
   ./system/version.nix

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -38,6 +38,7 @@
   ./system/nvram.nix
   ./system/patches.nix
   ./system/shells.nix
+  ./system/startup.nix
   ./system/version.nix
   ./time
   ./networking

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -69,6 +69,7 @@ in
       ${cfg.activationScripts.networking.text}
       ${cfg.activationScripts.keyboard.text}
       ${cfg.activationScripts.fonts.text}
+      ${cfg.activationScripts.nvram.text}
 
       ${cfg.activationScripts.postActivation.text}
 

--- a/modules/system/nvram.nix
+++ b/modules/system/nvram.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.system;
+
+  mkNvramVariables =
+    lib.attrsets.mapAttrsToList
+      (name: value: "nvram ${lib.escapeShellArg name}=${lib.escapeShellArg value}")
+      cfg.nvram.variables;
+in
+
+{
+  meta.maintainers = [
+    lib.maintainers.samasaur or "samasaur"
+  ];
+
+  options = {
+    system.nvram.variables = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = {};
+      internal = true;
+      example = {
+        "StartupMute" = "%01";
+      };
+      description = lib.mdDoc ''
+        Non-volatile RAM variables to set. Removing a key-value pair from this
+        list will **not** return the variable to its previous value, but will
+        no longer set its value on system configuration activations.
+      '';
+    };
+  };
+
+  config = {
+    system.activationScripts.nvram.text = ''
+      echo "setting nvram variables..." >&2
+
+      ${builtins.concatStringsSep "\n" mkNvramVariables}
+    '';
+  };
+}

--- a/modules/system/startup.nix
+++ b/modules/system/startup.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.system.startup;
+in
+
+{
+  meta.maintainers = [
+    lib.maintainers.samasaur or "samasaur"
+  ];
+
+  options = {
+    system.startup.chime = lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = false;
+      description = lib.mdDoc ''
+        Whether to enable the startup chime.
+
+        By default, this option does not affect your system configuration in any way.
+        However, this means that after it has been set once, unsetting it will not
+        return to the old behavior. It will allow the setting to be controlled in
+        System Settings, though.
+      '';
+    };
+  };
+
+  config = {
+    system.nvram.variables."StartupMute" = lib.mkIf (cfg.chime != null) (if cfg.chime then "%00" else "%01");
+  };
+}


### PR DESCRIPTION
Adds an option `system.startup.chime`, which can either be `null` (don't change the current setting), `true` (enable the startup chime), or `false` (disable the startup chime).

Because the startup chime settings are stored in NVRAM, I also added an internal `system.nvram.variables` option, rather than implement NVRAM settings specifically for the startup chime.

Will close #885 