### PR TITLE
defaults: only restart Dock when user is logged in

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -109,8 +109,11 @@ in
         ${concatStringsSep "\n" CustomUserPreferences}
 
         ${optionalString (length dock > 0) ''
-          echo >&2 "restarting Dock..."
-          killall Dock
+          # Only restart Dock if current user is logged in
+          if pgrep -xu $UID Dock; then
+            echo >&2 "restarting Dock..."
+            killall Dock || true
+          fi
         ''}
       '';
 


### PR DESCRIPTION
This can occur if your primary user is not logged in and you try to do a `darwin-rebuild switch`