### PR TITLE
added option `programs.bash.promptInit`

### DIFF
--- a/modules/programs/bash/default.nix
+++ b/modules/programs/bash/default.nix
@@ -31,6 +31,26 @@ in
       '';
     };
 
+    programs.bash.promptInit = mkOption {
+      type = types.lines;
+      default = ''
+        # Provide a nice prompt if the terminal supports it.
+        if [ "$TERM" != "dumb" ] || [ -n "$INSIDE_EMACS" ]; then
+          PROMPT_COLOR="1;31m"
+          ((UID)) && PROMPT_COLOR="1;32m"
+          if [ -n "$INSIDE_EMACS" ]; then
+            # Emacs term mode doesn't support xterm title escape sequence (\e]0;)
+            PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
+          else
+            PS1="\n\[\033[$PROMPT_COLOR\][\[\e]0;\u@\h: \w\a\]\u@\h:\w]\\$\[\033[0m\] "
+          fi
+          if test "$TERM" = "xterm"; then
+            PS1="\[\033]2;\h:\u:\w\007\]$PS1"
+          fi
+        fi
+      '';
+      description = "Shell script code used to initialise the bash prompt.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -72,6 +92,8 @@ in
 
       ${config.environment.interactiveShellInit}
       ${cfg.interactiveShellInit}
+
+      ${cfg.promptInit}
 
       ${optionalString cfg.enableCompletion ''
         if [ "$TERM" != "dumb" ]; then


### PR DESCRIPTION
Option is identical to NixOS option. Default value copied from there.

Motivation: I know `zsh` is default in macOS. But every time you enter `nix develop`, there is only a rudimentary prompt by default. Plus, on older MacBooks some people might not have transitioned to `zsh`, yet. Both `zsh` as well as `fish` provide this option as well.

Only problem is: This might break things for people using `programs.bash.interactiveShellInit` or `environment.interactiveShellInit` to configure their prompt, because it gets overwritten as I imitated the way it is implemented in the `zsh` module. I could, alternatively to the way it is done now,

1. move it up, so that it is executed during shell initialization before said option. Or 
2. provide a warning in the module, that alerts the user of the `interactiveShellInit` option to the change the next time they run `darwin-rebuild`.

Though the latter is more consistent with expected behaviour in my opinion, it will have to be removed after some grace period.