### PR TITLE
Overhaul user management

### DIFF
--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -170,6 +170,7 @@ in
   config.users = mkIf (any (cfg: cfg.enable && cfg.user == null && cfg.group == null) (attrValues config.services.github-runners)) {
     users."_github-runner" = {
       createHome = false;
+      isSystemUser = true;
       description = "GitHub Runner service user";
       gid = config.users.groups."_github-runner".gid;
       home = "/var/lib/github-runners";

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -160,7 +160,7 @@ in
             echo "[1;31mwarning: user $user is last user in admin group, skipping...[0m" >&2
           else
             echo "deleting user $user..."
-            # '-keepHome' doesn't always work so archive the home dir manually
+            # NOTE: '-keepHome' doesn't always work so archive the home dir manually
             cp -ax "/Users/$user" "/Users/$user (Deleted)" 2>/dev/null || true
             sysadminctl -deleteUser "$user" 2>/dev/null
             admins=(''${admins[@]/$user})
@@ -186,7 +186,7 @@ in
         # Always create users that don't exist
         if [ -z "$ignore" ]; then
           echo "creating user ${v.name}..." >&2
-          # Use sysadminctl to ensure all macOS user attributes are set.
+          # NOTE: use sysadminctl to ensure all macOS user attributes are set.
           # Otherwise, user management might break in System Settings with just dscl.
           ${concatStringsSep " " [
             "sysadminctl -addUser '${v.name}'"
@@ -203,7 +203,7 @@ in
           ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
           ${
              optionalString v.isTokenUser ''
-               # Only admin with token can set a token for a user
+               # NOTE: only admin with token can set a token for a user
                sysadminctl -adminUser "$(echo $tokenAdmins | head -n 1)" -adminPassword - \
                 -secureTokenOn '${v.name}' -password '${if v.password == null then "-" else "${v.password}"}'
              ''

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -169,6 +169,7 @@ in
               -GID ${toString v.gid} \
               -fullName '${v.description}' \
               -home '${v.home}' \
+              ${optionalString v.initialPassword != null "-password '${v.initialPassword}' \\"}
               -shell ${lib.escapeShellArg (shellPath v.shell)}
             dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
             ${optionalString v.createHome "createhomedir -cu '${v.name}'"}

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -169,10 +169,14 @@ in
               -GID ${toString v.gid} \
               -fullName '${v.description}' \
               -home '${v.home}' \
-              ${optionalString v.initialPassword != null "-password '${v.initialPassword}' \\"}
+              ${optionalString (v.initialPassword != null) "-password '${v.initialPassword}' \\"}
               -shell ${lib.escapeShellArg (shellPath v.shell)}
             dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
             ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
+            ${
+               optionalString (v.isHidden == false && v.initialPassword != null)
+                 "sysadminctl -adminUser \"$(id -F 501)\" -adminPassword - -secureTokenOn '${v.name}' -password '${v.initialPassword}'"
+             }
           fi
           # Always set the shell path, in case it was updated
           dscl . -create '/Users/${v.name}' UserShell ${lib.escapeShellArg (shellPath v.shell)}

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -9,19 +9,6 @@ let
   user = import ./user.nix;
 
   toArguments = concatMapStringsSep " " (v: "'${v}'");
-  toGID = v: { "${toString v.gid}" = v.name; };
-  toUID = v: { "${toString v.uid}" = v.name; };
-
-  isCreated = list: name: elem name list;
-  isDeleted = attrs: name: ! elem name (mapAttrsToList (n: v: v.name) attrs);
-
-  gids = mapAttrsToList (n: toGID) (filterAttrs (n: v: isCreated cfg.knownGroups v.name) cfg.groups);
-  uids = mapAttrsToList (n: toUID) (filterAttrs (n: v: isCreated cfg.knownUsers v.name) cfg.users);
-
-  createdGroups = mapAttrsToList (n: v: cfg.groups."${v}") cfg.gids;
-  createdUsers = mapAttrsToList (n: v: cfg.users."${v}") cfg.uids;
-  deletedGroups = filter (n: isDeleted cfg.groups n) cfg.knownGroups;
-  deletedUsers = filter (n: isDeleted cfg.users n) cfg.knownUsers;
 
   packageUsers = filterAttrs (_: u: u.packages != []) cfg.users;
 
@@ -31,6 +18,15 @@ let
     if types.shellPackage.check v
     then "/run/current-system/sw${v.shellPath}"
     else v;
+
+  dsclSearch = path: key: val: ''dscl . -search ${path} ${key} ${val} | /usr/bin/cut -s -w -f 1 | awk "NF"'';
+  diffArrays = a1: a2: ''echo ''${${a1}[@]} ''${${a1}[@]} ''${${a2}[@]} | tr ' ' '\n' | sort | uniq -u'';
+  groupMembership = g: ''
+    dscl . -list /Users | while read user; do
+      printf '%s ' "$user";
+      dsmemberutil checkmembership -U "$user" -G "${g}";
+    done | grep "is a member" | /usr/bin/cut -s -w -f 1
+  '';
 
 in
 
@@ -56,6 +52,17 @@ in
       '';
     };
 
+    users.mutableUsers = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        If set to true, you are free to add new users
+        and groups to the system with the ordinary sysadminctl and dscl commands.
+        The initial password for a user will be set according to users.users,
+        but existing passwords will not be changed.
+      '';
+    };
+
     users.groups = mkOption {
       type = types.attrsOf (types.submodule group);
       default = {};
@@ -68,18 +75,6 @@ in
       description = "Configuration for users.";
     };
 
-    users.gids = mkOption {
-      internal = true;
-      type = types.attrsOf types.str;
-      default = {};
-    };
-
-    users.uids = mkOption {
-      internal = true;
-      type = types.attrsOf types.str;
-      default = {};
-    };
-
     users.forceRecreate = mkOption {
       internal = true;
       type = types.bool;
@@ -90,112 +85,154 @@ in
 
   config = {
 
-    users.gids = mkMerge gids;
-    users.uids = mkMerge uids;
+    assertions = [
+      {
+        assertion = !cfg.mutableUsers -> !cfg.forceRecreate ->
+          any id (mapAttrsToList (n: v:
+            (v.password != null && v.isTokenUser && v.isAdminUser)
+          ) cfg.users);
+        message = ''
+          You must set a combined admin and token user with a password
+          to prevent being locked out of your system.
+          If you really want to be locked out of your system, set users.forceRecreate = true;
+          However, you are most probably better off by setting users.mutableUsers = true; and
+          manually changing the user with dscl.
+        '';
+      }
+    ] ++ (mapAttrsToList (n: v: {
+      assertion = let
+        isEffectivelySystemUser = hasPrefix "_" n && (
+          v.isSystemUser || (v.uid != null && (v.uid >= 200 && v.uid <= 400))
+        );
+      in xor isEffectivelySystemUser v.isNormalUser;
+        message = ''
+          Exactly one of users.users.${n}.isSystemUser and users.users.${n}.isNormalUser must be set.
+          System user name must start with '_' and uid in range (200-400).
+        '';
+    }) cfg.users);
 
-    system.activationScripts.groups.text = mkIf (cfg.knownGroups != []) ''
+    system.activationScripts.groups.text = mkIf ((length (attrNames cfg.groups)) > 0) ''
       echo "setting up groups..." >&2
 
-      ${concatMapStringsSep "\n" (v: ''
-        ${optionalString cfg.forceRecreate ''
-          g=$(dscl . -read '/Groups/${v.name}' PrimaryGroupID 2> /dev/null) || true
-          g=''${g#PrimaryGroupID: }
-          if [[ "$g" -eq ${toString v.gid} ]]; then
-            echo "deleting group ${v.name}..." >&2
-            dscl . -delete '/Groups/${v.name}' 2> /dev/null
-          else
-            echo "[1;31mwarning: existing group '${v.name}' has unexpected gid $g, skipping...[0m" >&2
-          fi
-        ''}
+      g=(${toArguments (attrNames cfg.groups)})
+      nix_g=($(${dsclSearch "/Groups" "NixDeclarative" "true"}))
 
-        g=$(dscl . -read '/Groups/${v.name}' PrimaryGroupID 2> /dev/null) || true
-        g=''${g#PrimaryGroupID: }
-        if [ -z "$g" ]; then
-          echo "creating group ${v.name}..." >&2
-          dscl . -create '/Groups/${v.name}' PrimaryGroupID ${toString v.gid}
-          dscl . -create '/Groups/${v.name}' RealName '${v.description}'
-          g=${toString v.gid}
-        fi
+      ${optionalString (!cfg.mutableUsers || cfg.forceRecreate) ''
+        # Delete old nix managed groups not in config
+        deleted=(${if cfg.forceRecreate then "$g" else "$(${diffArrays "g" "nix_g"})"})
+        for group in ''${deleted[@]}; do
+          echo "deleting group $group..."
+          dscl . -delete "/Groups/$group"
+        done
+        unset deleted
+      ''}
 
-        if [ "$g" -eq ${toString v.gid} ]; then
-          g=$(dscl . -read '/Groups/${v.name}' GroupMembership 2> /dev/null) || true
-          if [ "$g" != 'GroupMembership: ${concatStringsSep " " v.members}' ]; then
-            echo "updating group members ${v.name}..." >&2
-            dscl . -create '/Groups/${v.name}' GroupMembership ${toArguments v.members}
-          fi
-        else
-          echo "[1;31mwarning: existing group '${v.name}' has unexpected gid $g, skipping...[0m" >&2
+      # Create group properties according to config.
+      # Skip group if users.mutableUsers = true and group already exists.
+      ${concatMapStringsSep "\n" (v: v) (mapAttrsToList (n: v: ''
+        ignore=(${if cfg.mutableUsers
+          then "$(dscl . -read /Groups/${n} PrimaryGroupID 2> /dev/null || true)"
+          else ""
+        })
+        if [ -z "$ignore" ]; then
+          echo "creating group ${n}..." >&2
+          dscl . -create '/Groups/${n}' PrimaryGroupID ${toString v.gid}
+          dscl . -create '/Groups/${n}' RealName '${v.description}'
+          dscl . -create '/Groups/${n}' GroupMembership ${toArguments v.members}
+          dscl . -create '/Groups/${n}' NixDeclarative 'true'
         fi
-      '') createdGroups}
-
-      ${concatMapStringsSep "\n" (name: ''
-        g=$(dscl . -read '/Groups/${name}' PrimaryGroupID 2> /dev/null) || true
-        g=''${g#PrimaryGroupID: }
-        if [ -n "$g" ]; then
-          if [ "$g" -gt 501 ]; then
-            echo "deleting group ${name}..." >&2
-            dscl . -delete '/Groups/${name}' 2> /dev/null
-          else
-            echo "[1;31mwarning: existing group '${name}' has unexpected gid $g, skipping...[0m" >&2
-          fi
-        fi
-      '') deletedGroups}
+      '') cfg.groups)}
     '';
 
-    system.activationScripts.users.text = mkIf (cfg.knownUsers != []) ''
+    system.activationScripts.users.text = mkIf ((length (attrNames cfg.users)) > 0) ''
       echo "setting up users..." >&2
 
-      ${concatMapStringsSep "\n" (v: ''
-        ${optionalString cfg.forceRecreate ''
-          u=$(dscl . -read '/Users/${v.name}' UniqueID 2> /dev/null) || true
-          u=''${u#UniqueID: }
-          if [[ "$u" -eq ${toString v.uid} ]]; then
-            echo "deleting user ${v.name}..." >&2
-            sysadminctl -deleteUser '${v.name}' 2>/dev/null
-          else
-            echo "[1;31mwarning: existing user '${v.name}' has unexpected uid $u, skipping...[0m" >&2
-          fi
-        ''}
+      u=(${toArguments (attrNames cfg.users)})
+      nix_u=($(${dsclSearch "/Users" "NixDeclarative" "true"}))
+      admins=($(${groupMembership "admin"}))
+      admins=(''${admins[@]/root})
 
-        u=$(dscl . -read '/Users/${v.name}' UniqueID 2> /dev/null) || true
-        u=''${u#UniqueID: }
-        if [[ -n "$u" && "$u" -ne "${toString v.uid}" ]]; then
-          echo "[1;31mwarning: existing user '${v.name}' has unexpected uid $u, skipping...[0m" >&2
-        else
-          if [ -z "$u" ]; then
-            echo "creating user ${v.name}..." >&2
-            sysadminctl -addUser '${v.name}' \
-              ${optionalString (v.uid != null) "-UID ${toString v.uid} \\"}
-              ${optionalString (v.gid != null) "-GID ${toString v.gid} \\"}
-              ${optionalString (v.description != "") "-fullName '${v.description}' \\"}
-              ${optionalString (v.isNormalUser == false && v.createHome) "-home '${v.home}' \\"}
-              ${optionalString v.isSystemUser "-roleAccount \\"}
-              ${optionalString (v.initialPassword != null) "-password '${v.initialPassword}' \\"}
-              -shell ${lib.escapeShellArg (shellPath v.shell)}
-            dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
-            ${optionalString (v.isNormalUser == false && v.createHome) "createhomedir -cu '${v.name}'"}
-            ${
-               optionalString v.isTokenUser
-                 "sysadminctl -adminUser \"$(id -F 501)\" -adminPassword - -secureTokenOn '${v.name}' -password '${v.initialPassword}'"
-             }
+      ${optionalString (!cfg.mutableUsers || cfg.forceRecreate) ''
+        # Delete old nix managed users not in config
+        deleted=(${if cfg.forceRecreate then "$u" else "$(${diffArrays "u" "nix_u"})"})
+        for user in ''${deleted[@]}; do
+          if [ $(wc -w <<<''${admins[@]/$user}) -eq 0 ]; then
+            echo "[1;31mwarning: user $user is last user in admin group, skipping...[0m" >&2
+          else
+            echo "deleting user $user..."
+            # '-keepHome' doesn't always work so archive the home dir manually
+            cp -ax "/Users/$user" "/Users/$user (Deleted)" 2>/dev/null || true
+            sysadminctl -deleteUser "$user" 2>/dev/null
+            admins=(''${admins[@]/$user})
           fi
-          # Always set the shell path, in case it was updated
+        done
+        unset deleted
+      ''}
+
+      # Get admins with secure tokens for management of regular token users
+      tokenAdmins=($(for user in "''${admins[@]}"; do
+        printf '%s ' "$user";
+        sysadminctl -secureTokenStatus "$user" 2>/dev/stdout;
+      done | grep "is ENABLED" | /usr/bin/cut -s -w -f 1))
+
+      # Create and overwrite user properties according to config.
+      # Skip overwrite if users.mutableUsers = true,
+      # users.forceRecreate = false, and user already exists.
+      ${concatMapStringsSep "\n" (v: v) (mapAttrsToList (n: v: ''
+        ignore=("$(dscl . -read /Users/${n} UniqueID 2> /dev/null || true)")
+        force="${if (!cfg.mutableUsers && cfg.forceRecreate) then "true" else ""}"
+        mutable="${if cfg.mutableUsers then "true" else ""}"
+
+        # Always create users that don't exist
+        if [ -z "$ignore" ]; then
+          echo "creating user ${v.name}..." >&2
+          # Use sysadminctl to ensure all macOS user attributes are set.
+          # Otherwise, user management might break in System Settings with just dscl.
+          ${concatStringsSep " " [
+            "sysadminctl -addUser '${v.name}'"
+            "-shell ${lib.escapeShellArg (shellPath v.shell)}"
+            "${optionalString (v.uid != null) "-UID ${toString v.uid}"}"
+            "${optionalString (v.gid != null) "-GID ${toString v.gid}"}"
+            "${optionalString (v.description != "") "-fullName '${v.description}'"}"
+            "${optionalString (v.home != "/Users/${v.name}") "-home '${v.home}'"}"
+            "${optionalString (v.password != null) "-password '${v.password}'"}"
+            "${optionalString v.isSystemUser "-roleAccount"}"
+            "${optionalString v.isAdminUser "-admin"}"
+          ]}
+          dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
+          ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
+          ${
+             optionalString v.isTokenUser ''
+               # Only admin with token can set a token for a user
+               sysadminctl -adminUser "$(echo $tokenAdmins | head -n 1)" -adminPassword - \
+                -secureTokenOn '${v.name}' -password '${if v.password == null then "-" else "${v.password}"}'
+             ''
+           }
+        elif [ -n "$force" ]; then
+          dscl . -create '/Users/${v.name}' UniqueID ${toString v.uid}
+          dscl . -create '/Users/${v.name}' PrimaryGroupID ${toString v.gid}
+          dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
+          dscl . -create '/Users/${v.name}' RealName '${v.description}'
+          dscl . -create '/Users/${v.name}' NFSHomeDirectory '${v.home}'
           dscl . -create '/Users/${v.name}' UserShell ${lib.escapeShellArg (shellPath v.shell)}
-        fi
-      '') createdUsers}
-
-      ${concatMapStringsSep "\n" (name: ''
-        u=$(dscl . -read '/Users/${name}' UniqueID 2> /dev/null) || true
-        u=''${u#UniqueID: }
-        if [ -n "$u" ]; then
-          if [ "$u" -gt 501 ]; then
-            echo "deleting user ${name}..." >&2
-            sysadminctl -deleteUser '${name}' 2> /dev/null
+          ${optionalString v.isAdminUser "dscl . -merge '/Groups/admin' GroupMembership '${v.name}'"}
+          ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
+        elif [ -z "$mutable" ]; then
+          isTokenUser=$(sysadminctl -secureTokenStatus '${v.name}' 2>/dev/stdout \
+          | grep -o "is ENABLED" | wc -w)
+          # Admin with token is needed to reset user with token
+          if [ "$isTokenUser" -gt 0 ]; then
+            sysadminctl -adminUser "$(echo $tokenAdmins | head -n 1)" -adminPassword - \
+            -resetPasswordFor '${v.name}' -newPassword "${v.password}"
           else
-            echo "[1;31mwarning: existing user '${name}' has unexpected uid $u, skipping...[0m" >&2
+            sysadminctl -resetPasswordFor '${v.name}' -newPassword "${v.password}"
           fi
+          unset isTokenUser
+          dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
         fi
-      '') deletedUsers}
+        # Always set managed user NixDeclarative property if Nix is managing the user
+        dscl . -create '/Users/${v.name}' NixDeclarative 'true'
+      '') cfg.users)}
     '';
 
     environment.etc = mapAttrs' (name: { packages, ... }: {

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -151,7 +151,7 @@ in
           u=''${u#UniqueID: }
           if [[ "$u" -eq ${toString v.uid} ]]; then
             echo "deleting user ${v.name}..." >&2
-            dscl . -delete '/Users/${v.name}' 2> /dev/null
+            sysadminctl -deleteUser '${v.name}' 2>/dev/null
           else
             echo "[1;31mwarning: existing user '${v.name}' has unexpected uid $u, skipping...[0m" >&2
           fi
@@ -164,11 +164,13 @@ in
         else
           if [ -z "$u" ]; then
             echo "creating user ${v.name}..." >&2
-            dscl . -create '/Users/${v.name}' UniqueID ${toString v.uid}
-            dscl . -create '/Users/${v.name}' PrimaryGroupID ${toString v.gid}
+            sysadminctl -addUser '${v.name}' \
+              -UID ${toString v.uid} \
+              -GID ${toString v.gid} \
+              -fullName '${v.description}' \
+              -home '${v.home}' \
+              -shell ${lib.escapeShellArg (shellPath v.shell)}
             dscl . -create '/Users/${v.name}' IsHidden ${if v.isHidden then "1" else "0"}
-            dscl . -create '/Users/${v.name}' RealName '${v.description}'
-            dscl . -create '/Users/${v.name}' NFSHomeDirectory '${v.home}'
             ${optionalString v.createHome "createhomedir -cu '${v.name}'"}
           fi
           # Always set the shell path, in case it was updated
@@ -182,7 +184,7 @@ in
         if [ -n "$u" ]; then
           if [ "$u" -gt 501 ]; then
             echo "deleting user ${name}..." >&2
-            dscl . -delete '/Users/${name}' 2> /dev/null
+            sysadminctl -deleteUser '${name}' 2> /dev/null
           else
             echo "[1;31mwarning: existing user '${name}' has unexpected uid $u, skipping...[0m" >&2
           fi

--- a/modules/users/user.nix
+++ b/modules/users/user.nix
@@ -58,9 +58,14 @@ with lib;
     };
 
     initialPassword = mkOption {
-      type = types.string;
-      default = false;
-      description = "Sets the initial password for the user.";
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Specifies the initial password for the user,
+        i.e. the password assigned if the user does not already exist.
+        If {option}`users.isHidden` is set to false,
+        then the password is used for configuring a secure token for disk encryption.
+      '';
     };
 
     shell = mkOption {

--- a/modules/users/user.nix
+++ b/modules/users/user.nix
@@ -57,6 +57,12 @@ with lib;
       description = "Create the home directory when creating the user.";
     };
 
+    initialPassword = mkOption {
+      type = types.string;
+      default = false;
+      description = "Sets the initial password for the user.";
+    };
+
     shell = mkOption {
       type = types.either types.shellPackage types.path;
       default = "/sbin/nologin";

--- a/modules/users/user.nix
+++ b/modules/users/user.nix
@@ -152,8 +152,8 @@ with lib;
     })
 
     {
-      password = if config.initialPassword != null
-        then "${config.initialPassword}" else "${config.password}";
+      password = mkDefault (if config.initialPassword != null
+        then "${config.initialPassword}" else "${config.password}");
     }
   ];
 }


### PR DESCRIPTION
This PR is related to issues #554 and #96. I've opened this more as discussion around possibilities rather than as a request to actually merge the code. There are a few problems I see with nix-darwin around user management. Using numbers for reference later, these problems are:
1. No options to configure users as admin, system, or token users
  - New Macs and Nix installs use FileVault. `dscl` user management does not work for this as new users created will not be able to use FDE and so will be unable to login on reboot
  - `dscl` is an older (maybe arguably deprecated) tool for creating new users. New users created this way will lack specific metadata that prevents certain user management actions in System Settings such as profile picture selection and other odd behavior
  - `dscl` requires careful tracking of reserved UIDs/GIDs which can change between OS upgrades or other operations
2. Missing options to set passwords
3. Configured users/groups need an additional config option `knownUsers`/`knownGroups` in order to actually be managed by nix-darwin
  - This adds code duplication and a layer of confusing abstraction that diverges from NixOS; "If a user is configured isn't it already known?".
  - "Used to indicate what users are safe to create/delete based on the configuration. "; There is no mention if this option can do other things to those configured+unknown users/groups
  - Makes for a strange workflow that mixes mutable and immutable user management schemes (very different from NixOS)

The edits I made tackled these problems in the following manner (each numbered point corresponding to the problem with the same number):
1. Add these as configuration options; move from `dscl` to `sysadminctl` commands
  - `isNormalUser`: normal user according to macOS (i.e. `UID > 500`)
  - `isAdminUser`: adds the user to the `admin` group
  - `isSystemUser`: configure system user according to macOS (i.e. `200 <= UID <= 400`)
  - `isTokenUser`: configure the user for FDE by having an admin with a secure token add a token to this user
2. Add these as configuration options; use `sysadminctl` to perform user changes
  - `password`: behaves like NixOS option; password is only changes when users are immutable
  - `initialPassword`: equivalent to `password` when users are immutable; otherwise sets the initial password when a user is first created
3. Remove `knownUsers`/`knownGroups` in favor of NixOS `users.mutableUsers` flag
  - Adds a `NixDeclarative` attribute with `dscl` to track which users/groups are managed
  - If users are mutable then nothing should change, otherwise users with the `NixDeclarative` attribute are modified according to configs

This isn't a perfect approach to things as `isTokenUser` needs an admin user with a secure token to be able to enter their password as well as the user requiring the change to do the same, but in combination with the `mutableUsers` and `password` options this could be mitigated on new system builds by pulling the password from the config.

It's my intention with these changes to have a system whereby I can more easily manage an admin user (which runs nix-darwin and manages homebrew through it) and a normal user (for daily use) that can run `sudo -Hu admin darwin-rebuild` (because running as root is broken right now). This is typically how systems should be configured in macOS where running admin as a daily user goes against best practices [according to Apple](https://help.apple.com/machelp/mac/10.12/index.html#/mh11389). I've been using this code [in my personal system configuration](https://github.com/dlubawy/nix-configs/blob/main/darwin/default.nix) and it has achieved that for me. Hopefully, this can be of use to others as well.