### PR TITLE
tests/{networking-hostname,users-groups}: update for `lib.escapeShellArg` change

### DIFF
--- a/tests/networking-hostname.nix
+++ b/tests/networking-hostname.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ lib, config, pkgs, ... }:
 
 {
   networking.hostName = "EVE";
@@ -7,8 +7,8 @@
   test = ''
     echo checking hostname in /activate >&2
     grep "scutil --set ComputerName 'EVE’s MacBook Pro'" ${config.out}/activate
-    grep "scutil --set LocalHostName 'EVE'" ${config.out}/activate
-    grep "scutil --set HostName 'EVE'" ${config.out}/activate
+    grep "scutil --set LocalHostName ${lib.escapeShellArg "EVE"}" ${config.out}/activate
+    grep "scutil --set HostName ${lib.escapeShellArg "EVE"}" ${config.out}/activate
     echo checking defaults write in ${config.out}/activate-user >&2
   '';
 }

--- a/tests/users-groups.nix
+++ b/tests/users-groups.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ lib, config, pkgs, ... }:
 
 {
   users.knownGroups = [ "foo" "created.group" "deleted.group" ];
@@ -46,9 +46,9 @@
     grep "dscl . -create '/Users/foo' IsHidden 0" ${config.out}/activate
     grep "dscl . -create '/Users/foo' RealName 'Foo user'" ${config.out}/activate
     grep "dscl . -create '/Users/foo' NFSHomeDirectory '/Users/foo'" ${config.out}/activate
-    grep "dscl . -create '/Users/foo' UserShell '/run/current-system/sw/bin/bash'" ${config.out}/activate
+    grep "dscl . -create '/Users/foo' UserShell ${lib.escapeShellArg "/run/current-system/sw/bin/bash"}" ${config.out}/activate
     grep "dscl . -create '/Users/created.user' UniqueID 42001" ${config.out}/activate
-    grep "dscl . -create '/Users/created.user' UserShell '/sbin/nologin'" ${config.out}/activate
+    grep "dscl . -create '/Users/created.user' UserShell ${lib.escapeShellArg "/sbin/nologin"}" ${config.out}/activate
     grep "createhomedir -cu 'foo'" ${config.out}/activate
     grep -qv "dscl . -delete '/Groups/created.user'" ${config.out}/activate
 


### PR DESCRIPTION
Fixes the unstable tests.