### PR TITLE
`services.nix-daemon.environmentVariables`

### DIFF
--- a/modules/services/nix-daemon.nix
+++ b/modules/services/nix-daemon.nix
@@ -22,7 +22,9 @@ in
 
     services.nix-daemon.environmentVariables = mkOption {
       type = types.attrsOf types.str;
-      default = { };
+      default =
+        # See https://github.com/LnL7/nix-darwin/commit/a9e0f71c50fc9a72e22e991e323a6a7e50bfc0d7.
+        config.nix.envVars;
       example = {
         AWS_CONFIG_FILE = "/etc/nix/aws/config";
         AWS_SHARED_CREDENTIALS_FILE  = "/etc/nix/aws/credentials";
@@ -74,7 +76,6 @@ in
 
       serviceConfig.EnvironmentVariables = mkMerge [
         cfg.environmentVariables
-        config.nix.envVars
         {
           NIX_SSL_CERT_FILE = mkIf
             (config.environment.variables ? NIX_SSL_CERT_FILE)

--- a/modules/services/nix-daemon.nix
+++ b/modules/services/nix-daemon.nix
@@ -20,6 +20,17 @@ in
       description = "Whether to make the nix-daemon service socket activated.";
     };
 
+    services.nix-daemon.environmentVariables = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        AWS_CONFIG_FILE = "/etc/nix/aws/config";
+        AWS_SHARED_CREDENTIALS_FILE  = "/etc/nix/aws/credentials";
+        NIX_SSL_CERT_FILE = "/etc/nix/my-cert-file.crt";
+      };
+      description = "Extra environment variables provided to nix-daemon";
+    };
+
     services.nix-daemon.logFile = mkOption {
       type = types.nullOr types.path;
       default = null;
@@ -62,6 +73,7 @@ in
         };
 
       serviceConfig.EnvironmentVariables = mkMerge [
+        cfg.environmentVariables
         config.nix.envVars
         {
           NIX_SSL_CERT_FILE = mkIf


### PR DESCRIPTION
https://github.com/LnL7/nix-darwin/commit/a9e0f71c50fc9a72e22e991e323a6a7e50bfc0d7 made it possible to modify the environment passed to nix-daemon. This turns out to also be useful for [other things](https://github.com/NixOS/nix/issues/2161#issuecomment-2204763331), so let's make it a little more idiomatic and document it.
