### PR TITLE
feat: system.disableInstallerTools

### DIFF
--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -13,8 +13,19 @@ let
 in
 
 {
-  options = {
-    system.includeUninstaller = lib.mkOption {
+  options.system = {
+    disableInstallerTools = lib.mkOption {
+      type = lib.types.bool;
+      internal = true;
+      default = false;
+      description = ''
+        Disable darwin-rebuild and darwin-option. This is useful to shrink
+        systems which are not expected to rebuild or reconfigure themselves.
+        Use at your own risk!
+    '';
+    };
+
+    includeUninstaller = lib.mkOption {
       type = lib.types.bool;
       internal = true;
       default = true;
@@ -23,10 +34,10 @@ in
 
   config = {
     environment.systemPackages =
-      [ # Include nix-tools by default
+      [ darwin-version ]
+      ++ lib.optionals (!config.system.disableInstallerTools) [
         darwin-option
         darwin-rebuild
-        darwin-version
       ] ++ lib.optional config.system.includeUninstaller darwin-uninstaller;
 
     system.build = {


### PR DESCRIPTION
A port of https://github.com/NixOS/nixpkgs/blob/50f054152e00aaee3e75b3041f666453605029bd/nixos/modules/installer/tools/tools.nix#L121

Why?

Other installer tools exist like [`nh_darwin`](https://github.com/ToyVo/nh_darwin)