### PR TITLE
Add support for zsh-fast-syntax-highlighting

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -107,6 +107,12 @@ in
       default = false;
       description = "Enable zsh-syntax-highlighting.";
     };
+
+    programs.zsh.enableFastSyntaxHighlighting = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc "Enable zsh-fast-syntax-highlighting.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -115,7 +121,8 @@ in
       [ # Include zsh package
         pkgs.zsh
       ] ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
-        ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting;
+        ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting
+        ++ optional cfg.enableFastSyntaxHighlighting pkgs.zsh-fast-syntax-highlighting;
 
     environment.pathsToLink = [ "/share/zsh" ];
 
@@ -194,6 +201,10 @@ in
 
       ${optionalString cfg.enableSyntaxHighlighting
         "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+      }
+
+      ${optionalString cfg.enableFastSyntaxHighlighting
+        "source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh-fast-syntax-highlighting/zsh-fast-syntax-highlighting.zsh"
       }
 
       ${optionalString cfg.enableFzfCompletion "source ${fzfCompletion}"}

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -117,6 +117,9 @@ in
 
   config = mkIf cfg.enable {
 
+    warnings = mkIf (cfg.enableFastSyntaxHighlighting && cfg.enableSyntaxHighlighting) [
+      "zsh-fast-syntax-highlighting and zsh-syntax-highlighting are mutually exclusive. Disable one of them."
+    ];
     environment.systemPackages =
       [ # Include zsh package
         pkgs.zsh

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -108,11 +108,7 @@ in
       description = "Enable zsh-syntax-highlighting.";
     };
 
-    programs.zsh.enableFastSyntaxHighlighting = mkOption {
-      type = types.bool;
-      default = false;
-      description = lib.mdDoc "Enable zsh-fast-syntax-highlighting.";
-    };
+    programs.zsh.enableFastSyntaxHighlighting = mkEnableOption "zsh-fast-syntax-highlighting";
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -117,8 +117,11 @@ in
 
   config = mkIf cfg.enable {
 
-    warnings = mkIf (cfg.enableFastSyntaxHighlighting && cfg.enableSyntaxHighlighting) [
-      "zsh-fast-syntax-highlighting and zsh-syntax-highlighting are mutually exclusive. Disable one of them."
+    assertions = [
+      {
+        assertion = !(cfg.enableSyntaxHighlighting && cfg.enableFastSyntaxHighlighting);
+        message = "zsh-syntax-highlighting and zsh-fast-syntax-highlighting are mutually exclusive, please disable one of them.";
+      }
     ];
     environment.systemPackages =
       [ # Include zsh package


### PR DESCRIPTION
Hello,

I would like to add support for zsh-fast-syntax-highlighting which has marginally better performance than zsh-syntax-highlighting, to the zsh configuration module in nix-darwin. 

The repository can be found [here](https://github.com/zdharma-continuum/fast-syntax-highlighting)

There is an existing nix package for zsh-fast-syntax-highlighting [here](https://github.com/zdharma-continuum/fast-syntax-highlighting)