### PR TITLE
Backport Zsh fpath mangling from NixOS

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -137,7 +137,7 @@ in
 
       # Tell zsh how to find installed completions
       for p in ''${(z)NIX_PROFILES}; do
-        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
+        fpath=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions $fpath)
       done
 
       ${cfg.shellInit}

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -135,6 +135,11 @@ in
         . ${config.system.build.setEnvironment}
       fi
 
+      # Tell zsh how to find installed completions
+      for p in ''${(z)NIX_PROFILES}; do
+        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
+      done
+
       ${cfg.shellInit}
 
       # Read system-wide modifications.
@@ -181,11 +186,6 @@ in
 
       ${config.environment.interactiveShellInit}
       ${cfg.interactiveShellInit}
-
-      # Tell zsh how to find installed completions
-      for p in ''${(z)NIX_PROFILES}; do
-        fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
-      done
 
       ${cfg.promptInit}
 


### PR DESCRIPTION
Backports the following two commits from NixOS. Both are related to the way the Zsh `fpath` is being mangled:

- NixOS/nixpkgs@8dad5a22399782a4ef681174219546cb050e580f: ensures that the Zsh fpath contains entries from Nix unconditionally, even when `setopt no_global_rcs` is set in the user's `.zshenv`.

- NixOS/nixpkgs@f70e3f3738300ef1e94737c09364cd176893858f: ensures that Nix fpath entries take precedence over Zsh's ones.