### PR TITLE
Add support for trackpad force click

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -342,6 +342,14 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain."com.apple.trackpad.forceClick" = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Wheter to enable trackpad force click.
+      '';
+    };
+
     system.defaults.NSGlobalDomain."com.apple.springing.enabled" = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -343,7 +343,7 @@ in {
     };
 
     system.defaults.NSGlobalDomain."com.apple.trackpad.forceClick" = mkOption {
-      type = types.nullOr (types.enum [ 0 1 ]);
+      type = types.nullOr types.bool;
       default = null;
       description = ''
         Whether to enable trackpad force click.

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -343,7 +343,7 @@ in {
     };
 
     system.defaults.NSGlobalDomain."com.apple.trackpad.forceClick" = mkOption {
-      type = types.nullOr types.bool;
+      type = types.nullOr (types.enum [ 0 1 ]);
       default = null;
       description = ''
         Wheter to enable trackpad force click.

--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -346,7 +346,7 @@ in {
       type = types.nullOr (types.enum [ 0 1 ]);
       default = null;
       description = ''
-        Wheter to enable trackpad force click.
+        Whether to enable trackpad force click.
       '';
     };
 

--- a/modules/system/defaults/trackpad.nix
+++ b/modules/system/defaults/trackpad.nix
@@ -63,5 +63,14 @@ with lib;
       '';
     };
 
+    system.defaults.trackpad.TrackpadThreeFingerTapGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 2 ]);
+      default = null;
+      description = ''
+        0 to disable three finger tap, 2 to trigger Look up & data detectors.
+        The default is 2.
+      '';
+    };
+
   };
 }


### PR DESCRIPTION
This PR add support for setting the trackpad force click option under NSGlobalDomain, and also to setting the action to take on `com.apple.AppleMultitouchTrackpad` > `TrackpadThreeFingerTapGesture`.

Unintuitively, changing `TrackpadThreeFingerTapGesture` actually changes the `Look up & data detectors` dropdown under Trackpad.

![CleanShot 2024-05-23 at 16 44 57](https://github.com/LnL7/nix-darwin/assets/242529/8bf24c37-6d35-40d9-bcfd-b9dfac384dd7)

From my tests:

| Look up & data detectors | "com.apple.trackpad.forceClick" | TrackpadThreeFingerTapGesture |
|---|---|---|
| Off | 0 | 0 |
| Force Click with One Finger | 1 | 0 |
| Tap with Three Fingers| 0 | 2 |

