### PR TITLE
feat: add defaults screencapture show-thumbnail option

### DIFF
--- a/modules/system/defaults/screencapture.nix
+++ b/modules/system/defaults/screencapture.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 with lib;
 
@@ -27,6 +27,14 @@ with lib;
       description = ''
           Disable drop shadow border around screencaptures. The default is false.
         '';
+    };
+
+    system.defaults.screencapture.show-thumbnail = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Show thumbnail after screencapture before writing to file. The default is true.
+      '';
     };
   };
 }


### PR DESCRIPTION
# What does this PR do?

This PR adds a new `screencapture.show-thumbnail` option to the `system.defaults` configuration.

This option was found by observing how the output of `defaults read com.apple.screencapture` changed when the 'Show Floating Thumbnail' item was checked and unchecked in the 'Options' menu on the controls bar shown when '⌘ ⇧ 5' (default shortcut) is pressed in MacOS. It determines whether or not a thumbnail will be shown in the bottom right corner of the screen before the screen capture is persisted.

Users may wish to control this option to avoid waiting for the thumbnail to auto-close before accessing the capture.

# How was this tested?

I tested this by setting my `nix-darwin` input to the source branch as part of a flake including nix-darwin and home-manager, running on MacOS Sonoma 14.5 (23F79), and toggling the configuration option on and off between switching generations.

# Resources

The UI option (apologies for the poor quality - it's not possible to screen capture the screen capture UI!):
![Show Floating Thumbnail](https://github.com/LnL7/nix-darwin/assets/46845492/7d5bee2f-d93e-44c3-962a-8d9872ba535a)

My `defaults` output when 'Show Floating Thumbnail' enabled :
```
> defaults read com.apple.screencapture
{
    "last-analytics-stamp" = "739009399.177134";
    "last-selection" =     {
        Height = "837.75";
        Width = 1296;
        X = 216;
        Y = "139.625";
    };
    "last-selection-display" = 0;
    location = "~/Downloads";
    "location-last" = "~/Downloads";
    target = file;
}
```

My `defaults` output when 'Show Floating Thumbnail' disabled :
```
> defaults read com.apple.screencapture
{
    "last-analytics-stamp" = "739009399.177134";
    "last-selection" =     {
        Height = "837.75";
        Width = 1296;
        X = 216;
        Y = "139.625";
    };
    "last-selection-display" = 0;
    location = "~/Downloads";
    "location-last" = "~/Downloads";
    "show-thumbnail" = 0;
    target = file;
}
```