### PR TITLE
version: make `system.stateVersion` mandatory

### DIFF
--- a/modules/system/version.nix
+++ b/modules/system/version.nix
@@ -5,8 +5,6 @@ with lib;
 let
   cfg = config.system;
 
-  defaultStateVersion = options.system.stateVersion.default;
-
   # Based on `lib.trivial.revisionWithDefault` from nixpkgs.
   gitRevision = path:
     if pathIsGitRepo "${path}/.git"
@@ -34,8 +32,9 @@ in
 {
   options = {
     system.stateVersion = mkOption {
-      type = types.int;
-      default = 5;
+      type = types.ints.between 1 config.system.maxStateVersion;
+      # TODO: Remove this default and the assertion below.
+      default = config.system.maxStateVersion;
       description = ''
         Every once in a while, a new NixOS release may change
         configuration defaults in a way incompatible with stateful
@@ -47,6 +46,12 @@ in
         defaults corresponding to the specified release (such as using
         an older version of PostgreSQL).
       '';
+    };
+
+    system.maxStateVersion = mkOption {
+      internal = true;
+      type = types.int;
+      default = 5;
     };
 
     system.darwinLabel = mkOption {
@@ -121,9 +126,22 @@ in
     # documentation is not reprocessed on every commit
     system.darwinLabel = mkDefault "${cfg.nixpkgsVersion}+${cfg.darwinVersion}";
 
-    assertions = [ {
-      assertion = cfg.stateVersion <= defaultStateVersion;
-      message = "system.stateVersion = ${toString cfg.stateVersion}; is not a valid value";
-    } ];
+    assertions = [
+      {
+        assertion = options.system.stateVersion.highestPrio != (lib.mkOptionDefault { }).priority;
+        message = ''
+          The `system.stateVersion` option is not defined in your
+          nix-darwin configuration. The value is used to conditionalize
+          backwards‐incompatible changes in default settings. You should
+          usually set this once when installing nix-darwin on a new system
+          and then never change it (at least without reading all the relevant
+          entries in the changelog using `darwin-rebuild changelog`).
+
+          You can use the current value for new installations as follows:
+
+              system.stateVersion = ${toString config.system.maxStateVersion};
+        '';
+      }
+    ];
   };
 }

--- a/release.nix
+++ b/release.nix
@@ -40,6 +40,8 @@ let
           };
 
           config = {
+            system.stateVersion = lib.mkDefault config.system.maxStateVersion;
+
             system.build.run-test = pkgs.runCommand "darwin-test-${testName}"
               { allowSubstitutes = false; preferLocalBuild = true; }
               ''
@@ -71,6 +73,10 @@ let
       nano emacs vim;
   };
 
+  manual = buildFromConfig ({ lib, config, ... }: {
+    system.stateVersion = lib.mkDefault config.system.maxStateVersion;
+  }) (config: config.system.build.manual);
+
   jobs = {
 
     unstable = pkgs.releaseTools.aggregate {
@@ -92,9 +98,9 @@ let
       meta.description = "Release-critical builds for the darwin channel";
     };
 
-    manualHTML = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manualHTML);
-    manpages = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manpages);
-    options = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.optionsJSON);
+    manualHTML = manual.manualHTML;
+    manpages = manual.manpages;
+    options = manual.optionsJSON;
 
     examples.hydra = makeSystem ./modules/examples/hydra.nix;
     examples.lnl = makeSystem ./modules/examples/lnl.nix;


### PR DESCRIPTION
When testing the Sequoia UID change, I discovered that @mjm didn’t have `system.stateVersion` set; I suspect this is not too uncommon. Let’s make it required now, like NixOS is trying to, to improve our backwards‐compatibility story in anticipation of starting to cut release branches.