### PR TITLE
Use wait4path with command and script launchd options

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -20,7 +20,6 @@ let
     { config, name, ... }:
     let
 
-      cmd = config.command;
       env = config.environment // optionalAttrs (config.path != "") { PATH = config.path; };
 
     in
@@ -88,7 +87,11 @@ let
         '');
 
         serviceConfig.Label = mkDefault "${cfg.labelPrefix}.${name}";
-        serviceConfig.ProgramArguments = mkIf (cmd != "") [ "/bin/sh" "-c" "exec ${cmd}" ];
+        serviceConfig.ProgramArguments = mkIf (config.command != "") [
+          "/bin/sh"
+          "-c"
+          "/bin/wait4path /nix/store &amp;&amp; exec ${config.command}"
+        ];
         serviceConfig.EnvironmentVariables = mkIf (env != {}) env;
       };
     };

--- a/modules/services/karabiner-elements/default.nix
+++ b/modules/services/karabiner-elements/default.nix
@@ -38,14 +38,11 @@ in
     # the system extension is activated, so we can call activate from the manager
     # which will block until the system extension is activated.
     launchd.daemons.start_karabiner_daemons = {
-      serviceConfig.ProgramArguments = [
-        "/bin/sh" "-c"
-        "/bin/wait4path /nix/store &amp;&amp; ${pkgs.writeScript "start_karabiner_daemons" ''
+      script = ''
           ${parentAppDir}/.Karabiner-VirtualHIDDevice-Manager.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Manager activate
           launchctl kickstart system/org.pqrs.karabiner.karabiner_grabber
           launchctl kickstart system/org.pqrs.karabiner.karabiner_observer
-        ''}"
-      ];
+      '';
       serviceConfig.Label = "org.nixos.start_karabiner_daemons";
       serviceConfig.RunAtLoad = true;
     };
@@ -73,11 +70,7 @@ in
     };
 
     launchd.daemons.Karabiner-DriverKit-VirtualHIDDeviceClient = {
-      serviceConfig.ProgramArguments = [
-        "/bin/sh" "-c"
-        # For unknown reasons this daemon will fail if VirtualHIDDeviceClient is not exec'd.
-        "/bin/wait4path /nix/store &amp;&amp; exec \"${pkgs.karabiner-elements.driver}/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-DriverKit-VirtualHIDDeviceClient.app/Contents/MacOS/Karabiner-DriverKit-VirtualHIDDeviceClient\""
-      ];
+      command = "${pkgs.karabiner-elements.driver}/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-DriverKit-VirtualHIDDeviceClient.app/Contents/MacOS/Karabiner-DriverKit-VirtualHIDDeviceClient";
       serviceConfig.ProcessType = "Interactive";
       serviceConfig.Label = "org.pqrs.Karabiner-DriverKit-VirtualHIDDeviceClient";
       serviceConfig.KeepAlive = true;
@@ -95,14 +88,11 @@ in
     # We need this to run every reboot as /run gets nuked so we can't put this
     # inside the preActivation script as it only gets run on darwin-rebuild switch.
     launchd.daemons.setsuid_karabiner_session_monitor = {
-      serviceConfig.ProgramArguments = [
-        "/bin/sh" "-c"
-        "/bin/wait4path /nix/store &amp;&amp; ${pkgs.writeScript "setsuid_karabiner_session_monitor" ''
+      script = ''
           rm -rf /run/wrappers
           mkdir -p /run/wrappers/bin
           install -m4555 "${pkgs.karabiner-elements}/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_session_monitor" /run/wrappers/bin
-        ''}"
-      ];
+      '';
       serviceConfig.RunAtLoad = true;
       serviceConfig.KeepAlive.SuccessfulExit = false;
     };

--- a/modules/services/nix-daemon.nix
+++ b/modules/services/nix-daemon.nix
@@ -44,10 +44,7 @@ in
     nix.useDaemon = true;
 
     launchd.daemons.nix-daemon = {
-      serviceConfig.ProgramArguments = [
-        "/bin/sh" "-c"
-        "/bin/wait4path ${config.nix.package}/bin/nix-daemon &amp;&amp; exec ${config.nix.package}/bin/nix-daemon"
-      ];
+      command = lib.getExe' config.nix.package "nix-daemon";
       serviceConfig.ProcessType = config.nix.daemonProcessType;
       serviceConfig.LowPriorityIO = config.nix.daemonIOLowPriority;
       serviceConfig.Label = "org.nixos.nix-daemon"; # must match daemon installed by Nix regardless of the launchd label Prefix

--- a/modules/services/nix-optimise/default.nix
+++ b/modules/services/nix-optimise/default.nix
@@ -62,11 +62,8 @@ in
 
     launchd.daemons.nix-optimise = {
       environment.NIX_REMOTE = optionalString config.nix.useDaemon "daemon";
+      command = "${lib.getExe' config.nix.package "nix-store"} --optimise";
       serviceConfig = {
-        ProgramArguments = [
-          "/bin/sh" "-c"
-          "/bin/wait4path ${config.nix.package} &amp;&amp; exec ${config.nix.package}/bin/nix-store --optimise"
-        ];
         RunAtLoad = false;
         StartCalendarInterval = cfg.interval;
         UserName = cfg.user;

--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -54,12 +54,9 @@ in
     launchd.daemons.tailscaled = {
       # derived from
       # https://github.com/tailscale/tailscale/blob/main/cmd/tailscaled/install_darwin.go#L30
+      command = lib.getExe' cfg.package "tailscaled";
       serviceConfig = {
         Label = "com.tailscale.tailscaled";
-        ProgramArguments = [
-          "/bin/sh" "-c"
-          "/bin/wait4path ${cfg.package} &amp;&amp; ${cfg.package}/bin/tailscaled"
-        ];
         RunAtLoad = true;
       };
     };

--- a/tests/autossh.nix
+++ b/tests/autossh.nix
@@ -1,17 +1,19 @@
 { config, pkgs, ... }:
 
 {
-  services.autossh.sessions = [ {
-    name = "foo";
-    user = "jfelice";
-    extraArguments = "-i /some/key -T -N bar.eraserhead.net";
-  } ];
+  services.autossh.sessions = [
+    {
+      name = "foo";
+      user = "jfelice";
+      extraArguments = "-i /some/key -T -N bar.eraserhead.net";
+    }
+  ];
 
   test = ''
     plist=${config.out}/Library/LaunchDaemons/org.nixos.autossh-foo.plist
     test -f $plist
-    grep '<string>exec /nix/store/.*/bin/autossh ' $plist
-    grep '<string>exec.*-i /some/key ' $plist
+    grep '<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/.*/bin/autossh ' $plist
+    grep '<string>/bin/wait4path /nix/store &amp;&amp; exec.*-i /some/key ' $plist
     tr -d '\n\t ' <$plist |grep '<key>KeepAlive</key><true */>'
   '';
 }

--- a/tests/services-activate-system-changed-label-prefix.nix
+++ b/tests/services-activate-system-changed-label-prefix.nix
@@ -9,7 +9,7 @@
     grep "org.nix-darwin.activate-system" ${config.out}/Library/LaunchDaemons/org.nix-darwin.activate-system.plist
 
     echo checking activation of /run/current-system >&2
-    script=$(cat ${config.out}/Library/LaunchDaemons/org.nix-darwin.activate-system.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
+    script=$(cat ${config.out}/Library/LaunchDaemons/org.nix-darwin.activate-system.plist | awk -F'[< ]' '$6 ~ "^/nix/store/.*" {print $6}')
     grep "ln -sfn .* /run/current-system" "$script"
   '';
 }

--- a/tests/services-activate-system.nix
+++ b/tests/services-activate-system.nix
@@ -8,7 +8,7 @@
     grep "org.nixos.activate-system" ${config.out}/Library/LaunchDaemons/org.nixos.activate-system.plist
 
     echo checking activation of /run/current-system >&2
-    script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.activate-system.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
+    script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.activate-system.plist | awk -F'[< ]' '$6 ~ "^/nix/store/.*" {print $6}')
     grep "ln -sfn .* /run/current-system" "$script"
   '';
 }

--- a/tests/services-buildkite-agent.nix
+++ b/tests/services-buildkite-agent.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 
 let
-  buildkite-agent = pkgs.runCommand "buildkite-agent-0.0.0" {} "mkdir $out";
+  buildkite-agent = pkgs.runCommand "buildkite-agent-0.0.0" { } "mkdir $out";
   tokenPath = pkgs.writeText "buildkite_token" "TEST_TOKEN";
 in
 
@@ -20,7 +20,7 @@ in
     grep "org.nixos.buildkite-agent-test" ${config.out}/Library/LaunchDaemons/org.nixos.buildkite-agent-test.plist
 
     echo "checking creation of buildkite-agent service config" >&2
-    script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.buildkite-agent-test.plist | awk -F'[< ]' '$3 ~ "^/nix/store/.*" {print $3}')
+    script=$(cat ${config.out}/Library/LaunchDaemons/org.nixos.buildkite-agent-test.plist | awk -F'[< ]' '$6 ~ "^/nix/store/.*" {print $6}')
     grep "yolo=1" "$script"
     grep "${tokenPath}" "$script"
 

--- a/tests/services-lorri.nix
+++ b/tests/services-lorri.nix
@@ -1,14 +1,29 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 let
   plistPath = "${config.out}/user/Library/LaunchAgents/org.nixos.lorri.plist";
-  expectedPath = "${lib.makeBinPath [config.nix.package pkgs.git pkgs.gnutar pkgs.gzip]}";
-  expectedNixPath = "${"nixpkgs="+ toString pkgs.path}";
+  expectedPath = "${lib.makeBinPath [
+    config.nix.package
+    pkgs.git
+    pkgs.gnutar
+    pkgs.gzip
+  ]}";
+  expectedNixPath = "${"nixpkgs=" + toString pkgs.path}";
 in
 {
   services.lorri.enable = true;
   test = ''
-    PATH=${lib.makeBinPath [ pkgs.xcbuild pkgs.jq ]}:$PATH
+    PATH=${
+      lib.makeBinPath [
+        pkgs.xcbuild
+        pkgs.jq
+      ]
+    }:$PATH
 
     plutil -lint ${plistPath}
     plutil -convert json -o service.json ${plistPath}
@@ -21,7 +36,7 @@ in
     <service.json jq -e ".ProgramArguments|length       == 3"
     <service.json jq -e ".ProgramArguments[0]           == \"/bin/sh\""
     <service.json jq -e ".ProgramArguments[1]           == \"-c\""
-    <service.json jq -e ".ProgramArguments[2]           == \"exec ${pkgs.lorri}/bin/lorri daemon\""
+    <service.json jq -e ".ProgramArguments[2]           == \"/bin/wait4path /nix/store && exec ${pkgs.lorri}/bin/lorri daemon\""
     <service.json jq -e ".RunAtLoad                     == true"
   '';
 }

--- a/tests/services-nix-gc.nix
+++ b/tests/services-nix-gc.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 
 let
-  nix = pkgs.runCommand "nix-2.2" {} "mkdir -p $out";
+  nix = pkgs.runCommand "nix-2.2" { } "mkdir -p $out";
 in
 
 {
@@ -13,7 +13,7 @@ in
   test = ''
     echo checking nix-gc service in /Library/LaunchDaemons >&2
     grep "<string>org.nixos.nix-gc</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
-    grep "<string>exec ${nix}/bin/nix-collect-garbage --delete-older-than 30d</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
+    grep "<string>/bin/wait4path /nix/store &amp;&amp; exec ${nix}/bin/nix-collect-garbage --delete-older-than 30d</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
     grep "<key>UserName</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
     grep "<string>nixuser</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
 

--- a/tests/services-nix-optimise.nix
+++ b/tests/services-nix-optimise.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 
 let
-  nix = pkgs.runCommand "nix-2.2" {} "mkdir -p $out";
+  nix = pkgs.runCommand "nix-2.2" { } "mkdir -p $out";
 in
 
 {
@@ -13,7 +13,7 @@ in
     echo checking nix-optimise service in /Library/LaunchDaemons >&2
     grep "<string>org.nixos.nix-optimise</string>" \
       ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist
-    grep "<string>/bin/wait4path ${nix} &amp;&amp; exec ${nix}/bin/nix-store --optimise</string>" \
+    grep "<string>/bin/wait4path /nix/store &amp;&amp; exec ${nix}/bin/nix-store --optimise</string>" \
       ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist
     grep "<key>UserName</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist
     grep "<string>nixuser</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist


### PR DESCRIPTION
Addresses my recent issue, https://github.com/LnL7/nix-darwin/issues/1043.

I've attempted to make this compatible with both the 'command' and 'script' options of 'launchd.daemons.<name>'. This works fine on my machine, but some tests that check the launchd plist files fail because this will change the format of them slightly. 

I thought I would put this first commit here in case anyone had any objections before I went ahead and rewrote all of the tests and modules to not use wait4path anymore. 