### PR TITLE
Put nixpkgs in NIX_PATH and system registry for flake configs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
             }
             ++ [ ({ lib, ... }: {
               nixpkgs.source = lib.mkDefault nixpkgs;
+              nixpkgs.flake.source = lib.mkDefault nixpkgs;
 
               system.checks.verifyNixPath = lib.mkDefault false;
 

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -47,6 +47,7 @@
   ./nix/linux-builder.nix
   ./nix/nix-darwin.nix
   ./nix/nixpkgs.nix
+  ./nix/nixpkgs-flake.nix
   ./environment
   ./fonts
   ./launchd

--- a/modules/nix/nixpkgs-flake.nix
+++ b/modules/nix/nixpkgs-flake.nix
@@ -1,0 +1,105 @@
+{ config, options, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.nixpkgs.flake;
+in
+{
+  options.nixpkgs.flake = {
+    source = mkOption {
+      # In newer Nix versions, particularly with lazy trees, outPath of
+      # flakes becomes a Nix-language path object. We deliberately allow this
+      # to gracefully come through the interface in discussion with @roberth.
+      #
+      # See: https://github.com/NixOS/nixpkgs/pull/278522#discussion_r1460292639
+      type = types.nullOr (types.either types.str types.path);
+
+      default = null;
+      defaultText = "if (using nix-darwin.lib.darwinSystem) then nixpkgs.source else null";
+
+      example = ''builtins.fetchTarball { name = "source"; sha256 = "${lib.fakeHash}"; url = "https://github.com/nixos/nixpkgs/archive/somecommit.tar.gz"; }'';
+
+      description = ''
+        The path to the nixpkgs sources used to build the system. This is automatically set up to be
+        the store path of the nixpkgs flake used to build the system if using
+        `nixpkgs.lib.darwinSystem`, and is otherwise null by default.
+
+        This can also be optionally set if the nix-darwin system is not built with a flake but still uses
+        pinned sources: set this to the store path for the nixpkgs sources used to build the system,
+        as may be obtained by `builtins.fetchTarball`, for example.
+
+        Note: the name of the store path must be "source" due to
+        <https://github.com/NixOS/nix/issues/7075>.
+      '';
+    };
+
+    setNixPath = mkOption {
+      type = types.bool;
+
+      default = cfg.source != null;
+      defaultText = "config.nixpkgs.flake.source != null";
+
+      description = ''
+        Whether to set {env}`NIX_PATH` to include `nixpkgs=flake:nixpkgs` such that `<nixpkgs>`
+        lookups receive the version of nixpkgs that the system was built with, in concert with
+        {option}`nixpkgs.flake.setFlakeRegistry`.
+
+        This is on by default for nix-darwin configurations built with flakes.
+
+        This makes {command}`nix-build '<nixpkgs>' -A hello` work out of the box on flake systems.
+
+        Note that this option makes the nix-darwin closure depend on the nixpkgs sources, which may add
+        undesired closure size if the system will not have any nix commands run on it.
+      '';
+    };
+
+    setFlakeRegistry = mkOption {
+      type = types.bool;
+
+      default = cfg.source != null;
+      defaultText = "config.nixpkgs.flake.source != null";
+
+      description = ''
+        Whether to pin nixpkgs in the system-wide flake registry (`/etc/nix/registry.json`) to the
+        store path of the sources of nixpkgs used to build the nix-darwin system.
+
+        This is on by default for nix-darwin configurations built with flakes.
+
+        This option makes {command}`nix run nixpkgs#hello` reuse dependencies from the system, avoid
+        refetching nixpkgs, and have a consistent result every time.
+
+        Note that this option makes the nix-darwin closure depend on the nixpkgs sources, which may add
+        undesired closure size if the system will not have any nix commands run on it.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.source != null) (mkMerge [
+    {
+      assertions = [
+        {
+          assertion = cfg.setNixPath -> cfg.setFlakeRegistry;
+          message = ''
+            Setting `nixpkgs.flake.setNixPath` requires that `nixpkgs.flake.setFlakeRegistry` also
+            be set, since it is implemented in terms of indirection through the flake registry.
+          '';
+        }
+      ];
+    }
+    (mkIf cfg.setFlakeRegistry {
+      nix.registry.nixpkgs.to = mkDefault {
+        type = "path";
+        path = cfg.source;
+      };
+    })
+    (mkIf cfg.setNixPath {
+      # N.B. This does not include darwin-config in NIX_PATH unlike modules/nix/default.nix
+      # because we would need some kind of evil shim taking the *calling* flake's self path,
+      # perhaps, to ever make that work (in order to know where the Nix expr for the system came
+      # from and how to call it).
+      nix.nixPath = mkDefault ([ "nixpkgs=flake:nixpkgs" ]
+        ++ optional config.nix.channel.enable "/nix/var/nix/profiles/per-user/root/channels");
+    })
+  ]);
+}


### PR DESCRIPTION
Backport of NixOS/nixpkgs@e456032addae76701eb17e6c03fc515fd78ad74f, which ensures that `NIX_PATH` includes `nixpkgs=flake:nixpkgs` when the system was built from a flake.

Here is the rationale for having `NIX_PATH` correctly set in a flake context, especially since Nix 2.24: https://github.com/NixOS/nixpkgs/pull/273170#issuecomment-2342254448

---

💻 **Demonstration from a REPL session, using my own system flake importing this branch**

1. Before `switch`, despite having `extra-nix-path = nixpkgs=flake:nixpkgs` in `nix.conf`:

   ```console
   $ nix repl --expr 'import <nixpkgs> {}'
   Nix 2.24.6
          error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)
   ```

1. Open the REPL and load the flake's output to execute `nix-darwin.lib.darwinSystem`:

   ```console
   $ nix repl
   Nix 2.24.6
   Type :? for help.
   >
   ```
   ```console
   > darwinCfg = (builtins.getFlake (builtins.toString ./.)).darwinConfigurations.myhost
   ```

1. Verify that `nix.registry` was populated:

   - With `nix.registry.nixpkgs` equal to nix-darwin's `nixpkgs.source` (default)

      ```console
      > darwinCfg.options.nix.registry.value.nixpkgs.to
      {
        path = { ... };
        type = "path";
      }
      > builtins.toPath darwinCfg.options.nix.registry.value.nixpkgs.to.path
      "/nix/store/1h99qq6970gkx3j0m9w4yrrl9y99y1nk-source"
      ```

   - With `nix.registry.nixpkgs` [overriden by the user](https://github.com/DeterminateSystems/nix/blob/5dad5cea44bafbace2b3a170799c0b2f88982649/flake.nix#L107-L117)

      ```console
      > darwinCfg.options.nix.registry.value.nixpkgs.to
      {
        type = "tarball";
        url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1.0.tar.gz";
      }
      ```

1. Verify that `nix.nixPath` was populated:

   - With `nix.channel.enable = true` (default)
      ```console
      > darwinCfg.options.nix.nixPath.value
      [
        "nixpkgs=flake:nixpkgs"
        "/nix/var/nix/profiles/per-user/root/channels"
      ]
      ```

   - With `nix.channel.enable = false`
      ```console
      > darwinCfg.options.nix.nixPath.value
      [ "nixpkgs=flake:nixpkgs" ]
      ```

1. After a `switch`, the system can perform `<nixpkgs>` lookups successfully:

   ```console
   $ darwin-rebuild switch
   $ exec zsh -il
   $ nix repl --expr 'import <nixpkgs> {}'
   Nix 2.24.6
   Type :? for help.
   Loading installable ''...
   Added 22627 variables.
   ```