### PR TITLE
Drop compatibility for unsupported Nixpkgs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
   description = "John's darwin system";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-23.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin";
     nix-darwin.url = "github:LnL7/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/eval-config.nix
+++ b/eval-config.nix
@@ -16,6 +16,7 @@ let
   };
 
   eval = lib.evalModules (builtins.removeAttrs args [ "lib" ] // {
+    class = "darwin";
     modules = modules ++ [ argsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;
   });

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687274257,
-        "narHash": "sha256-TutzPriQcZ8FghDhEolnHcYU2oHIG5XWF+/SUBNnAOE=",
-        "path": "/nix/store/22qgs3skscd9bmrxv9xv4q5d4wwm5ppx-source",
-        "rev": "2c9ecd1f0400076a4d6b2193ad468ff0a7e7fdc5",
-        "type": "path"
+        "lastModified": 1718149104,
+        "narHash": "sha256-Ds1QpobBX2yoUDx9ZruqVGJ/uQPgcXoYuobBguyKEh8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e913ae340076bbb73d9f4d3d065c2bca7caafb16",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -21,7 +21,7 @@ let
     It isn't perfect, but it seems to cover a vast majority of use cases.
     Caveat: even if the package is reached by a different means,
     the path above will be shown and not e.g. `${config.services.foo.package}`. */
-  realManual = import ../../doc/manual {
+  manual = import ../../doc/manual {
     inherit pkgs config;
     version = config.system.darwinVersion;
     revision = config.system.darwinRevision;
@@ -43,38 +43,6 @@ let
           pkgSet;
       in scrubbedEval.options;
   };
-
-  # TODO: Remove this when dropping 22.11 support.
-  manual = realManual //
-    lib.optionalAttrs (!pkgs.buildPackages ? nixos-render-docs) rec {
-      optionsJSON = pkgs.writeTextFile {
-        name = "options.json-stub";
-        destination = "/share/doc/darwin/options.json";
-        text = "{}";
-      };
-      manpages = pkgs.writeTextFile {
-        name = "darwin-manpages-stub";
-        destination = "/share/man/man5/configuration.nix.5";
-        text = ''
-          .TH "CONFIGURATION\&.NIX" "5" "01/01/1980" "Darwin" "Darwin Reference Pages"
-          .SH "NAME"
-          \fIconfiguration\&.nix\fP \- Darwin system configuration specification
-          .SH "DESCRIPTION"
-          .PP
-          The nix\-darwin documentation now requires nixpkgs 23.05 to build.
-        '';
-      };
-      manualHTML = pkgs.writeTextFile {
-        name = "darwin-manual-html-stub";
-        destination = "/share/doc/darwin/index.html";
-        text = ''
-          <!DOCTYPE html>
-          <title>Darwin Configuration Options</title>
-          The nix-darwin documentation now requires nixpkgs 23.05 to build.
-        '';
-      };
-      manualHTMLIndex = "${manualHTML}/share/doc/darwin/index.html";
-    };
 
   helpScript = pkgs.writeScriptBin "darwin-help"
     ''

--- a/modules/documentation/default.nix
+++ b/modules/documentation/default.nix
@@ -11,9 +11,9 @@ let
   regularConfig = config;
 
   argsModule = {
-    config._module.args = regularConfig._module.args // {
+    config._module.args = lib.mkForce (regularConfig._module.args // {
       modules = [ ];
-    };
+    });
   };
 
   /* For the purpose of generating docs, evaluate options with each derivation
@@ -28,8 +28,9 @@ let
     inherit (config.system) nixpkgsRevision;
     options =
       let
-        scrubbedEval = evalModules {
-          modules = baseModules ++ [ argsModule ];
+        scrubbedEval = import ../../eval-config.nix {
+          inherit lib;
+          modules = [ argsModule ];
           specialArgs = { pkgs = scrubDerivations "pkgs" pkgs; };
         };
         scrubDerivations = namePrefix: pkgSet: mapAttrs


### PR DESCRIPTION
https://github.com/LnL7/nix-darwin/pull/932 already broke these versions, so we can do some clean‐up.