### PR TITLE
Support new nix 2.20 command syntax

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -62,13 +62,17 @@ let
         if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then ''
           echo "Ignoring validation for cross-compilation"
         ''
-        else ''
+        else
+        let
+          showCommand = if isNixAtLeast "2.20pre" then "config show" else "show-config";
+        in
+        ''
           echo "Validating generated nix.conf"
           ln -s $out ./nix.conf
           set -e
           set +o pipefail
           NIX_CONF_DIR=$PWD \
-            ${cfg.package}/bin/nix show-config ${optionalString (isNixAtLeast "2.3pre") "--no-net"} \
+            ${cfg.package}/bin/nix ${showCommand} ${optionalString (isNixAtLeast "2.3pre") "--no-net"} \
               ${optionalString (isNixAtLeast "2.4pre") "--option experimental-features nix-command"} \
             |& sed -e 's/^warning:/error:/' \
             | (! grep '${if cfg.checkConfig then "^error:" else "^error: unknown setting"}')


### PR DESCRIPTION
This commit updates the nix.conf validation logic to accommodate different versions of Nix. It introduces a conditional assignment of the `showCommand` variable, which determines the appropriate command to use based on the Nix version. For versions at least "2.20pre", it uses "config show"; otherwise, it falls back to "show-config". This change ensures compatibility across various Nix releases.

Same as fix for NixOS - https://github.com/NixOS/nixpkgs/pull/271423