### PR TITLE
flake: match NixOS definition of `nixpkgs.flake.source`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
             }
             ++ [ ({ lib, ... }: {
               nixpkgs.source = lib.mkDefault nixpkgs;
-              nixpkgs.flake.source = lib.mkDefault nixpkgs;
+              nixpkgs.flake.source = lib.mkDefault nixpkgs.outPath;
 
               system.checks.verifyNixPath = lib.mkDefault false;
 


### PR DESCRIPTION
Closes: #1082