### PR TITLE
homebrew: add extraMasApps option for composability of mas apps

### DIFF
--- a/tests/homebrew.nix
+++ b/tests/homebrew.nix
@@ -66,6 +66,17 @@ in
     Xcode = 497799835;
   };
 
+  homebrew.extraMasApps = [
+    {
+      name = "Transporter";
+      id = 1450874784;
+    }
+    {
+      name = "AppleConfigurator";
+      id = 1037126344;
+    }
+  ];
+
   homebrew.whalebrews = [
     "whalebrew/wget"
   ];
@@ -94,6 +105,8 @@ in
     echo "checking mas entries in Brewfile" >&2
     ${mkTest "1Password for Safari" ''mas "1Password for Safari", id: 1569813296''}
     ${mkTest "Xcode" ''mas "Xcode", id: 497799835''}
+    ${mkTest "Transporter" ''mas "Transporter", id: 1450874784''}
+    ${mkTest "AppleConfigurator" ''mas "AppleConfigurator", id: 1037126344''}
 
     echo "checking whalebrew entries in Brewfile" >&2
     ${mkTest "whalebrew/wget" ''whalebrew "whalebrew/wget"''}


### PR DESCRIPTION
I thought it might be good to have masApps as a list such that it is automatically merged and can be composed in different files/modules like with casks and brews.

Attempted to fit it into `masApps` but struggled to get the tests to pass so opted for `extraMasApps` option instead. Happy to make changes if this approach is not ideal.