### PR TITLE
{ids,checks}: update for new builder UID/GID values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  CURRENT_STABLE_CHANNEL: nixpkgs-23.11-darwin
+  CURRENT_STABLE_CHANNEL: nixpkgs-24.05-darwin
 
 jobs:
   test-stable:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,13 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
+    # We use the Determinate Systems installer for 2.18 because the
+    # Sequoia UID/GID changes have not yet been backported to the
+    # official installer for that version.
     - name: Install nix corresponding to latest stable channel
-      uses: cachix/install-nix-action@v23
+      uses: DeterminateSystems/nix-installer-action@main
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.13.6/install
+        nix-package-url: https://releases.nixos.org/nix/nix-2.18.5/nix-2.18.5-x86_64-darwin.tar.xz
     - run: nix-build ./release.nix -I nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }} -I darwin=. -A tests
     - run: nix-build ./release.nix -I nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }} -I darwin=. -A manpages
     - run: nix-build ./release.nix -I nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }} -I darwin=. -A examples.simple
@@ -38,18 +41,20 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
+    # We use the Determinate Systems installer for 2.18 because the
+    # Sequoia UID/GID changes have not yet been backported to the
+    # official installer for that version.
     - name: Install nix corresponding to latest stable channel
-      uses: cachix/install-nix-action@v23
+      uses: DeterminateSystems/nix-installer-action@main
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.13.6/install
-        nix_path: nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }}
+        nix-package-url: https://releases.nixos.org/nix/nix-2.18.5/nix-2.18.5-x86_64-darwin.tar.xz
     - name: Install ${{ env.CURRENT_STABLE_CHANNEL }} channel
       run: |
         nix-channel --add https://nixos.org/channels/${{ env.CURRENT_STABLE_CHANNEL }} nixpkgs
         nix-channel --update
     - name: Install nix-darwin and test
       run: |
-        export NIX_PATH=$HOME/.nix-defexpr/channels
+        export NIX_PATH=nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }}
 
         # We run nix-darwin twice to test that it can create darwin-configuration correctly for us
         # but we expect it to fail setting up /etc/nix/nix.conf
@@ -128,10 +133,13 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
-    - name: Install nix version corresponding to latest stable channel
-      uses: cachix/install-nix-action@v23
+    # We use the Determinate Systems installer for 2.18 because the
+    # Sequoia UID/GID changes have not yet been backported to the
+    # official installer for that version.
+    - name: Install nix corresponding to latest stable channel
+      uses: DeterminateSystems/nix-installer-action@main
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.13.6/install
+        nix-package-url: https://releases.nixos.org/nix/nix-2.18.5/nix-2.18.5-x86_64-darwin.tar.xz
     - name: Install nix-darwin
       run: |
         mkdir -p ~/.config/nix-darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v23
+      uses: cachix/install-nix-action@v27
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.24.6/install
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-unstable -I darwin=. -A tests
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-unstable -I darwin=. -A manpages
     - run: nix-build ./release.nix -I nixpkgs=channel:nixpkgs-unstable -I darwin=. -A examples.simple
@@ -82,8 +84,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v23
+      uses: cachix/install-nix-action@v27
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.24.6/install
         nix_path: nixpkgs=channel:nixpkgs-unstable
     - name: Install nixpkgs-unstable channel
       run: |
@@ -209,7 +212,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v23
+      uses: cachix/install-nix-action@v27
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.24.6/install
     - name: Install nix-darwin
       run: |
         mkdir -p ~/.config/nix-darwin

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+2024-09-10
+- The default Nix build user group ID is now set to 350 when
+  `system.stateVersion` ≥ 5, to reflect the default for new Nix
+  installations. This only affects installations that enable
+  `nix.configureBuildUsers`, and any divergence will be detected on
+  system activation. To use `nix.configureBuildUsers` with a higher
+  `system.stateVersion` on installations using the old group ID, set:
+
+      ids.gids.nixbld = 30000;
+
+  We do not recommend trying to change the group ID with macOS user
+  management tools without a complete uninstallation and reinstallation
+  of Nix.
+
 2024-06-15
 - SECURITY NOTICE: The previous implementation of the
   `users.users.<name>.openssh.authorizedKeys.*` options would not delete

--- a/modules/examples/flake/flake.nix
+++ b/modules/examples/flake/flake.nix
@@ -32,7 +32,7 @@
 
       # Used for backwards compatibility, please read the changelog before changing.
       # $ darwin-rebuild changelog
-      system.stateVersion = 4;
+      system.stateVersion = 5;
 
       # The platform the configuration will be used on.
       nixpkgs.hostPlatform = "x86_64-darwin";

--- a/modules/examples/ofborg.nix
+++ b/modules/examples/ofborg.nix
@@ -25,5 +25,5 @@ with lib;
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
-  system.stateVersion = 4;
+  system.stateVersion = 5;
 }

--- a/modules/examples/simple.nix
+++ b/modules/examples/simple.nix
@@ -21,5 +21,5 @@
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
-  system.stateVersion = 4;
+  system.stateVersion = 5;
 }

--- a/modules/misc/ids.nix
+++ b/modules/misc/ids.nix
@@ -8,7 +8,7 @@
 # to change uids/gids on service start, in example a service with a lot of
 # files.
 
-{ lib, ... }:
+{ lib, config, ... }:
 
 let
   inherit (lib) types;
@@ -34,15 +34,14 @@ in
 
   };
 
-
   config = {
 
     ids.uids = {
-      nixbld = 300;
+      nixbld = lib.mkDefault 350;
     };
 
     ids.gids = {
-      nixbld = 30000;
+      nixbld = lib.mkDefault (if config.system.stateVersion < 5 then 30000 else 350);
     };
 
   };

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -46,12 +46,17 @@ let
 
   oldBuildUsers = ''
     if dscl . -list /Users | grep -q '^nixbld'; then
-        echo "[1;31mwarning: Detected old style nixbld users[0m" >&2
+        echo "[1;31merror: Detected old style nixbld users, aborting activation[0m" >&2
         echo "These can cause migration problems when upgrading to certain macOS versions" >&2
         echo "You can enable the following option to migrate to new style nixbld users" >&2
         echo >&2
         echo "    nix.configureBuildUsers = true;" >&2
         echo >&2
+        echo "or disable this check with" >&2
+        echo >&2
+        echo "    system.checks.verifyBuildUsers = false;" >&2
+        echo >&2
+        exit 2
     fi
   '';
 
@@ -260,7 +265,7 @@ in
     system.checks.text = mkMerge [
       darwinChanges
       runLink
-      oldBuildUsers
+      (mkIf (cfg.verifyBuildUsers && !config.nix.configureBuildUsers) oldBuildUsers)
       (mkIf cfg.verifyBuildUsers buildUsers)
       (mkIf (!config.nix.useDaemon) singleUser)
       nixStore

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -242,7 +242,9 @@ in
 
     system.checks.verifyBuildUsers = mkOption {
       type = types.bool;
-      default = !(config.nix.settings.auto-allocate-uids or false);
+      default =
+        (config.nix.useDaemon && !(config.nix.settings.auto-allocate-uids or false))
+        || config.nix.configureBuildUsers;
       description = "Whether to run the Nix build users validation checks.";
     };
 
@@ -259,7 +261,7 @@ in
       darwinChanges
       runLink
       oldBuildUsers
-      (mkIf (config.nix.useDaemon && cfg.verifyBuildUsers) buildUsers)
+      (mkIf cfg.verifyBuildUsers buildUsers)
       (mkIf (!config.nix.useDaemon) singleUser)
       nixStore
       (mkIf (config.nix.gc.automatic && config.nix.gc.user == null) nixGarbageCollector)

--- a/modules/system/version.nix
+++ b/modules/system/version.nix
@@ -35,7 +35,7 @@ in
   options = {
     system.stateVersion = mkOption {
       type = types.int;
-      default = 4;
+      default = 5;
       description = ''
         Every once in a while, a new NixOS release may change
         configuration defaults in a way incompatible with stateful


### PR DESCRIPTION
See:

* https://github.com/LnL7/nix-darwin/issues/970
* https://github.com/NixOS/nix/issues/10892
* https://github.com/NixOS/nix/pull/11075
* https://github.com/NixOS/nix/pull/10919
* https://github.com/DeterminateSystems/nix-installer/issues/1001
* https://github.com/DeterminateSystems/nix-installer/issues/1115
* https://github.com/DeterminateSystems/nix-installer/pull/1123
* https://github.com/DeterminateSystems/nix-installer/pull/1143
* https://git.lix.systems/lix-project/lix-installer/issues/24

This is fairly subtle stuff, but also time‐critical; Apple has given us an unexpected gift by announcing that **Sequoia will release on Monday**, making it the earliest macOS release in over a decade. Currently, Nix users upgrading to Sequoia get a broken installation that outputs a useless error message, and users who have already migrated their users can’t activate their configuration if they manage Nix users with nix-darwin.

I wanted to do a “proper” migration based on our existing user management functionality, but we simply don’t have the time. The best thing we can do for users to reduce the support burden and reputation hit of everything breaking is to get the upstream migration script in front of them ASAP. Therefore, this adds support for the new values, and adds checks when the UIDs/GID aren’t as expected that tell the user what they can do to remediate. **I want to get this merged within 24 hours if possible.**

I had to do some ugly work to the CI to get it to pass, as Nix have not yet released fixed installers for versions other than 2.24. But it does pass, and I have verified that all the main code paths here seem to behave as expected.

Sorry for neglecting nix-darwin recently. Now that I’m slightly less busy with Nixpkgs work I hope to do more soon, but this is really urgent so I dropped everything to get it out. 

Thanks to @mjm for helping test this.

cc @Enzime @Samasaur1 @malob @LnL7 for code review
cc @abathur for feedback on error message wording

Closes: #970