### PR TITLE
Fix: per user activation

### DIFF
--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -70,6 +70,7 @@ in
       ${cfg.activationScripts.keyboard.text}
       ${cfg.activationScripts.fonts.text}
       ${cfg.activationScripts.nvram.text}
+      ${cfg.activationScripts.userDefaults.text}
 
       ${cfg.activationScripts.postActivation.text}
 
@@ -105,7 +106,6 @@ in
       ${cfg.activationScripts.checks.text}
       ${cfg.activationScripts.etcChecks.text}
       ${cfg.activationScripts.extraUserActivation.text}
-      ${cfg.activationScripts.userDefaults.text}
       ${cfg.activationScripts.userLaunchd.text}
       ${cfg.activationScripts.homebrew.text}
 

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -10,6 +10,11 @@ let
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
 
+  configurableUsers = lib.filterAttrs (n: v: lib.hasPrefix "/Users" v.home) config.users.users;
+  userDefaultsToList = domain: attrs: builtins.concatLists (mapAttrsToList (n: v:
+    (builtins.map (cmd: "sudo -u ${n} " + cmd) (defaultsToList "${v.home}/Library/Preferences/${domain}" attrs))
+  ) configurableUsers);
+
   # defaults
   alf = defaultsToList "/Library/Preferences/com.apple.alf" cfg.alf;
   loginwindow = defaultsToList "/Library/Preferences/com.apple.loginwindow" cfg.loginwindow;
@@ -17,23 +22,23 @@ let
   SoftwareUpdate = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.SoftwareUpdate" cfg.SoftwareUpdate;
 
   # userDefaults
-  GlobalPreferences = defaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
-  LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
-  NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
-  menuExtraClock = defaultsToList "com.apple.menuextra.clock" cfg.menuExtraClock;
-  dock = defaultsToList "com.apple.dock" cfg.dock;
-  finder = defaultsToList "com.apple.finder" cfg.finder;
-  magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
-  magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
-  screencapture = defaultsToList "com.apple.screencapture" cfg.screencapture;
-  screensaver = defaultsToList "com.apple.screensaver" cfg.screensaver;
-  spaces = defaultsToList "com.apple.spaces" cfg.spaces;
-  trackpad = defaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
-  trackpadBluetooth = defaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
-  universalaccess = defaultsToList "com.apple.universalaccess" cfg.universalaccess;
-  ActivityMonitor = defaultsToList "com.apple.ActivityMonitor" cfg.ActivityMonitor;
-  CustomUserPreferences = flatten (mapAttrsToList (name: value: defaultsToList name value) cfg.CustomUserPreferences);
-  CustomSystemPreferences = flatten (mapAttrsToList (name: value: defaultsToList name value) cfg.CustomSystemPreferences);
+  GlobalPreferences = userDefaultsToList ".GlobalPreferences" cfg.".GlobalPreferences";
+  LaunchServices = userDefaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
+  NSGlobalDomain = userDefaultsToList ".GlobalPreferences" cfg.NSGlobalDomain;
+  menuExtraClock = userDefaultsToList "com.apple.menuextra.clock" cfg.menuExtraClock;
+  dock = userDefaultsToList "com.apple.dock" cfg.dock;
+  finder = userDefaultsToList "com.apple.finder" cfg.finder;
+  magicmouse = userDefaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
+  magicmouseBluetooth = userDefaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
+  screencapture = userDefaultsToList "com.apple.screencapture" cfg.screencapture;
+  screensaver = userDefaultsToList "com.apple.screensaver" cfg.screensaver;
+  spaces = userDefaultsToList "com.apple.spaces" cfg.spaces;
+  trackpad = userDefaultsToList "com.apple.AppleMultitouchTrackpad" cfg.trackpad;
+  trackpadBluetooth = userDefaultsToList "com.apple.driver.AppleBluetoothMultitouch.trackpad" cfg.trackpad;
+  universalaccess = userDefaultsToList "com.apple.universalaccess" cfg.universalaccess;
+  ActivityMonitor = userDefaultsToList "com.apple.ActivityMonitor" cfg.ActivityMonitor;
+  CustomUserPreferences = flatten (mapAttrsToList (name: value: userDefaultsToList name value) cfg.CustomUserPreferences);
+  CustomSystemPreferences = flatten (mapAttrsToList (name: value: userDefaultsToList name value) cfg.CustomSystemPreferences);
 
   mkIfAttrs = list: mkIf (any (attrs: attrs != { }) list);
 in


### PR DESCRIPTION
Would partially solve some of the issues around per user activation scripts (ex: #554). Summary of the issue is that `system.defaults` does not get applied to other users on activation. This is because each call to `defaults write` must be done by each user for the preferences to actually apply (i.e. root/admin cannot call this on their behalf). The only solution is to run each of the `defaults write` calls with `sudo -u` for each configurable user (those within `/Users`) to ensure `system.defaults` are actually applied on the whole system for all users. **Note:** this means the user running `darwin-rebuild` must also be in sudoers and capable of using `sudo -u` for each user.

I think the real solution for per user scripts is the one discussed elsewhere (ex: #96) and remove them entirely in favor of home-manager. Until that happens though, this is the only method I know to fix activation in a multi-user system for configs that should be applied to all users.