### PR TITLE
fix: move pam configuration to sudo_local

### DIFF
--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -37,11 +37,11 @@ let
   ''
     ${if isEnabled then ''
       if ! grep '${option}' ${file} > /dev/null; then
-        ${sed} -i '2iauth       sufficient     pam_tid.so # nix-darwin: ${option}' ${file}
+        ${sed} -i 's/#\(auth\s\+sufficient\s\+pam_tid.so\)/\1 # nix-darwin: ${option}/g' ${file}
       fi
     '' else ''
       if grep '${option}' ${file} > /dev/null; then
-        ${sed} -i '/${option}/d' ${file}
+        ${sed} -i 's/\(.*\)#.*${option}/#\1/g' ${file}
       fi
     ''}
   '';

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -49,9 +49,13 @@ let
   let
     option = "security.pam.enablePamReattach";
   in
+  # NOTE: needs to check that `pkgs.pam-reattach` is in the line in case the store location updates
   ''
     ${if isEnabled then ''
-      if ! grep '${option}' ${file} > /dev/null; then
+      if ! grep '${pkgs.pam-reattach}' ${file} > /dev/null; then
+        if grep '${option}' ${file} > /dev/null; then
+          ${sed} -i '/${option}/d' ${file}
+        fi
         ${sed} -i '1iauth optional ${pkgs.pam-reattach}/lib/pam/pam_reattach.so # nix-darwin: ${option}' ${file}
       fi
     '' else ''

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -61,7 +61,7 @@ in
 
   config =
   let
-    isPamEnabled = (cfg.enableSudoTouchIdAuth || cft.enablePamReattach);
+    isPamEnabled = (cfg.enableSudoTouchIdAuth || cfg.enablePamReattach);
   in
   {
     environment.etc."pam.d/sudo_local" = {

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -22,6 +22,10 @@ let
     ${if isEnabled then ''
       # Check if include line is needed (macOS < 14)
       if ! grep 'sudo_local' ${file} > /dev/null; then
+        # Clear out older implementation
+        if grep '${option}' ${file} > /dev/null; then
+          ${sed} -i '/${option}/d' ${file}
+        fi
         ${sed} -i '2iauth       include        sudo_local # nix-darwin: ${option}' ${file}
       fi
     '' else ''

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -17,15 +17,17 @@ let
   let
     file = "/etc/pam.d/sudo";
     option = "security.pam";
+    deprecatedOption = "security.pam.enableSudoTouchIdAuth";
     sed = "${pkgs.gnused}/bin/sed";
   in ''
     ${if isEnabled then ''
+      # NOTE: this can be removed at some point when support for older versions are dropped
+      # Always clear out older implementation if it exists
+      if grep '${deprecatedOption}' ${file} > /dev/null; then
+        ${sed} -i '/${option}/d' ${file}
+      fi
       # Check if include line is needed (macOS < 14)
       if ! grep 'sudo_local' ${file} > /dev/null; then
-        # Clear out older implementation
-        if grep '${option}' ${file} > /dev/null; then
-          ${sed} -i '/${option}/d' ${file}
-        fi
         ${sed} -i '2iauth       include        sudo_local # nix-darwin: ${option}' ${file}
       fi
     '' else ''

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -4,17 +4,6 @@ with lib;
 
 let
   cfg = config.security.pam;
-
-  # Implementation Notes
-  #
-  # We don't use `environment.etc` because this would require that the user manually delete
-  # `/etc/pam.d/sudo` which seems unwise given that applying the nix-darwin configuration requires
-  # sudo. We also can't use `system.patchs` since it only runs once, and so won't patch in the
-  # changes again after OS updates (which remove modifications to this file).
-  #
-  # As such, we resort to line addition/deletion in place using `sed`. We add a comment to the
-  # added line that includes the name of the option, to make it easier to identify the line that
-  # should be deleted when the option is disabled.
 in
 {
   options = {
@@ -28,16 +17,18 @@ in
           ```
         '';
       };
-      enablePamReattach = mkEnableOption ''
-        Enable re-attaching a program to the user's bootstrap session.
-        This allows programs like tmux and screen that run in the background to
-        survive across user sessions to work with PAM services that are tied to the
-        bootstrap session.
-        When enabled, this option adds the following line to /etc/pam.d/sudo_local:
-        ```
-        auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
-        ```
-      '';
+      enablePamReattach = mkEnableOption "" // {
+        description = ''
+          Enable re-attaching a program to the user's bootstrap session.
+          This allows programs like tmux and screen that run in the background to
+          survive across user sessions to work with PAM services that are tied to the
+          bootstrap session.
+          When enabled, this option adds the following line to /etc/pam.d/sudo_local:
+          ```
+          auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
+          ```
+        '';
+      };
     };
   };
 

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -4,39 +4,6 @@ with lib;
 
 let
   cfg = config.security.pam;
-
-  # Implementation Notes
-  #
-  # Uses `environment.etc` to create the `/etc/pam.d/sudo_local` file that will be used
-  # to manage all things pam related for nix-darwin. An activation script will run to check
-  # for the existance of the line `auth       include        sudo_local`. This is included
-  # in macOS Sonoma and later. If the line is not there already then `sed` will add it.
-  # In those cases, the line will include the name of the option root (`security.pam`),
-  # to make it easier to identify the line that should be deleted when the option is disabled.
-  mkIncludeSudoLocalScript = isEnabled:
-  let
-    file = "/etc/pam.d/sudo";
-    option = "security.pam";
-    deprecatedOption = "security.pam.enableSudoTouchIdAuth";
-    sed = "${pkgs.gnused}/bin/sed";
-  in ''
-    ${if isEnabled then ''
-      # NOTE: this can be removed at some point when support for older versions are dropped
-      # Always clear out older implementation if it exists
-      if grep '${deprecatedOption}' ${file} > /dev/null; then
-        ${sed} -i '/${option}/d' ${file}
-      fi
-      # Check if include line is needed (macOS < 14)
-      if ! grep 'sudo_local' ${file} > /dev/null; then
-        ${sed} -i '2iauth       include        sudo_local # nix-darwin: ${option}' ${file}
-      fi
-    '' else ''
-      # Remove include line if we added it
-      if grep '${option}' ${file} > /dev/null; then
-        ${sed} -i '/${option}/d' ${file}
-      fi
-    ''}
-  '';
 in
 {
   options = {
@@ -68,19 +35,53 @@ in
   config =
   let
     isPamEnabled = (cfg.enableSudoTouchIdAuth || cfg.enablePamReattach);
+
+    # Implementation Notes
+    #
+    # Uses `environment.etc` to create the `/etc/pam.d/sudo_local` file that will be used
+    # to manage all things pam related for nix-darwin. An activation script will run to check
+    # for the existance of the line `auth       include        sudo_local`. This is included
+    # in macOS Sonoma and later. If the line is not there already then `sed` will add it.
+    # In those cases, the line will include the marker (`security.pam.sudo_local`),
+    # to make it easier to identify the line that should be deleted when the option is disabled.
+    # Upgrading to Sonoma from a previous version should see the `/etc/pam.d/sudo` file
+    # replaced with one containing the `auth        include        sudo_local` line, but
+    # it will not include the marker because this line's inclusion is now managed by Apple.
   in
   {
     environment.etc."pam.d/sudo_local" = {
       enable = isPamEnabled;
-      text = lib.strings.concatStringsSep "\n" [
-        (lib.optionalString cfg.enablePamReattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
-        (lib.optionalString cfg.enableSudoTouchIdAuth "auth       sufficient     pam_tid.so")
+      text = lib.concatLines [
+        (lib.mkIf cfg.enablePamReattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
+        (lib.mkIf cfg.enableSudoTouchIdAuth "auth       sufficient     pam_tid.so")
       ];
     };
-    system.activationScripts.pam.text = ''
+    system.activationScripts.pam.text =
+    let
+      file = "/etc/pam.d/sudo";
+      marker = "security.pam";
+      deprecatedOption = "security.pam.enableSudoTouchIdAuth";
+      sed = "${pkgs.gnused}/bin/sed";
+    in
+    ''
       # PAM settings
       echo >&2 "setting up pam..."
-      ${mkIncludeSudoLocalScript isPamEnabled}
+      ${if isPamEnabled then ''
+        # REMOVEME when macOS 13 no longer supported
+        # Always clear out older implementation if it exists
+        if grep '${deprecatedOption}' ${file} > /dev/null; then
+          ${sed} -i '/${deprecatedOption}/d' ${file}
+        fi
+        # Check if include line is needed (macOS < 14)
+        if ! grep 'sudo_local' ${file} > /dev/null; then
+          ${sed} -i '2iauth       include        sudo_local # nix-darwin: ${marker}' ${file}
+        fi
+      '' else ''
+        # Remove include line if we added it
+        if grep '${marker}' ${file} > /dev/null; then
+          ${sed} -i '/${marker}/d' ${file}
+        fi
+      ''}
     '';
   };
 }

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -15,21 +15,46 @@ let
   # As such, we resort to line addition/deletion in place using `sed`. We add a comment to the
   # added line that includes the name of the option, to make it easier to identify the line that
   # should be deleted when the option is disabled.
-  mkSudoTouchIdAuthScript = isEnabled:
-  let
-    file   = "/etc/pam.d/sudo";
-    option = "security.pam.enableSudoTouchIdAuth";
-    sed = "${pkgs.gnused}/bin/sed";
-  in ''
+  template   = "/etc/pam.d/sudo_local.template";
+  file   = "/etc/pam.d/sudo_local";
+  sed = "${pkgs.gnused}/bin/sed";
+  mkSudoLocal = isEnabled:
+  ''
     ${if isEnabled then ''
-      # Enable sudo Touch ID authentication, if not already enabled
-      if ! grep 'pam_tid.so' ${file} > /dev/null; then
-        ${sed} -i '2i\
-      auth       sufficient     pam_tid.so # nix-darwin: ${option}
-        ' ${file}
+      if [ ! -f ${file} ]; then
+        cp ${template} ${file}
       fi
     '' else ''
-      # Disable sudo Touch ID authentication, if added by nix-darwin
+      if [ -f ${file} ]; then
+        rm ${file}
+      fi
+    ''}
+  '';
+  mkSudoTouchIdAuthScript = isEnabled:
+  let
+    option = "security.pam.enableSudoTouchIdAuth";
+  in
+  ''
+    ${if isEnabled then ''
+      if ! grep '${option}' ${file} > /dev/null; then
+        ${sed} -i '2iauth       sufficient     pam_tid.so # nix-darwin: ${option}' ${file}
+      fi
+    '' else ''
+      if grep '${option}' ${file} > /dev/null; then
+        ${sed} -i '/${option}/d' ${file}
+      fi
+    ''}
+  '';
+  mkPamReattachScript = isEnabled:
+  let
+    option = "security.pam.enablePamReattach";
+  in
+  ''
+    ${if isEnabled then ''
+      if ! grep '${option}' ${file} > /dev/null; then
+        ${sed} -i '1iauth optional ${pkgs.pam-reattach}/lib/pam/pam_reattach.so # nix-darwin: ${option}' ${file}
+      fi
+    '' else ''
       if grep '${option}' ${file} > /dev/null; then
         ${sed} -i '/${option}/d' ${file}
       fi
@@ -39,22 +64,31 @@ in
 
 {
   options = {
-    security.pam.enableSudoTouchIdAuth = mkEnableOption "" // {
+    security.pam = {
+    enableSudoTouchIdAuth = mkEnableOption "" // {
       description = ''
         Enable sudo authentication with Touch ID.
 
-        When enabled, this option adds the following line to
-        {file}`/etc/pam.d/sudo`:
+        When enabled, this option creates {file}
+        from {template}:
 
         ```
+        # sudo_local: local config file which survives system update and is included for sudo
+        # uncomment following line to enable Touch ID for sudo
         auth       sufficient     pam_tid.so
         ```
-
-        ::: {.note}
-        macOS resets this file when doing a system update. As such, sudo
-        authentication with Touch ID won't work after a system update
-        until the nix-darwin configuration is reapplied.
-        :::
+      '';
+    };
+    enablePamReattach = mkEnableOption ''
+        Enable re-attaching a program to the user's bootstrap session.
+        This allows programs like tmux and screen that run in the background to
+        survive across user sessions to work with PAM services that are tied to the
+        bootstrap session.
+        When enabled, this option adds the following line to /etc/pam.d/sudo_local:
+            auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
+        (Note that macOS resets this file when doing a system update. As such, sudo
+        authentication with Touch ID won't work after a system update until the nix-darwin
+        configuration is reapplied.)
       '';
     };
   };
@@ -63,6 +97,8 @@ in
     system.activationScripts.pam.text = ''
       # PAM settings
       echo >&2 "setting up pam..."
+      ${mkSudoLocal (cfg.enableSudoTouchIdAuth || cfg.enablePamReattach)}
+      ${mkPamReattachScript cfg.enablePamReattach}
       ${mkSudoTouchIdAuthScript cfg.enableSudoTouchIdAuth}
     '';
   };

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -22,25 +22,23 @@ in
       enableSudoTouchIdAuth = mkEnableOption "" // {
         description = ''
           Enable sudo authentication with Touch ID.
-
-          When enabled, this option creates {file} with:
+          When enabled, this option adds the following line to {file}:
           ```
           auth       sufficient     pam_tid.so
           ```
         '';
       };
       enablePamReattach = mkEnableOption ''
-          Enable re-attaching a program to the user's bootstrap session.
-          This allows programs like tmux and screen that run in the background to
-          survive across user sessions to work with PAM services that are tied to the
-          bootstrap session.
-          When enabled, this option adds the following line to /etc/pam.d/sudo_local:
-              auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
-          (Note that macOS resets this file when doing a system update. As such, sudo
-          authentication with Touch ID won't work after a system update until the nix-darwin
-          configuration is reapplied.)
-        '';
-      };
+        Enable re-attaching a program to the user's bootstrap session.
+        This allows programs like tmux and screen that run in the background to
+        survive across user sessions to work with PAM services that are tied to the
+        bootstrap session.
+        When enabled, this option adds the following line to /etc/pam.d/sudo_local:
+        ```
+        auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
+        ```
+      '';
+    };
   };
 
   config = {

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -65,7 +65,7 @@ in
   in
   {
     environment.etc."pam.d/sudo_local" = {
-      enable = (cfg.enablePamReattach || cfg.enableSudoTouchIdAuth);
+      enable = isPamEnabled;
       text = lib.strings.concatStringsSep "\n" [
         (lib.optionalString cfg.enablePamReattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
         (lib.optionalString cfg.enableSudoTouchIdAuth "auth       sufficient     pam_tid.so")

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -46,16 +46,10 @@ in
   config = {
     environment.etc."pam.d/sudo_local" = {
       enable = (cfg.enablePamReattach || cfg.enableSudoTouchIdAuth);
-      text = ''
-        ${if cfg.enablePamReattach
-          then "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so"
-          else ""
-        }
-        ${if cfg.enableSudoTouchIdAuth
-          then "auth       sufficient     pam_tid.so"
-          else ""
-        }
-      '';
+      text = lib.strings.concatStringsSep "\n" [
+        (lib.optionalString cfg.enablePamReattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
+        (lib.optionalString cfg.enableSudoTouchIdAuth "auth       sufficient     pam_tid.so")
+      ];
     };
   };
 }

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -15,95 +15,47 @@ let
   # As such, we resort to line addition/deletion in place using `sed`. We add a comment to the
   # added line that includes the name of the option, to make it easier to identify the line that
   # should be deleted when the option is disabled.
-  template   = "/etc/pam.d/sudo_local.template";
-  file   = "/etc/pam.d/sudo_local";
-  sed = "${pkgs.gnused}/bin/sed";
-  mkSudoLocal = isEnabled:
-  ''
-    ${if isEnabled then ''
-      if [ ! -f ${file} ]; then
-        cp ${template} ${file}
-      fi
-    '' else ''
-      if [ -f ${file} ]; then
-        rm ${file}
-      fi
-    ''}
-  '';
-  mkSudoTouchIdAuthScript = isEnabled:
-  let
-    option = "security.pam.enableSudoTouchIdAuth";
-  in
-  ''
-    ${if isEnabled then ''
-      if ! grep '${option}' ${file} > /dev/null; then
-        ${sed} -i 's/#\(auth\s\+sufficient\s\+pam_tid.so\)/\1 # nix-darwin: ${option}/g' ${file}
-      fi
-    '' else ''
-      if grep '${option}' ${file} > /dev/null; then
-        ${sed} -i 's/\(.*\)#.*${option}/#\1/g' ${file}
-      fi
-    ''}
-  '';
-  mkPamReattachScript = isEnabled:
-  let
-    option = "security.pam.enablePamReattach";
-  in
-  # NOTE: needs to check that `pkgs.pam-reattach` is in the line in case the store location updates
-  ''
-    ${if isEnabled then ''
-      if ! grep '${pkgs.pam-reattach}' ${file} > /dev/null; then
-        if grep '${option}' ${file} > /dev/null; then
-          ${sed} -i '/${option}/d' ${file}
-        fi
-        ${sed} -i '1iauth optional ${pkgs.pam-reattach}/lib/pam/pam_reattach.so # nix-darwin: ${option}' ${file}
-      fi
-    '' else ''
-      if grep '${option}' ${file} > /dev/null; then
-        ${sed} -i '/${option}/d' ${file}
-      fi
-    ''}
-  '';
 in
-
 {
   options = {
     security.pam = {
-    enableSudoTouchIdAuth = mkEnableOption "" // {
-      description = ''
-        Enable sudo authentication with Touch ID.
+      enableSudoTouchIdAuth = mkEnableOption "" // {
+        description = ''
+          Enable sudo authentication with Touch ID.
 
-        When enabled, this option creates {file}
-        from {template}:
-
-        ```
-        # sudo_local: local config file which survives system update and is included for sudo
-        # uncomment following line to enable Touch ID for sudo
-        auth       sufficient     pam_tid.so
-        ```
-      '';
-    };
-    enablePamReattach = mkEnableOption ''
-        Enable re-attaching a program to the user's bootstrap session.
-        This allows programs like tmux and screen that run in the background to
-        survive across user sessions to work with PAM services that are tied to the
-        bootstrap session.
-        When enabled, this option adds the following line to /etc/pam.d/sudo_local:
-            auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
-        (Note that macOS resets this file when doing a system update. As such, sudo
-        authentication with Touch ID won't work after a system update until the nix-darwin
-        configuration is reapplied.)
-      '';
-    };
+          When enabled, this option creates {file} with:
+          ```
+          auth       sufficient     pam_tid.so
+          ```
+        '';
+      };
+      enablePamReattach = mkEnableOption ''
+          Enable re-attaching a program to the user's bootstrap session.
+          This allows programs like tmux and screen that run in the background to
+          survive across user sessions to work with PAM services that are tied to the
+          bootstrap session.
+          When enabled, this option adds the following line to /etc/pam.d/sudo_local:
+              auth       optional       /path/in/nix/store/lib/pam/pam_reattach.so"
+          (Note that macOS resets this file when doing a system update. As such, sudo
+          authentication with Touch ID won't work after a system update until the nix-darwin
+          configuration is reapplied.)
+        '';
+      };
   };
 
   config = {
-    system.activationScripts.pam.text = ''
-      # PAM settings
-      echo >&2 "setting up pam..."
-      ${mkSudoLocal (cfg.enableSudoTouchIdAuth || cfg.enablePamReattach)}
-      ${mkPamReattachScript cfg.enablePamReattach}
-      ${mkSudoTouchIdAuthScript cfg.enableSudoTouchIdAuth}
-    '';
+    environment.etc."pam.d/sudo_local" = {
+      enable = (cfg.enablePamReattach || cfg.enableSudoTouchIdAuth);
+      text = ''
+        ${if cfg.enablePamReattach
+          then "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so"
+          else ""
+        }
+        ${if cfg.enableSudoTouchIdAuth
+          then "auth       sufficient     pam_tid.so"
+          else ""
+        }
+      '';
+    };
   };
 }

--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -51,10 +51,10 @@ in
   {
     environment.etc."pam.d/sudo_local" = {
       enable = isPamEnabled;
-      text = lib.concatLines [
-        (lib.mkIf cfg.enablePamReattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
-        (lib.mkIf cfg.enableSudoTouchIdAuth "auth       sufficient     pam_tid.so")
-      ];
+      text = lib.concatLines (
+        (lib.optional cfg.enablePamReattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
+        ++ (lib.optional cfg.enableSudoTouchIdAuth "auth       sufficient     pam_tid.so")
+      );
     };
     system.activationScripts.pam.text =
     let

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -59,6 +59,7 @@ in
       ${cfg.activationScripts.groups.text}
       ${cfg.activationScripts.users.text}
       ${cfg.activationScripts.applications.text}
+      ${cfg.activationScripts.pam.text}
       ${cfg.activationScripts.patches.text}
       ${cfg.activationScripts.etc.text}
       ${cfg.activationScripts.defaults.text}

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -59,7 +59,6 @@ in
       ${cfg.activationScripts.groups.text}
       ${cfg.activationScripts.users.text}
       ${cfg.activationScripts.applications.text}
-      ${cfg.activationScripts.pam.text}
       ${cfg.activationScripts.patches.text}
       ${cfg.activationScripts.etc.text}
       ${cfg.activationScripts.defaults.text}


### PR DESCRIPTION
Addresses #985 and #787.

* Moves pam configuration to `/etc/pam.d/sudo_local`
* Performs configuration through `environment.etc`
* Adds a `pam_reattach` option to fix sudo TouchID in tmux

Implementation uses `environment.etc` to create the `/etc/pam.d/sudo_local` file and adds the `pkgs.pam-reattach` option provided in #662. Follows [the comment](https://github.com/LnL7/nix-darwin/pull/787#issuecomment-2165246619) by @emilazy to have nix-darwin manage the file entirely. If the file exists already, nix-darwin should handle it through the usual warning telling the user to rename the file to `sudo_local.before-nix-darwin`. As identified by @lilyball in [their comment](https://github.com/LnL7/nix-darwin/pull/787#issuecomment-1742376938), the symlink approach here shouldn't impact users since it doesn't touch the main `/etc/pam.d/sudo` file. As long as `/etc/pam.d/sudo` remains a regular file than this should work fine without disrupting sudo to apply `nix-darwin` configurations.

I recognize this may be a duplicate PR given all the other open issues/PRs, but I haven't seen movement on them in a while. Feel free to close this if it's unnecessary.