### PR TITLE
`mapAttrsFlatten` -> `mapAttrsToList`

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -9,7 +9,7 @@ let
     mapAttrsToList (n: v: ''export ${n}="${v}"'') cfg.variables;
 
   aliasCommands =
-    mapAttrsFlatten (n: v: ''alias ${n}=${escapeShellArg v}'')
+    mapAttrsToList (n: v: ''alias ${n}=${escapeShellArg v}'')
       (filterAttrs (k: v: v != null) cfg.shellAliases);
 
   makeDrvBinPath = concatMapStringsSep ":" (p: if isDerivation p then "${p}/bin" else p);

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -9,7 +9,7 @@ let
   cfg = config.programs.fish;
 
   fishAliases = concatStringsSep "\n" (
-    mapAttrsFlatten (k: v: "alias ${k} ${escapeShellArg v}")
+    mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}")
       (filterAttrs (k: v: v != null) cfg.shellAliases)
   );
 


### PR DESCRIPTION
deprecated in https://github.com/NixOS/nixpkgs/commit/473e469d5a921a57b484a09d446cee6c231cd592