### PR TITLE
checks.nix: disable verifyBuildUsers for auto-allocate-uids

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -220,7 +220,7 @@ in
 
     system.checks.verifyBuildUsers = mkOption {
       type = types.bool;
-      default = true;
+      default = !(config.nix.settings.auto-allocate-uids or false);
       description = "Whether to run the Nix build users validation checks.";
     };
 


### PR DESCRIPTION
Follow https://github.com/LnL7/nix-darwin/pull/681, but disable the check automatically if `config.nix.settings.auto-allocate-uids` is explicitly set to `true`.

Note that by default `config.nix.settings = {}`, and this should not affact people who do not configure `nix.settings.auto-allocate-uids`.