### PR TITLE
feat(trackpad): add additional trackpad and gesture support

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -149,6 +149,38 @@ in {
         else map (folder: { tile-data = { file-data = { _CFURLString = "file://" + folder; _CFURLStringType = 15; }; }; tile-type = if strings.hasInfix "." (last (splitString "/" folder)) then "file-tile" else "directory-tile"; }) value;
     };
 
+    system.defaults.dock.showAppExposeGestureEnabled = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable trackpad gestures (three- or four-finger vertical swipe) to show App Exposé. The default is false. This feature interacts with `system.defaults.trackpad.TrackpadFourFingerVertSwipeGesture` and `system.defaults.trackpad.TrackpadThreeFingerVertSwipeGesture` to determine which gesture triggers App Exposé.
+      '';
+    };
+
+    system.defaults.dock.showDesktopGestureEnabled = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable four-finger spread gesture to show the Desktop. The default is false. 
+      '';
+    };
+
+    system.defaults.dock.showLaunchpadGestureEnabled = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable four-finger pinch gesture to show the Launchpad. The default is false. 
+      '';
+    };
+
+    system.defaults.dock.showMissionControlGestureEnabled = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable trackpad gestures (three- or four-finger vertical swipe) to show Mission Control. The default is false. This feature interacts with `system.defaults.trackpad.TrackpadFourFingerVertSwipeGesture` and `system.defaults.trackpad.TrackpadThreeFingerVertSwipeGesture` to determine which gesture triggers Mission Control.
+      '';
+    };
+
     system.defaults.dock.show-process-indicators = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/modules/system/defaults/trackpad.nix
+++ b/modules/system/defaults/trackpad.nix
@@ -9,7 +9,7 @@ with lib;
       type = types.nullOr types.bool;
       default = null;
       description = ''
-        Whether to enable trackpad tap to click.  The default is false.
+        Whether to enable tap to click. The default is false.
       '';
     };
 
@@ -17,7 +17,7 @@ with lib;
       type = types.nullOr types.bool;
       default = null;
       description = ''
-        Whether to enable tap-to-drag. The default is false.
+        Whether to enable tap to drag. The default is false.
       '';
     };
 
@@ -25,7 +25,8 @@ with lib;
       type = types.nullOr types.bool;
       default = null;
       description = ''
-        Whether to enable trackpad right click.  The default is false.
+        Whether to enable trackpad right click (two-finger tap/click).
+        The default is false.
       '';
     };
 
@@ -33,7 +34,7 @@ with lib;
       type = types.nullOr types.bool;
       default = null;
       description = ''
-        Whether to enable three finger drag.  The default is false.
+        Whether to enable three-finger drag. The default is false.
       '';
     };
 
@@ -41,7 +42,7 @@ with lib;
       type = types.nullOr (types.enum [ 0 1 ]);
       default = null;
       description = ''
-        0 to enable Silent Clicking, 1 to disable.  The default is 1.
+        0 to enable Silent Clicking, 1 to disable. The default is 1.
       '';
     };
 
@@ -67,8 +68,132 @@ with lib;
       type = types.nullOr (types.enum [ 0 2 ]);
       default = null;
       description = ''
-        0 to disable three finger tap, 2 to trigger Look up & data detectors.
+        Whether to enable three-finger tap gesture: 0 to disable, 2 to trigger Look up & data detectors.
         The default is 2.
+      '';
+    };
+
+    system.defaults.trackpad.ActuateDetents = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable haptic feedback. The default is true.
+      '';
+    };
+
+    system.defaults.trackpad.DragLock = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable drag lock. The default is false.
+      '';
+    };
+
+    system.defaults.trackpad.ForceSuppressed = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to disable force click. The default is false.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadCornerSecondaryClick = mkOption {
+      type = types.nullOr (types.enum [ 0 1 2 ]);
+      default = null;
+      description = ''
+        Whether to enable secondary click: 0 to disable, 1 to set bottom-left corner, 2 to set bottom-right corner.
+        The default is 0.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadFourFingerHorizSwipeGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 2 ]);
+      default = null;
+      description = ''
+        Whether to enable four-finger horizontal swipe gesture: 0 to disable, 2 to swipe between full-screen applications.
+        The default is 0.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadFourFingerPinchGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 2 ]);
+      default = null;
+      description = ''
+        Whether to enable four-finger pinch gesture (spread shows the Desktop, pinch shows the Launchpad): 0 to disable, 2 to enable.
+        The default is 0.
+        This setting interacts with `system.defaults.dock.showDesktopGestureEnabled` and `system.defaults.dock.showLaunchpadGestureEnabled` to determine whether gestures are enabled for the Desktop, Launchpad, or both.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadFourFingerVertSwipeGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 2 ]);
+      default = null;
+      description = ''
+        0 to disable four finger vertical swipe gestures, 2 to enable (down for Mission Control, up for App Exposé).
+        The default is 2.
+        When both three- and four-finger vertical swipe gestures are enabled, the three-finger variant takes precedence. This setting interacts with `system.defaults.dock.showAppExposeGestureEnabled` and `system.defaults.dock.showMissionControlGestureEnabled` to determine whether vertical swipe gestures are enabled for App Exposé, Mission Control, or both. 
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadMomentumScroll = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to use inertia when scrolling. The default is true.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadPinch = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable two-finger pinch gesture for zooming in and out.
+        The default is false.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadRotate = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable two-finger rotation gesture. The default is false.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadThreeFingerHorizSwipeGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 1 2 ]);
+      default = null;
+      description = ''
+        Whether to enable three-finger horizontal swipe gesture: 0 to disable, 1 to swipe between pages, 2 to swipe between full-screen applications.
+        The default is 2.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadThreeFingerVertSwipeGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 2 ]);
+      default = null;
+      description = ''
+        Whether to enable three-finger vertical swipe gesture (down for Mission Control, up for App Exposé): 0 to disable, 2 to enable.
+        The default is 2.
+        This setting interacts with `system.defaults.dock.showAppExposeGestureEnabled` and `system.defaults.dock.showMissionControlGestureEnabled` to determine whether vertical swipe gestures are enabled for App Exposé, Mission Control, or both.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadTwoFingerDoubleTapGesture = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether to enable smart zoom when double-tapping with two fingers.
+        The default is false.
+      '';
+    };
+
+    system.defaults.trackpad.TrackpadTwoFingerFromRightEdgeSwipeGesture = mkOption {
+      type = types.nullOr (types.enum [ 0 3 ]);
+      default = null;
+      description = ''
+        Whether to enable two-finger swipe-from-right-edge gesture: 0 to disable, 3 to open Notification Center.
+        The default is 0.
       '';
     };
 


### PR DESCRIPTION
This PR adds additional trackpad and gesture support.

To `system.defaults.trackpad` it adds:

```
ActuateDetents
DragLock
ForceSuppressed
TrackpadCornerSecondaryClick
TrackpadFourFingerHorizSwipeGesture
TrackpadFourFingerPinchGesture
TrackpadFourFingerVertSwipeGesture
TrackpadMomentumScroll
TrackpadPinch
TrackpadRotate
TrackpadThreeFingerHorizSwipeGesture
TrackpadThreeFingerTapGesture
TrackpadThreeFingerVertSwipeGesture
TrackpadTwoFingerDoubleTapGesture
TrackpadTwoFingerFromRightEdgeSwipeGesture
```

and to `system.defaults.dock` it adds:

```
showAppExposeGestureEnabled
showDesktopGestureEnabled
showLaunchpadGestureEnabled
showMissionControlGestureEnabled
```

A few questions:

1. I have tested locally - am I meant to also add these settings to `tests/system-defaults-write.nix`?
1. There is an inconsistency in the way that we represent `defaults write` commands with only 2 options. `defaults read` outputs these as `-int` (0 or 1), even if the user sets them via `-bool`. In this repo, there is a mix of representing them as `types.bool` and `types.enum [ 0 1 ]`. Does the project have a preference? Should we make them all the same?
1. I have a question about formatting, but thought it best to separate that into its own issue (#).