### PR TITLE
cachix-agent: fix crash calling `security`

### DIFF
--- a/modules/services/cachix-agent.nix
+++ b/modules/services/cachix-agent.nix
@@ -58,7 +58,7 @@ in {
         exec ${cfg.package}/bin/cachix deploy agent ${cfg.name}
       '';
 
-      path = [ config.nix.package pkgs.coreutils ];
+      path = [ config.nix.package pkgs.coreutils config.environment.systemPath ];
 
       environment = {
         NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
One of cachix-agent's dependencies, `hs-certificate`, makes calls to `security`. This lives in `/usr/bin`, which isn't available from launchd. This commit makes the system paths available to cachix-agent.

Fixes #924.

cc @domenkozar 