### PR TITLE
gpg: Suppress stderr from gpg-connect-agent on shell init

### DIFF
--- a/modules/programs/gnupg.nix
+++ b/modules/programs/gnupg.nix
@@ -43,7 +43,7 @@ in
     '' + (optionalString cfg.agent.enableSSHSupport ''
       # SSH agent protocol doesn't support changing TTYs, so bind the agent
       # to every new TTY.
-      ${pkgs.gnupg}/bin/gpg-connect-agent --quiet updatestartuptty /bye > /dev/null
+      ${pkgs.gnupg}/bin/gpg-connect-agent --quiet updatestartuptty /bye > /dev/null 2>&1
 
       export SSH_AUTH_SOCK=$(${pkgs.gnupg}/bin/gpgconf --list-dirs agent-ssh-socket)
     '');


### PR DESCRIPTION
In some scenarios, the command may fail, e.g. when the shell is executed with a different $HOME from where gpg agent is configured to run from.

(E.g. this happens in kitty terminal test suite.)

This patch will suppress stderr errors on tty in this situation.

Note that zsh does not allow to suppress execution of /etc/zshenv on startup, so it's impossible to skip it in the test suite environment.

An alternative would be to set IN_NIX_SHELL in the test suite, but this was rejected in upstream:

https://github.com/kovidgoyal/kitty/pull/7800

There's also a kitty package specific fix posted here but this may be unnecessary once nix-darwin is patched here:

https://github.com/NixOS/nixpkgs/pull/338070