### PR TITLE
(feature) Add swapLeftCtrlAndFn

### DIFF
--- a/modules/system/keyboard.nix
+++ b/modules/system/keyboard.nix
@@ -38,6 +38,12 @@ in
       description = "Whether to swap the left Command key and left Alt key.";
     };
 
+    system.keyboard.swapLeftCtrlAndFn = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to swap the left Control key and Fn (Globe) key.";
+    };
+
     system.keyboard.userKeyMapping = mkOption {
       internal = true;
       type = types.listOf (types.attrsOf types.int);
@@ -65,6 +71,14 @@ in
       (mkIf cfg.swapLeftCommandAndLeftAlt {
         HIDKeyboardModifierMappingSrc = 30064771298;
         HIDKeyboardModifierMappingDst = 30064771299;
+      })
+      (mkIf cfg.swapLeftCtrlAndFn {
+        HIDKeyboardModifierMappingSrc = 30064771296;
+        HIDKeyboardModifierMappingDst = 1095216660483;
+      })
+      (mkIf cfg.swapLeftCtrlAndFn {
+        HIDKeyboardModifierMappingSrc = 1095216660483;
+        HIDKeyboardModifierMappingDst = 30064771296;
       })
     ];
 

--- a/tests/system-keyboard-mapping.nix
+++ b/tests/system-keyboard-mapping.nix
@@ -6,6 +6,7 @@
   system.keyboard.remapCapsLockToEscape = true;
   system.keyboard.nonUS.remapTilde = true;
   system.keyboard.swapLeftCommandAndLeftAlt = true;
+  system.keyboard.swapLeftCtrlAndFn = true;
 
   test = ''
     echo checking keyboard mappings in /activate >&2
@@ -17,5 +18,7 @@
     grep "\"HIDKeyboardModifierMappingDst\":30064771296" ${config.out}/activate
     grep "\"HIDKeyboardModifierMappingDst\":30064771298" ${config.out}/activate
     grep "\"HIDKeyboardModifierMappingDst\":30064771299" ${config.out}/activate
+    grep "\"HIDKeyboardModifierMappingDst\":30064771296" ${config.out}/activate
+    grep "\"HIDKeyboardModifierMappingDst\":1095216660483" ${config.out}/activate
   '';
 }


### PR DESCRIPTION
Use this and never find yourself again hitting fn because of muscle memory! (you can even physically swap the keycaps, at least on M series)

Keycodes have been pulled from https://hidutil-generator.netlify.app/ and the hex value has been converted to a base 10 int.

(was previously opened as #991 but made a mistake)