### PR TITLE
Add hot reload workaround for skhd service

### DIFF
--- a/modules/services/skhd/default.nix
+++ b/modules/services/skhd/default.nix
@@ -32,6 +32,11 @@ in
 
     environment.etc."skhdrc".text = cfg.skhdConfig;
 
+    # Hot-reload workaround until https://github.com/koekeishiya/skhd/issues/342 is fixed
+    system.activationScripts.postActivation.text = ''
+      su - $(${pkgs.coreutils}/bin/logname) -c '${cfg.package}/bin/skhd -r'
+    '';
+
     launchd.user.agents.skhd = {
       path = [ config.environment.systemPath ];
 


### PR DESCRIPTION
Workaround for #333, until https://github.com/koekeishiya/skhd/issues/342 is solved.

## Changes:
- Forces reload of skhd's config at postActivation

the `logname` pkg should be present in macos by default, tho I used `pkgs.coreutils` to ensure immutability (if for any reason the machine doesn't have the pkg etc).

### More info here: https://github.com/LnL7/nix-darwin/issues/333#issuecomment-2049843403

### Question about when the service changes:
I didn't check if the config is empty as someone can go from a config to an empty one.
But at that point also the service in launchd changes. 
- What is the behavior of the service in this case?
- Should I still force the reload of the config or is not needed?