### PR TITLE
Use the correct file location for `SoftwareUpdate` plist.

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -14,7 +14,7 @@ let
   alf = defaultsToList "/Library/Preferences/com.apple.alf" cfg.alf;
   loginwindow = defaultsToList "/Library/Preferences/com.apple.loginwindow" cfg.loginwindow;
   smb = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.smb.server" cfg.smb;
-  SoftwareUpdate = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.SoftwareUpdate" cfg.SoftwareUpdate;
+  SoftwareUpdate = defaultsToList "/Library/Preferences/com.apple.SoftwareUpdate" cfg.SoftwareUpdate;
 
   # userDefaults
   GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";


### PR DESCRIPTION
I'm not sure if something changed in macOS or if this ever worked (@treffynnon, who originally added this might know 🤷).

I've tried both `true` and `false` for [`system.defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates`](https://daiderd.com/nix-darwin/manual/index.html#opt-system.defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates) and nothing seems to change in System Settings as I would have expected it to.

<img width="827" alt="image" src="https://github.com/LnL7/nix-darwin/assets/484429/eb6a0a24-fc2f-4bf6-b97d-3ff3b5b1e1fd">

I _did_ discover that there's a `/Library/Preferences/com.apple.SoftwareUpdate.plist` on my mac which _does_ appear to reflect the Software Update settings.

> `$ plutil -p /Library/Preferences/com.apple.SoftwareUpdate.plist`
```
{
  "AutomaticallyInstallMacOSUpdates" => 0
  "LastAttemptBuildVersion" => "14.5 (23F79)"
  "LastAttemptSystemVersion" => "14.5 (23F79)"
  "LastBackgroundSuccessfulDate" => 2024-07-02 01:19:50 +0000
  "LastFullSuccessfulDate" => 2024-07-02 16:26:36 +0000
  "LastRecommendedMajorOSBundleIdentifier" => ""
  "LastRecommendedUpdatesAvailable" => 0
  "LastResultCode" => 2
  "LastSessionSuccessful" => 1
  "LastSuccessfulDate" => 2024-07-02 16:27:14 +0000
  "LastUpdatesAvailable" => 0
  "PrimaryLanguages" => [
    0 => "en-US"
    1 => "en"
  ]
  "RecommendedUpdates" => [
  ]
}
```

I was able to write to this file and get the expected results in System Settings.

> `$ sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist AutomaticallyInstallMacOSUpdates -bool true`

This leads me to believe that the proposed changes will work as expected (at least on a MacBook Pro with an Apple M3 Max running Sonoma 14.5 😅).