### PR TITLE
chore: removing deprecations for 25.05 nix

### DIFF
--- a/modules/services/jankyborders/default.nix
+++ b/modules/services/jankyborders/default.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  inherit (lib) maintainers mkEnableOption mkIf mkPackageOptionMD mkOption types;
+  inherit (lib) maintainers mkEnableOption mkIf mkPackageOption mkOption types;
 
   cfg = config.services.jankyborders;
   joinStrings = strings: builtins.concatStringsSep "," strings;
@@ -24,7 +24,7 @@ in {
   options.services.jankyborders = {
     enable = mkEnableOption "Enable the jankyborders service.";
 
-    package = mkPackageOptionMD pkgs "jankyborders" {};
+    package = mkPackageOption pkgs "jankyborders" {};
 
     width = mkOption {
       type = types.float;


### PR DESCRIPTION
Removing deprecations for Nix 25.05. Apologies for closing the previous PR that got approved - my local nix-darwin fork wasn't in sync and I made a mess. 