### PR TITLE
Fix NextDNS arguments

### DIFF
--- a/modules/services/nextdns/default.nix
+++ b/modules/services/nextdns/default.nix
@@ -31,7 +31,7 @@ in {
     launchd.daemons.nextdns = {
       path = [ nextdns ];
       serviceConfig.ProgramArguments =
-        [ "${pkgs.nextdns}/bin/nextdns" "run" (escapeShellArgs cfg.arguments) ];
+        [ "${pkgs.nextdns}/bin/nextdns" "run" ] ++ cfg.arguments;
       serviceConfig.KeepAlive = true;
       serviceConfig.RunAtLoad = true;
     };

--- a/tests/services-nextdns.nix
+++ b/tests/services-nextdns.nix
@@ -12,6 +12,7 @@ in {
     echo >&2 "checking nextdns service in ~/Library/LaunchDaemons"
     grep "org.nixos.nextdns" ${config.out}/Library/LaunchDaemons/org.nixos.nextdns.plist
     grep "/bin/nextdns" ${config.out}/Library/LaunchDaemons/org.nixos.nextdns.plist
-    grep "'-config' '10.0.3.0/24=abcdef'" ${config.out}/Library/LaunchDaemons/org.nixos.nextdns.plist
+    grep -- "-config" ${config.out}/Library/LaunchDaemons/org.nixos.nextdns.plist
+    grep "10.0.3.0/24=abcdef" ${config.out}/Library/LaunchDaemons/org.nixos.nextdns.plist
   '';
 }


### PR DESCRIPTION
It seems that `escapeShellArgs` doesn't play nicely with launchd, as it surrounds strings with single quotes that are interpreted literally by launchd and passed as arguments (think passing `"'-profile'"` instead of `"-profile"`).

```
Unrecognized parameter: '-profile'
```

```
Unrecognized parameter: '-profile 192.168.4.0/24=XXXXXX'
```

This PR maps the single version of `escapeShellArg` to each argument, and removes the resulting surrounding quotes.