### PR TITLE
ci, readme: update stable nixpkgs to 23.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  CURRENT_STABLE_CHANNEL: nixpkgs-23.05-darwin
+  CURRENT_STABLE_CHANNEL: nixpkgs-23.11-darwin
 
 jobs:
   test-stable:

--- a/.github/workflows/update-manual.yml
+++ b/.github/workflows/update-manual.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Build manual
       run: |
-        nix-build ./release.nix -I nixpkgs=channel:nixpkgs-23.05-darwin -I darwin=. -A manualHTML
+        nix-build ./release.nix -I nixpkgs=channel:nixpkgs-23.11-darwin -I darwin=. -A manualHTML
 
     - name: Push update to manual
       run: |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
   description = "John's darwin system";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-23.05-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-23.11-darwin";
     nix-darwin.url = "github:LnL7/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };


### PR DESCRIPTION
Sounds like a prerequisite for all PRs trying to drop `lib.mdDoc`?