### PR TITLE
module : `jankyborders` for window borders Configuration

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -87,6 +87,7 @@
   ./services/wg-quick.nix
   ./services/yabai
   ./services/nextdns
+  ./services/jankyborders
   ./programs/bash
   ./programs/direnv.nix
   ./programs/fish.nix

--- a/modules/services/jankyborders/default.nix
+++ b/modules/services/jankyborders/default.nix
@@ -1,0 +1,157 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) maintainers mkEnableOption mkIf mkPackageOptionMD mkOption types;
+
+  cfg = config.services.jankyborders;
+  joinStrings = strings: builtins.concatStringsSep "," strings;
+
+  optionalArg = arg: value:
+    if value != null && value != ""
+    then
+      if lib.isList value
+      then lib.map (val: "${arg}=${val}") value
+      else ["${arg}=${value}"]
+    else [];
+in {
+  meta.maintainers = [
+    maintainers.amsynist or "amsynist"
+  ];
+
+  options.services.jankyborders = {
+    enable = mkEnableOption "Enable the jankyborders service.";
+
+    package = mkPackageOptionMD pkgs "jankyborders" {};
+
+    width = mkOption {
+      type = types.float;
+      default = 5.0;
+      description = ''
+        Determines the width of the border. For example, width=5.0 creates a border 5.0 points wide.
+      '';
+    };
+
+    hidpi = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If set to on, the border will be drawn with retina resolution.
+      '';
+    };
+
+    active_color = mkOption {
+      type = types.str;
+      default = "0xFFFFFFFF";
+      example = "0xFFFFFFFF";
+      description = ''
+        Sets the border color for the focused window (format: 0xAARRGGBB). For instance, active_color="0xff00ff00" creates a green border.
+        For Gradient Border : active_color="gradient(top_right=0x9992B3F5,bottom_left=0x9992B3F5)"
+      '';
+    };
+
+    inactive_color = mkOption {
+      type = types.str;
+      default = "0xFFFFFFFF";
+      example = "0xFFFFFFFF";
+      description = ''
+        Sets the border color for all windows not in focus (format: 0xAARRGGBB).
+        For Gradient Border : inactive_color="gradient(top_right=0x9992B3F5,bottom_left=0x9992B3F5)"
+      '';
+    };
+
+    background_color = mkOption {
+      type = types.str;
+      default = "";
+      example = "0xFFFFFFFF";
+      description = ''
+        Sets the background fill color for all windows (only 0xAARRGGBB arguments supported).
+      '';
+    };
+
+    style = mkOption {
+      type = types.str;
+      default = "round";
+      example = "square/round";
+      description = ''
+        Specifies the style of the border (either round or square).
+      '';
+    };
+
+    blur_radius = mkOption {
+      type = types.float;
+      default = 0.0;
+      example = 5.0;
+      description = ''
+        Sets the blur radius applied to the borders or backgrounds with transparency.
+      '';
+    };
+
+    ax_focus = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If set to true, the (slower) accessibility API is used to resolve the focused window.
+      '';
+    };
+
+    blacklist = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["Safari" "kitty"];
+      description = ''
+        The applications specified here are excluded from being bordered.
+        For example, blacklist = [ "Safari" "kitty" ] excludes Safari and kitty from being bordered.
+      '';
+    };
+
+    whitelist = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["Arc" "USB Overdrive"];
+      description = ''
+        Once this list is populated, only applications listed here are considered for receiving a border.
+        If the whitelist is empty (default) it is inactive.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.blacklist != [] && cfg.whitelist != []);
+        message = "Cannot define both a blacklist and a whitelist for jankyborders.";
+      }
+    ];
+    environment.systemPackages = [cfg.package];
+
+    launchd.user.agents.jankyborders = {
+      serviceConfig.ProgramArguments =
+        [
+          "${cfg.package}/bin/borders"
+        ]
+        ++ (optionalArg "width" (toString cfg.width))
+        ++ (optionalArg "hidpi" (
+          if cfg.hidpi
+          then "on"
+          else "off"
+        ))
+        ++ (optionalArg "active_color" cfg.active_color)
+        ++ (optionalArg "inactive_color" cfg.inactive_color)
+        ++ (optionalArg "background_color" cfg.background_color)
+        ++ (optionalArg "style" cfg.style)
+        ++ (optionalArg "blur_radius" (toString cfg.blur_radius))
+        ++ (optionalArg "ax_focus" (
+          if cfg.ax_focus
+          then "on"
+          else "off"
+        ))
+        ++ (optionalArg "blacklist" (joinStrings cfg.blacklist))
+        ++ (optionalArg "whitelist" (joinStrings cfg.whitelist));
+      serviceConfig.KeepAlive = true;
+      serviceConfig.RunAtLoad = true;
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -138,6 +138,7 @@ let
     tests.services-synapse-bt = makeTest ./tests/services-synapse-bt.nix;
     tests.services-synergy = makeTest ./tests/services-synergy.nix;
     tests.services-yabai = makeTest ./tests/services-yabai.nix;
+    tests.services-jankyborders = makeTest ./tests/services-jankyborders.nix;
     tests.system-defaults-write = makeTest ./tests/system-defaults-write.nix;
     tests.system-environment = makeTest ./tests/system-environment.nix;
     tests.system-keyboard-mapping = makeTest ./tests/system-keyboard-mapping.nix;

--- a/tests/services-jankyborders.nix
+++ b/tests/services-jankyborders.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  jankyborders = pkgs.runCommand "borders-0.0.0" {} "mkdir $out";
+in
+
+{
+  services.jankyborders.enable = true;
+  services.jankyborders.package = jankyborders;
+  services.jankyborders.width = 5.0;
+  services.jankyborders.hidpi = true;
+  services.jankyborders.active_color = "0xFFFFFFFF";
+
+
+
+  test = ''
+    echo >&2 "checking jankyborders service in ~/Library/LaunchAgents"
+    grep "org.nixos.jankyborders" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
+    grep "${jankyborders}/bin/borders" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
+
+    echo >&2 "checking jankyborders config arguments"
+    grep "width=5.000000" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
+    grep "hidpi=on" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
+    grep "active_color=0xFFFFFFFF" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
+
+  '';
+}


### PR DESCRIPTION
[](url)Hi @LnL7,

I hope this message finds you well. I am submitting this PR to add a new NixOS module for [jankyborders](https://search.nixos.org/packages?channel=24.05&show=jankyborders&from=0&size=50&sort=relevance&type=packages&query=jankyborders). This module provides configuration options to enable the service and customize various parameters such as width, active and inactive colors, HiDPI mode, and focus settings.

Official Repo : https://github.com/FelixKratz/JankyBorders

### Summary of Changes
- Added a new module `services.jankyborders` to the NixOS configuration.
- Included configuration options for:
  - `width`
  - `active_color`
  - `inactive_color`
  - `hidpi`
  - `ax_focus`
  - `background_color`
  - `blur_radius`
  - `blacklist`
  - `whitelist`
- Implemented a test case to verify the correct setup of the `jankyborders` service.

### Module Usage Example
```nix
{ pkgs, ... }:
{
  services.jankyborders = {
    enable = true;
    package = pkgs.jankyborders;
    width = 5.0;
    active_color = "gradient(top_left=0xffDDB6F2,bottom_right=0xff96CDFB)";
    inactive_color = "0x9992B3F5";
    hidpi = true;
    ax_focus = true;
    whitelist = ["Arc" "USB Drive" "WezTerm"];
  };
}
```

