### PR TITLE
Fix darwin-rebuild changelog not displaying

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -203,7 +203,7 @@ if [ "$action" = edit ]; then
   fi
 fi
 
-if [ "$action" = switch ] || [ "$action" = build ] || [ "$action" = check ]; then
+if [ "$action" = switch ] || [ "$action" = build ] || [ "$action" = check ] || [ "$action" = changelog ]; then
   echo "building the system configuration..." >&2
   if [ -z "$flake" ]; then
     systemConfig="$(nix-build '<darwin>' "${extraBuildFlags[@]}" -A system)"
@@ -252,11 +252,7 @@ if [ "$action" = switch ] || [ "$action" = activate ] || [ "$action" = rollback 
 fi
 
 if [ "$action" = changelog ]; then
-  echo >&2
-  echo "[1;1mCHANGELOG[0m" >&2
-  echo >&2
-  head -n 32 "$systemConfig/darwin-changes"
-  echo >&2
+  ${PAGER:-less} -- "$systemConfig/darwin-changes"
 fi
 
 if [ "$action" = check ]; then


### PR DESCRIPTION
The script returns early when `$systemConfig` is empty, which currently prevents the changelog from being displayed.

Fixes #329

---

Before, `$systemConfig=`

```console
$ darwin-rebuild changelog
(nothing)
```

After, `$systemConfig=/nix/store/22dc9r5hhm311x5bffwjjr1abr3r2jrz-darwin-system-24.05.20240830.6e99f2a+darwin5.f4f18f3`:

```console
$ darwin-rebuild changelog
CHANGELOG

2024-09-10
- The default Nix build user group ID is now set to 350 when
  `system.stateVersion` ≥ 5, to reflect the default for new Nix
  installations. This only affects installations that enable
  `nix.configureBuildUsers`, and any divergence will be detected on
  system activation. To use `nix.configureBuildUsers` with a higher
  `system.stateVersion` on installations using the old group ID, set:

      ids.gids.nixbld = 30000;

  We do not recommend trying to change the group ID with macOS user
  management tools without a complete uninstallation and reinstallation
  of Nix.

...
```