### PR TITLE
programs.jdks: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -91,6 +91,7 @@
   ./programs/direnv.nix
   ./programs/fish.nix
   ./programs/gnupg.nix
+  ./programs/jdks.nix
   ./programs/man.nix
   ./programs/info
   ./programs/nix-index

--- a/modules/programs/jdks.nix
+++ b/modules/programs/jdks.nix
@@ -1,0 +1,98 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.jdks;
+in
+
+{
+  meta.maintainers = [
+    lib.maintainers.samasaur or "samasaur"
+  ];
+
+  options.programs.jdks = {
+    installed = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [];
+      example = lib.literalExpression
+        ''
+          [ pkgs.zulu8 pkgs.zulu11 pkgs.zulu17 ];
+        '';
+      description = ''
+        JDKs to install systemwide.
+
+        These JDKs will be symlinked into /Library/Java/JavaVirtualMachines
+      '';
+    };
+
+    # selected = lib.mkOption {
+    #   type = with lib.types; nullOr package; # use string instead? or version?
+    #   default = null;
+    #   example = "";
+    #   description = ''
+    #     The JDK to set as active.
+    #
+    #     Tools such as `java`, `javac`, etc. will use this JDK.
+    #
+    #     Should it also be added to the list of installed JDKs if not there?
+    #   '';
+    # };
+  };
+
+  config = {
+    # environment.variables = lib.mkIf (cfg.selected != null) {
+    #   JAVA_HOME = "hello";
+    # };
+    # launchd.envVariables = lib.mkIf (cfg.selected != null) {
+    #   JAVA_HOME = "hello";
+    # };
+
+    system.build.jdks = pkgs.runCommand "jdks"
+      { preferLocalBuild = true; }
+      ''
+        mkdir -p $out/Library/Java/JavaVirtualMachines
+        cd $out/Library/Java/JavaVirtualMachines
+        ${lib.concatMapStringsSep "\n" (jdk: ''ln -s "${jdk}/"*.jdk .'') cfg.installed}
+      '';
+
+    system.activationScripts.jdks.text = ''
+      echo "linking JDKs..." >&2
+
+      # link new JDKs
+      ${lib.optionalString (cfg.installed != []) ''
+        for _jdk in ${config.system.build.jdks}/Library/Java/JavaVirtualMachines/*.jdk; do
+          # $_jdk is the full nix store path (because it reads symlinks?), so shorten it (to e.g. `zulu-8.jdk`)
+          export jdk=$(basename $_jdk)
+          if ! diff "${config.system.build.jdks}/Library/Java/JavaVirtualMachines/''${jdk}" "/Library/Java/JavaVirtualMachines/''${jdk}" &> /dev/null; then
+            # $jdk from the new system is different from the one with the same name in /Library/Java/JavaVirtualMachines
+            if ! test -e "/Library/Java/JavaVirtualMachines/''${jdk}"; then
+              # one with the same name as $jdk doesn't exist in /Library/Java/JavaVirtualMachines
+              # do nothing
+              true
+            elif test -f "/Library/Java/JavaVirtualMachines/''${jdk}"; then
+              echo "Preexisting JDK /Library/Java/JavaVirtualMachines/$jdk was manually installed; not overwriting..." >&2
+              continue
+            elif test -L "/Library/Java/JavaVirtualMachines/''${jdk}"; then
+              echo "Preexisting JDK /Library/Java/JavaVirtualMachines/$jdk was manually linked into place; overwriting..." >&2
+            fi
+            # link $jdk into place, overwriting if necessary
+            ln -sf "${config.system.build.jdks}/Library/Java/JavaVirtualMachines/''${jdk}" "/Library/Java/JavaVirtualMachines/''${jdk}"
+          fi
+        done
+      ''}
+
+      # remove installed JDKs that were from the previous system but aren't in the new system
+      for _jdk in $(ls /run/current-system/Library/Java/JavaVirtualMachines 2> /dev/null); do
+        # this is not actually necessary, but I'm doing it for consistency
+        export jdk=$(basename $_jdk)
+        if test ! -e "${config.system.build.jdks}/Library/Java/JavaVirtualMachines/''${jdk}"; then
+          # $jdk was in the old system config, but not the new system config
+          if test -e "/Library/Java/JavaVirtualMachines/''${jdk}"; then
+            # $jdk was linked into place; remove it
+            echo "Removing old JDK ''${jdk}..." >&2
+            rm -f "/Library/Java/JavaVirtualMachines/''${jdk}"
+          fi
+        fi
+      done
+    '';
+  };
+}

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -70,6 +70,7 @@ in
       ${cfg.activationScripts.keyboard.text}
       ${cfg.activationScripts.fonts.text}
       ${cfg.activationScripts.nvram.text}
+      ${cfg.activationScripts.jdks.text}
 
       ${cfg.activationScripts.postActivation.text}
 

--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -123,6 +123,9 @@ in
         mkdir -p $out/user/Library
         ln -s ${cfg.build.launchd}/user/Library/LaunchAgents $out/user/Library/LaunchAgents
 
+        mkdir -p $out/Library/Java
+        ln -s ${cfg.build.jdks}/Library/Java/JavaVirtualMachines $out/Library/Java/JavaVirtualMachines
+
         echo "$activationScript" > $out/activate
         substituteInPlace $out/activate --subst-var out
         chmod u+x $out/activate


### PR DESCRIPTION
This PR allows you to install Java versions system-wide.

I've left stubs in place to allow setting the JDK to use, but I have not yet implemented that, so this only adds support for `programs.jdk.installed`