### PR TITLE
github-runnners: fix workDir missing on reboot

### DIFF
--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -41,7 +41,7 @@ in
     in
     {
       launchd = mkIf cfg.enable {
-        text = mkBefore (''
+        text = mkBefore ''
           echo >&2 "setting up GitHub Runner '${cfg.name}'..."
 
           ${pkgs.coreutils}/bin/mkdir -p -m 0750 ${escapeShellArg (mkStateDir cfg)}
@@ -49,10 +49,7 @@ in
 
           ${pkgs.coreutils}/bin/mkdir -p -m 0750 ${escapeShellArg (mkLogDir cfg)}
           ${pkgs.coreutils}/bin/chown ${user}:${group} ${escapeShellArg (mkLogDir cfg)}
-        '' + optionalString (cfg.workDir == null) ''
-          ${pkgs.coreutils}/bin/mkdir -p -m 0750 ${escapeShellArg (mkWorkDir cfg)}
-          ${pkgs.coreutils}/bin/chown ${user}:${group} ${escapeShellArg (mkWorkDir cfg)}
-        '');
+        '';
       };
     }));
 
@@ -62,6 +59,9 @@ in
       stateDir = mkStateDir cfg;
       logDir = mkLogDir cfg;
       workDir = mkWorkDir cfg;
+      user = if (cfg.user != null) then cfg.user else "_github-runner";
+      # If both user and group are null then we manage the group, otherwise if only group is null then there's no group
+      group = if (cfg.group != null) then group else if (cfg.user == null) then "_github-runner" else "";
     in
     nameValuePair
       (mkSvcName name)
@@ -116,6 +116,12 @@ in
           ''
             echo "Configuring GitHub Actions Runner"
 
+            ${optionalString (cfg.workDir == null) ''
+              # /var/run gets cleared every reboot so we need to create it before starting the service
+              ${pkgs.coreutils}/bin/mkdir -p -m 0750 ${escapeShellArg workDir}
+              ${pkgs.coreutils}/bin/chown ${user}:${group} ${escapeShellArg workDir}
+            ''}
+
             # Always clean the working directory
             ${pkgs.findutils}/bin/find ${escapeShellArg workDir} -mindepth 1 -delete
 
@@ -147,7 +153,7 @@ in
             StandardErrorPath = "${logDir}/launchd-stderr.log";
             StandardOutPath = "${logDir}/launchd-stdout.log";
             ThrottleInterval = 30;
-            UserName = if (cfg.user != null) then cfg.user else "_github-runner";
+            UserName = user;
             WatchPaths = [
               "/etc/resolv.conf"
               "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"


### PR DESCRIPTION
As `/var/run` gets cleared on every reboot, all jobs will fail with `Access to the path '/var/run/github-runners/<name>' is denied.`