### PR TITLE
Add mongodb service

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -68,6 +68,7 @@
   ./services/lorri.nix
   ./services/mail/offlineimap.nix
   ./services/mopidy.nix
+  ./services/mongodb
   ./services/monitoring/telegraf.nix
   ./services/netbird.nix
   ./services/nix-daemon.nix

--- a/modules/services/mongodb/default.nix
+++ b/modules/services/mongodb/default.nix
@@ -1,0 +1,140 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.mongodb;
+
+  mongodb = cfg.package;
+
+  mongoCnf = cfg:
+    pkgs.writeText "mongodb.conf" ''
+      net.bindIp: ${cfg.bind_ip}
+      ${optionalString cfg.quiet "systemLog.quiet: true"}
+      systemLog.destination: syslog
+      ${optionalString (cfg.replSetName != "")
+      "replication.replSetName: ${cfg.replSetName}"}
+      ${cfg.extraConfig}
+    '';
+  # ${optionalString cfg.enableAuth "security.authorization: enabled"}
+in {
+  meta.maintainers = [ lib.maintainers.obinmatt or "obinmatt" ];
+
+  ###### interface
+
+  options = {
+    services.mongodb = {
+      enable = mkEnableOption "the MongoDB server";
+
+      package = mkPackageOption pkgs "mongodb" { };
+
+      user = mkOption {
+        type = types.str;
+        default = "mongodb";
+        description = "User account under which MongoDB runs";
+      };
+
+      bind_ip = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "IP to bind to";
+      };
+
+      quiet = mkOption {
+        type = types.bool;
+        default = false;
+        description = "quieter output";
+      };
+
+      enableAuth = mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          "Enable client authentication. Creates a default superuser with username root!";
+      };
+
+      initialRootPassword = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Password for the root user if auth is enabled.";
+      };
+
+      dbpath = mkOption {
+        type = types.str;
+        default = "~/.mongodb/data";
+        description = "Location where MongoDB stores its files";
+      };
+
+      pidFile = mkOption {
+        type = types.str;
+        default = "~/.mongodb/mongodb.pid";
+        description = "Location of MongoDB pid file";
+      };
+
+      replSetName = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          If this instance is part of a replica set, set its name here.
+          Otherwise, leave empty to run as single node.
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          storage.journal.enabled: false
+        '';
+        description = "MongoDB extra configuration in YAML format";
+      };
+
+      initialScript = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          A file containing MongoDB statements to execute on first startup.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.mongodb.enable {
+    # these require a different implementation (user) or functionality that launchd does not provide
+    warnings = if cfg.user != "mongodb" || cfg.enableAuth != false
+    || cfg.initialRootPassword != null || cfg.initialScript != null then
+      [
+        "Currently nix-darwin does not support mongodb user, enableAuth, initialRootPassword or initialScript"
+      ]
+    else
+      [ ];
+
+    environment.systemPackages = [ mongodb ];
+
+    launchd.user.agents.mongodb = {
+      path = [ mongodb ];
+      serviceConfig = {
+        KeepAlive = true;
+        RunAtLoad = true;
+      };
+      script = ''
+        # preStart
+        rm ${cfg.dbpath}/mongod.lock || true
+        if ! test -e ${cfg.dbpath}; then
+          ${pkgs.coreutils}/bin/install -d -m 700 ${cfg.dbpath}
+        fi
+        if ! test -e ${cfg.pidFile}; then
+          ${pkgs.coreutils}/bin/install -D /dev/null ${cfg.pidFile}
+        fi
+
+        # start
+        exec ${mongodb}/bin/mongod --config ${
+          mongoCnf cfg
+        } --dbpath ${cfg.dbpath} --fork --pidfilepath ${cfg.pidFile}
+
+        # postStart
+        # launchd does not have this functionality
+      '';
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -1,8 +1,5 @@
-{ nixpkgs ? <nixpkgs>
-, supportedSystems ? [ "x86_64-darwin" ]
-, scrubJobs ? true
+{ nixpkgs ? <nixpkgs>, supportedSystems ? [ "x86_64-darwin" ], scrubJobs ? true,
 }:
-
 let
   inherit (release) mapTestOn packagePlatforms pkgs all linux darwin;
 
@@ -10,54 +7,47 @@ let
 
   mapPlatforms = systems: pkgs.lib.mapAttrs (n: v: systems);
 
-  buildFromConfig = configuration: sel: sel
-    (import ./. { inherit nixpkgs configuration system; }).config;
+  buildFromConfig = configuration: sel:
+    sel (import ./. { inherit nixpkgs configuration system; }).config;
 
-  makeSystem = configuration: pkgs.lib.genAttrs [ system ] (system:
-    buildFromConfig configuration (config: config.system.build.toplevel)
-  );
+  makeSystem = configuration:
+    pkgs.lib.genAttrs [ system ] (system:
+      buildFromConfig configuration (config: config.system.build.toplevel));
 
   makeTest = test:
     let
       testName =
-        builtins.replaceStrings [ ".nix" ] [ "" ]
-          (builtins.baseNameOf test);
+        builtins.replaceStrings [ ".nix" ] [ "" ] (builtins.baseNameOf test);
 
-      configuration =
-        { config, lib, pkgs, ... }:
-        with lib;
-        {
+      configuration = { config, lib, pkgs, ... }:
+        with lib; {
           imports = [ test ];
 
           options = {
-            out = mkOption {
-              type = types.package;
-            };
+            out = mkOption { type = types.package; };
 
-            test = mkOption {
-              type = types.lines;
-            };
+            test = mkOption { type = types.lines; };
           };
 
           config = {
-            system.build.run-test = pkgs.runCommand "darwin-test-${testName}"
-              { allowSubstitutes = false; preferLocalBuild = true; }
-              ''
-                #! ${pkgs.stdenv.shell}
-                set -e
+            system.build.run-test = pkgs.runCommand "darwin-test-${testName}" {
+              allowSubstitutes = false;
+              preferLocalBuild = true;
+            } ''
+              #! ${pkgs.stdenv.shell}
+              set -e
 
-                echo >&2 "running tests for system ${config.out}"
-                echo >&2
-                ${config.test}
-                echo >&2 ok
-                touch $out
-              '';
+              echo >&2 "running tests for system ${config.out}"
+              echo >&2
+              ${config.test}
+              echo >&2 ok
+              touch $out
+            '';
 
             out = config.system.build.toplevel;
           };
         };
-    in
-      buildFromConfig configuration (config: config.system.build.run-test);
+    in buildFromConfig configuration (config: config.system.build.run-test);
 
   release = import <nixpkgs/pkgs/top-level/release-lib.nix> {
     inherit supportedSystems scrubJobs;
@@ -66,35 +56,35 @@ let
 
   packageSet = {
     inherit (pkgs)
-      stdenv bash zsh nix
-      tmux reattach-to-user-namespace
-      nano emacs vim;
+      stdenv bash zsh nix tmux reattach-to-user-namespace nano emacs vim;
   };
 
   jobs = {
-
     unstable = pkgs.releaseTools.aggregate {
       name = "darwin-${pkgs.lib.nixpkgsVersion}";
-      constituents =
-        [ jobs.stdenv.x86_64-darwin
-          jobs.bash.x86_64-darwin
-          jobs.zsh.x86_64-darwin
-          jobs.nix.x86_64-darwin
-          jobs.reattach-to-user-namespace.x86_64-darwin
-          jobs.tmux.x86_64-darwin
-          jobs.nano.x86_64-darwin
-          jobs.vim.x86_64-darwin
-          jobs.emacs.x86_64-darwin
-          jobs.examples.hydra.x86_64-darwin
-          jobs.examples.lnl.x86_64-darwin
-          jobs.examples.simple.x86_64-darwin
-        ];
+      constituents = [
+        jobs.stdenv.x86_64-darwin
+        jobs.bash.x86_64-darwin
+        jobs.zsh.x86_64-darwin
+        jobs.nix.x86_64-darwin
+        jobs.reattach-to-user-namespace.x86_64-darwin
+        jobs.tmux.x86_64-darwin
+        jobs.nano.x86_64-darwin
+        jobs.vim.x86_64-darwin
+        jobs.emacs.x86_64-darwin
+        jobs.examples.hydra.x86_64-darwin
+        jobs.examples.lnl.x86_64-darwin
+        jobs.examples.simple.x86_64-darwin
+      ];
       meta.description = "Release-critical builds for the darwin channel";
     };
 
-    manualHTML = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manualHTML);
-    manpages = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manpages);
-    options = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.optionsJSON);
+    manualHTML = buildFromConfig ({ ... }: { })
+      (config: config.system.build.manual.manualHTML);
+    manpages = buildFromConfig ({ ... }: { })
+      (config: config.system.build.manual.manpages);
+    options = buildFromConfig ({ ... }: { })
+      (config: config.system.build.manual.optionsJSON);
 
     examples.hydra = makeSystem ./modules/examples/hydra.nix;
     examples.lnl = makeSystem ./modules/examples/lnl.nix;
@@ -109,22 +99,29 @@ let
     tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;
     tests.launchd-setenv = makeTest ./tests/launchd-setenv.nix;
     tests.networking-hostname = makeTest ./tests/networking-hostname.nix;
-    tests.networking-networkservices = makeTest ./tests/networking-networkservices.nix;
+    tests.networking-networkservices =
+      makeTest ./tests/networking-networkservices.nix;
     tests.nixpkgs-overlays = makeTest ./tests/nixpkgs-overlays.nix;
     tests.programs-ssh = makeTest ./tests/programs-ssh.nix;
     tests.programs-tmux = makeTest ./tests/programs-tmux.nix;
     tests.programs-zsh = makeTest ./tests/programs-zsh.nix;
-    tests.programs-ssh-empty-known-hosts = makeTest ./tests/programs-ssh-empty-known-hosts.nix;
+    tests.programs-ssh-empty-known-hosts =
+      makeTest ./tests/programs-ssh-empty-known-hosts.nix;
     tests.security-pki = makeTest ./tests/security-pki.nix;
-    tests.services-activate-system = makeTest ./tests/services-activate-system.nix;
-    tests.services-activate-system-changed-label-prefix = makeTest ./tests/services-activate-system-changed-label-prefix.nix;
-    tests.services-buildkite-agent = makeTest ./tests/services-buildkite-agent.nix;
-    tests.services-github-runners = makeTest ./tests/services-github-runners.nix;
+    tests.services-activate-system =
+      makeTest ./tests/services-activate-system.nix;
+    tests.services-activate-system-changed-label-prefix =
+      makeTest ./tests/services-activate-system-changed-label-prefix.nix;
+    tests.services-buildkite-agent =
+      makeTest ./tests/services-buildkite-agent.nix;
+    tests.services-github-runners =
+      makeTest ./tests/services-github-runners.nix;
     tests.services-lorri = makeTest ./tests/services-lorri.nix;
     tests.services-nix-daemon = makeTest ./tests/services-nix-daemon.nix;
     tests.sockets-nix-daemon = makeTest ./tests/sockets-nix-daemon.nix;
     tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
-    tests.services-eternal-terminal = makeTest ./tests/services-eternal-terminal.nix;
+    tests.services-eternal-terminal =
+      makeTest ./tests/services-eternal-terminal.nix;
     tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
     tests.services-nix-optimise = makeTest ./tests/services-nix-optimise.nix;
     tests.services-nextdns = makeTest ./tests/services-nextdns.nix;
@@ -139,18 +136,16 @@ let
     tests.services-synergy = makeTest ./tests/services-synergy.nix;
     tests.services-yabai = makeTest ./tests/services-yabai.nix;
     tests.services-jankyborders = makeTest ./tests/services-jankyborders.nix;
+    tests.services-mongodb = makeTest ./tests/services-mongodb.nix;
     tests.system-defaults-write = makeTest ./tests/system-defaults-write.nix;
     tests.system-environment = makeTest ./tests/system-environment.nix;
-    tests.system-keyboard-mapping = makeTest ./tests/system-keyboard-mapping.nix;
+    tests.system-keyboard-mapping =
+      makeTest ./tests/system-keyboard-mapping.nix;
     tests.system-packages = makeTest ./tests/system-packages.nix;
     tests.system-path = makeTest ./tests/system-path.nix;
     tests.system-shells = makeTest ./tests/system-shells.nix;
     tests.users-groups = makeTest ./tests/users-groups.nix;
     tests.users-packages = makeTest ./tests/users-packages.nix;
     tests.fonts = makeTest ./tests/fonts.nix;
-
-  }
-  // (mapTestOn (packagePlatforms packageSet));
-
-in
-  jobs
+  } // (mapTestOn (packagePlatforms packageSet));
+in jobs

--- a/tests/services-mongodb.nix
+++ b/tests/services-mongodb.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+let mongodb = pkgs.runCommand "mongodb-0.0.0" { } "mkdir $out";
+in {
+  services.mongodb.enable = true;
+  services.mongodb.package = mongodb;
+
+  test = ''
+    echo >&2 "checking mongodb service in ~/Library/LaunchAgents"
+    grep "org.nixos.mongodb" ${config.out}/user/Library/LaunchAgents/org.nixos.mongodb.plist
+    grep "${mongodb}/bin" ${config.out}/user/Library/LaunchAgents/org.nixos.mongodb.plist
+    grep "mongodb-start" ${config.out}/user/Library/LaunchAgents/org.nixos.mongodb.plist
+  '';
+}


### PR DESCRIPTION
Closes #1062 

This is my first attempt at anything launchd related so bear with me. I used the postgres implementation as an example for this one combined with nixos module.

Details:
- I went with a `launchd.agent` so the `user` option does nothing.
- For the auth, the nixos module uses `systemd-run` to run the command, I don't think there is an equivalent for `launchd` so I omitted that step.
- For the `dbpath` I pass it as an option to the exec command instead of adding it into the `mongodb.conf` file because the file cannot handle `~` in paths.
- I formatted the files using `nixfmt`.

If I need to make any changes please let me know!