### PR TITLE
feat: add dock item property overrides

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -200,17 +200,32 @@ in
     };
 
     system.defaults.dock.persistent-others = mkOption {
-      type = types.nullOr (types.listOf (types.either types.path types.str));
+      type = types.nullOr (types.listOf (types.oneOf [ types.path types.str types.attrs ]));
       default = null;
-      example = [ "/Users/my_user_name/Documents" "/Users/my_user_name/Downloads" ];
+      example = [
+        "/Users/my_user_name/Documents"
+        { name = "/Users/my_user_name/Downloads"; tile-data = { arrangement = 2; showas = 1; }; }
+      ];
       description = ''
         Persistent folders in the dock.
         Note: tilde(`~`) does not get reliably expanded.
       '';
       apply = value:
-        if !(isList value)
-        then value
-        else map (folder: { tile-data = { file-data = { _CFURLString = "file://" + folder; _CFURLStringType = 15; }; }; tile-type = if strings.hasInfix "." (last (splitString "/" folder)) then "file-tile" else "directory-tile"; }) value;
+        if !(isList value) then value else
+        let
+          pathToConfig = (path: {
+            tile-data = { file-data = { _CFURLString = "file://" + path; _CFURLStringType = 15; }; };
+            tile-type = if strings.hasInfix "." (last (splitString "/" path)) then "file-tile" else "directory-tile";
+          });
+        in
+        map
+          (folder:
+            if (isString folder)
+            then pathToConfig folder
+            else
+              (lib.recursiveUpdate (builtins.removeAttrs folder [ "name" ])
+                (pathToConfig folder.name)))
+          value;
     };
 
     system.defaults.dock.scroll-to-open = mkOption {


### PR DESCRIPTION
#### feat: add dock item property overrides <sup>e8be494</sup>
This allows configuring things like "Sort by", "Display as" and "View
content as" by mirroring the exact value observed on a `defaults read`.

The existing options and values weren't formalized in the schema as I
have no expectations of stability across OS versions.


#### docs: don't use tildes on dock.persistent-others examples <sup>73a5575</sup>
It no longer works on Sonoma 14.6.1, leaving a `?` instead of the
desired folder.


#### style: whitespace <sup>31b0fb7</sup>
(nixpkgs-fmt)


Thanks for nix-darwin! ❤️ 