### PR TITLE
Add support for persistent-apps in dock

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -123,6 +123,19 @@ in {
       '';
     };
 
+    system.defaults.dock.persistent-apps = mkOption {
+      type = types.nullOr (types.listOf (types.either types.path types.str));
+      default = null;
+      example = [ "/Applications/Safari.app" "/System/Applications/Utilities/Terminal.app" ];
+      description = lib.mdDoc ''
+        Persistent applications in the dock.
+      '';
+      apply = value:
+        if !(isList value)
+        then value
+        else map (app: { tile-data = { file-data = { _CFURLString = app; _CFURLStringType = 0; }; }; }) value;
+    };
+
     system.defaults.dock.show-process-indicators = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -225,6 +225,36 @@ defaults write com.apple.dock 'orientation' $'<?xml version="1.0" encoding="UTF-
 <plist version="1.0">
 <string>left</string>
 </plist>'
+defaults write com.apple.dock 'persistent-apps' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>tile-data</key>
+		<dict>
+			<key>file-data</key>
+			<dict>
+				<key>_CFURLString</key>
+				<string>MyApp.app</string>
+				<key>_CFURLStringType</key>
+				<integer>0</integer>
+			</dict>
+		</dict>
+	</dict>
+	<dict>
+		<key>tile-data</key>
+		<dict>
+			<key>file-data</key>
+			<dict>
+				<key>_CFURLString</key>
+				<string>Cool.app</string>
+				<key>_CFURLStringType</key>
+				<integer>0</integer>
+			</dict>
+		</dict>
+	</dict>
+</array>
+</plist>'
 
 
 

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -46,6 +46,7 @@
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";
+  system.defaults.dock.persistent-apps = ["MyApp.app" "Cool.app"];
   system.defaults.screencapture.location = "/tmp";
   system.defaults.screensaver.askForPassword = true;
   system.defaults.screensaver.askForPasswordDelay = 5;


### PR DESCRIPTION
Applications added to the dock point to an old derivation when a new derivation of an application is added to the Nix store. This allows configuring the persistent applications to display system apps or apps in the Nix store.

Updates require re-login or restarting the Dock process e.g. `killall Dock`.

Dependent on: #897
Supersedes the old PR: #619