### PR TITLE
Remove nix-shell early return in /etc/{zshenv,bashrc}

### DIFF
--- a/modules/programs/bash/default.nix
+++ b/modules/programs/bash/default.nix
@@ -55,9 +55,6 @@ in
       if [ -n "$__ETC_BASHRC_SOURCED" -o -n "$NOSYSBASHRC" ]; then return; fi
       __ETC_BASHRC_SOURCED=1
 
-      # Don't execute this file when running in a pure nix-shell.
-      if [ "$IN_NIX_SHELL" = "pure" ]; then return; fi
-
       if [ -z "$__NIX_DARWIN_SET_ENVIRONMENT_DONE" ]; then
         . ${config.system.build.setEnvironment}
       fi

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -127,9 +127,6 @@ in
       if [ -n "''${__ETC_ZSHENV_SOURCED-}" ]; then return; fi
       __ETC_ZSHENV_SOURCED=1
 
-      # Don't execute this file when running in a pure nix-shell.
-      if test -n "$IN_NIX_SHELL"; then return; fi
-
       if [ -z "''${__NIX_DARWIN_SET_ENVIRONMENT_DONE-}" ]; then
         . ${config.system.build.setEnvironment}
       fi

--- a/tests/programs-zsh.nix
+++ b/tests/programs-zsh.nix
@@ -22,8 +22,6 @@
 
      echo >&2 "checking setEnvironment in /etc/zshenv"
      fgrep '. ${config.system.build.setEnvironment}' ${config.out}/etc/zshenv
-     echo >&2 "checking nix-shell return /etc/zshenv"
-     grep 'if test -n "$IN_NIX_SHELL"; then return; fi' ${config.out}/etc/zshenv
      echo >&2 "checking zshenv.d in /etc/zshenv"
      grep 'source /etc/zshenv.d/\*.conf' ${config.out}/etc/zshenv
 


### PR DESCRIPTION
The condition does not match the comment, and therefore not the original intention. It currently returns early in *any* type of Nix shell, not just pure ones, including 'nix develop'.

Besides being unnecessary, this check prevents Nix shells from functioning properly. For instance, it causes the initialization of the Zsh fpath to be skipped, which is critical. The fact that the user is unable to opt out of this behaviour makes this an ever bigger problem since /etc/zshenv is being loaded unconditionally by Zsh.

For reference, NixOS does not perform such check, and apparently never did based on my inspection of the [commit history](https://github.com/NixOS/nixpkgs/commits/nixos-24.05/nixos/modules/programs/zsh/zsh.nix).

For a history, see the following commits (without comment or context unfortunately):
- 71f25cba9d530e3e7f58bd4698b8595dc1373927
- 94fddd38afe7312d1409e901b927230a7d3a2199