### PR TITLE
hercules-ci-agent: fix crash calling `security`

### DIFF
--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -25,7 +25,7 @@ in
     launchd.daemons.hercules-ci-agent = {
       script = "exec ${cfg.package}/bin/hercules-ci-agent --config ${cfg.tomlFile}";
 
-      path = [ config.nix.package ];
+      path = [ config.nix.package config.environment.systemPath ];
       environment = {
         NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       };


### PR DESCRIPTION
hercules ci agent has the same problem as was reported in https://github.com/LnL7/nix-darwin/issues/924.

I had originally fixed this downstream in nix-community by wrapping `/usr/bin/security` (https://github.com/nix-community/infra/commit/5da85a9b7276f15a64052dcc820ab210d742b914) but here I've reused the same fix that was used for cachix agent.

cc @roberth 