### PR TITLE
Change zsh default prompt

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -55,7 +55,7 @@ in
 
     programs.zsh.promptInit = mkOption {
       type = types.lines;
-      default = "autoload -U promptinit && promptinit && prompt walters && setopt prompt_sp";
+      default = "autoload -U promptinit && promptinit && prompt suse && setopt prompt_sp";
       description = "Shell script code used to initialise the zsh prompt.";
     };
 


### PR DESCRIPTION
Zsh prompt Walters causes issues as the default prompt and is a strange default, e.g.
it sets the RPS1.

We should use the same prompt as NixOS uses:
https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/zsh/zsh.nix#L93

Resolves:
https://github.com/LnL7/nix-darwin/issues/667

Related discussion:
https://github.com/NixOS/nixpkgs/pull/38535