### PR TITLE
github-runners: move `workDir` outside of `/run`

### DIFF
--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -22,12 +22,12 @@ with lib;
 
       * `/var/lib/github-runners/<name>`:
         State directory to store the runner registration credentials
+      * `/var/lib/github-runners/_work/<name>`:
+        Working directory for workflow files. The runner only uses this
+        directory if `workDir` is `null` (see the `workDir` option for details).
       * `/var/log/github-runners/<name>`:
         The launchd service writes the stdout and stderr streams to this
         directory.
-      * `/var/run/github-runners/<name>`:
-        Working directory for workflow files. The runner only uses this
-        directory if `workDir` is `null` (see the `workDir` option for details).
     '';
     example = {
       runner1 = {

--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -4,7 +4,7 @@ let
   mkSvcName = name: "github-runner-${name}";
   mkStateDir = cfg: "/var/lib/github-runners/${cfg.name}";
   mkLogDir = cfg: "/var/log/github-runners/${cfg.name}";
-  mkWorkDir = cfg: if (cfg.workDir != null) then cfg.workDir else "/var/run/github-runners/${cfg.name}";
+  mkWorkDir = cfg: if (cfg.workDir != null) then cfg.workDir else "/var/lib/github-runners/_work/${cfg.name}";
 in
 {
   config.assertions = flatten (
@@ -16,6 +16,10 @@ in
       {
         assertion = !cfg.noDefaultLabels || (cfg.extraLabels != [ ]);
         message = "`services.github-runners.${name}`: The `extraLabels` option is mandatory if `noDefaultLabels` is set";
+      }
+      {
+        assertion = cfg.workDir == null || !(hasPrefix "/run/" cfg.workDir || hasPrefix "/var/run/" cfg.workDir || hasPrefix "/private/var/run/");
+        message = "`services.github-runners.${name}`: `workDir` being inside /run is not supported";
       }
     ])
   );

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -101,6 +101,8 @@ in
 
       ${cfg.activationScripts.preUserActivation.text}
 
+      # This should be running at the system level, but as user activation runs first
+      # we run it here with sudo
       ${cfg.activationScripts.createRun.text}
       ${cfg.activationScripts.checks.text}
       ${cfg.activationScripts.etcChecks.text}


### PR DESCRIPTION
Turns out I messed up when testing #1013 and forgot to reboot when testing and the PR didn't actually work.

As `/run` gets recreated every reboot and we can't specify dependencies for launchd, creating the `workDir` every reboot will require extra complexity with a separate daemon that runs as `root` otherwise it won't have sufficient privileges.

As we clean the `workDir` when the service first starts anyway, it ends up being the same.