### PR TITLE
users: allow arbitrary group IDs

### DIFF
--- a/modules/users/group.nix
+++ b/modules/users/group.nix
@@ -13,10 +13,7 @@ with lib;
     };
 
     gid = mkOption {
-      type = mkOptionType {
-        name = "gid";
-        check = t: isInt t && t > 501;
-      };
+      type = types.int;
       description = "The group's GID.";
     };
 


### PR DESCRIPTION
The upstream Nix UID/GID changes for Sequoia will require us to manage a group with GID 350. That will require more work on our end to ensure compatibility and a working migration path, but this is enough to allow hacking around it locally in system configurations for now.