### PR TITLE
zsh: let children shells set their fpath

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -124,9 +124,8 @@ in
       # This file is read for all shells.
 
       # Only execute this file once per shell.
-      # But don't clobber the environment of interactive non-login children!
       if [ -n "$__ETC_ZSHENV_SOURCED" ]; then return; fi
-      export __ETC_ZSHENV_SOURCED=1
+      __ETC_ZSHENV_SOURCED=1
 
       # Don't execute this file when running in a pure nix-shell.
       if test -n "$IN_NIX_SHELL"; then return; fi


### PR DESCRIPTION
Follow up to #1066

This is a backport of NixOS/nixpkgs@55819e6c861f53450030eea832a76583a6786370, which allows children Zsh shells to set their `fpath`.

Without this fix, a child shell opened with a command such as `zsh -il` only contains Zsh's default fpath entry, and none of Nix's profiles fpath entries.

---

Before, opening a child shell causes Nix's `fpath` entries to get skipped:
```console
$ echo $fpath
/opt/homebrew/share/zsh/site-functions /Users/acotten/.nix-profile/share/zsh/site-functions /Users/acotten/.nix-profile/share/zsh/5.9/functions /Users/acotten/.nix-profile/share/zsh/vendor-completions /etc/profiles/per-user/acotten/share/zsh/site-functions /etc/profiles/per-user/acotten/share/zsh/5.9/functions /etc/profiles/per-user/acotten/share/zsh/vendor-completions /run/current-system/sw/share/zsh/site-functions /run/current-system/sw/share/zsh/5.9/functions /run/current-system/sw/share/zsh/vendor-completions /nix/var/nix/profiles/default/share/zsh/site-functions /nix/var/nix/profiles/default/share/zsh/5.9/functions /nix/var/nix/profiles/default/share/zsh/vendor-completions /nix/store/fq0zsssivzwkm4cj05wp8imm386l9gx8-zsh-5.9/share/zsh/5.9/functions
$ zsh -il
$ echo $fpath
/opt/homebrew/share/zsh/site-functions /nix/store/fq0zsssivzwkm4cj05wp8imm386l9gx8-zsh-5.9/share/zsh/5.9/functions
```

After, `fpath` is properly re-populated with Nix's entries:
```console
$ echo $fpath
/opt/homebrew/share/zsh/site-functions /Users/acotten/.nix-profile/share/zsh/site-functions /Users/acotten/.nix-profile/share/zsh/5.9/functions /Users/acotten/.nix-profile/share/zsh/vendor-completions /etc/profiles/per-user/acotten/share/zsh/site-functions /etc/profiles/per-user/acotten/share/zsh/5.9/functions /etc/profiles/per-user/acotten/share/zsh/vendor-completions /run/current-system/sw/share/zsh/site-functions /run/current-system/sw/share/zsh/5.9/functions /run/current-system/sw/share/zsh/vendor-completions /nix/var/nix/profiles/default/share/zsh/site-functions /nix/var/nix/profiles/default/share/zsh/5.9/functions /nix/var/nix/profiles/default/share/zsh/vendor-completions /nix/store/fq0zsssivzwkm4cj05wp8imm386l9gx8-zsh-5.9/share/zsh/5.9/functions
$ zsh -il
$ echo $fpath
/opt/homebrew/share/zsh/site-functions /Users/acotten/.nix-profile/share/zsh/site-functions /Users/acotten/.nix-profile/share/zsh/5.9/functions /Users/acotten/.nix-profile/share/zsh/vendor-completions /etc/profiles/per-user/acotten/share/zsh/site-functions /etc/profiles/per-user/acotten/share/zsh/5.9/functions /etc/profiles/per-user/acotten/share/zsh/vendor-completions /run/current-system/sw/share/zsh/site-functions /run/current-system/sw/share/zsh/5.9/functions /run/current-system/sw/share/zsh/vendor-completions /nix/var/nix/profiles/default/share/zsh/site-functions /nix/var/nix/profiles/default/share/zsh/5.9/functions /nix/var/nix/profiles/default/share/zsh/vendor-completions /nix/store/fq0zsssivzwkm4cj05wp8imm386l9gx8-zsh-5.9/share/zsh/5.9/functions
```