### PR TITLE
Expose `extendModules` attr

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -82,12 +82,10 @@ let
     modules = modules ++ [ argsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;
   });
-in
-
-{
-  inherit (eval._module.args) pkgs;
-  inherit (eval) options config;
-  inherit (eval) _module;
-
-  system = eval.config.system.build.toplevel;
-}
+  
+  withExtraAttrs = configuration: configuration // {
+    inherit (configuration._module.args) pkgs;
+    system = configuration.config.system.build.toplevel;
+    extendModules = args: withExtraAttrs (configuration.extendModules args);
+  };
+in withExtraAttrs eval


### PR DESCRIPTION
expose extendModules

implementation reference is https://github.com/nix-community/home-manager/blob/3142bdcc470e1e291e1fbe942fd69e06bd00c5df/modules/default.nix#L43

ref: https://github.com/LnL7/nix-darwin/pull/777
ref: https://github.com/LnL7/nix-darwin/issues/609