### PR TITLE
Add offline and substituters flags

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -117,7 +117,17 @@ while [ $# -gt 0 ]; do
       shift 1
       ;;
     --offline)
+      extraMetadataFlags+=("$i")
       extraBuildFlags+=("$i")
+      ;;
+    --substituters)
+      if [ -z "$1" ]; then
+        echo "$0: '$i' requires an argument"
+        exit 1
+      fi
+      j=$1; shift 1
+      extraMetadataFlags+=("$i" "$j")
+      extraBuildFlags+=("$i" "$j")
       ;;
     *)
       echo "$0: unknown option '$i'"

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -12,7 +12,7 @@ showSyntax() {
   echo "               [--keep-going] [-k] [--keep-failed] [-K] [--fallback] [--show-trace]" >&2
   echo "               [-I path] [--option name value] [--arg name value] [--argstr name value]" >&2
   echo "               [--flake flake] [--update-input input flake] [--impure] [--recreate-lock-file]" >&2
-  echo "               [--no-update-lock-file] [--refresh] ..." >&2
+  echo "               [--no-update-lock-file] [--refresh] [--offline] ..." >&2
   exit 1
 }
 
@@ -115,6 +115,9 @@ while [ $# -gt 0 ]; do
         mkdir -p -m 0755 "$(dirname "$profile")"
       fi
       shift 1
+      ;;
+    --offline)
+      extraBuildFlags+=("$i")
       ;;
     *)
       echo "$0: unknown option '$i'"

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -12,7 +12,8 @@ showSyntax() {
   echo "               [--keep-going] [-k] [--keep-failed] [-K] [--fallback] [--show-trace]" >&2
   echo "               [-I path] [--option name value] [--arg name value] [--argstr name value]" >&2
   echo "               [--flake flake] [--update-input input flake] [--impure] [--recreate-lock-file]" >&2
-  echo "               [--no-update-lock-file] [--refresh] [--offline] ..." >&2
+  echo "               [--no-update-lock-file] [--refresh]" >&2
+  echo "               [--offline] [--substituters substituters-list] ..." >&2
   exit 1
 }
 

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
     edit|switch|activate|build|check|changelog)
       action=$i
       ;;
-    --show-trace|--keep-going|--keep-failed|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback)
+    --show-trace|--keep-going|--keep-failed|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--offline)
       extraMetadataFlags+=("$i")
       extraBuildFlags+=("$i")
       ;;
@@ -116,10 +116,6 @@ while [ $# -gt 0 ]; do
         mkdir -p -m 0755 "$(dirname "$profile")"
       fi
       shift 1
-      ;;
-    --offline)
-      extraMetadataFlags+=("$i")
-      extraBuildFlags+=("$i")
       ;;
     --substituters)
       if [ -z "$1" ]; then


### PR DESCRIPTION
Add missing `--offline` and `--substituters` options to `darwin-rebuild` which is impossible to use now.

Closes #608