### PR TITLE
launchd: only support setting `command` to a list

### DIFF
--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -68,7 +68,7 @@
   # security.sandbox.profiles.fetch-nixpkgs-updates.writablePaths = [ (toString ~/Code/nixos/nixpkgs) ];
 
   # launchd.user.agents.fetch-nixpkgs-updates = {
-  #   command = "/usr/bin/sandbox-exec -f ${config.security.sandbox.profiles.fetch-nixpkgs-updates.profile} ${pkgs.git}/bin/git -C ${toString ~/Code/nixos/nixpkgs} fetch origin master";
+  #   command = [ "/usr/bin/sandbox-exec" "-f" config.security.sandbox.profiles.fetch-nixpkgs-updates.profile (lib.getExe pkgs.git) "-C" "${toString ~/Code/nixos/nixpkgs}" "fetch" "origin" "master" ];
   #   environment.HOME = "";
   #   environment.NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   #   serviceConfig.KeepAlive = false;

--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -45,8 +45,9 @@ let
         };
 
         command = mkOption {
-          type = types.either types.str types.path;
-          default = "";
+          type = types.listOf (types.either types.str types.path);
+          default = [ ];
+          apply = escapeShellArgs;
           description = "Command executed as the service's main process.";
         };
 
@@ -55,15 +56,6 @@ let
           default = "";
           description = "Shell commands executed as the service's main process.";
         };
-
-        # preStart = mkOption {
-        #   type = types.lines;
-        #   default = "";
-        #   description = ''
-        #     Shell commands executed before the service's main process
-        #     is started.
-        #   '';
-        # };
 
         serviceConfig = mkOption {
           type = types.submodule launchdConfig;
@@ -80,11 +72,11 @@ let
       };
 
       config = {
-        command = mkIf (config.script != "") (pkgs.writeScript "${name}-start" ''
+        command = mkIf (config.script != "") [ (pkgs.writeScript "${name}-start" ''
           #! ${stdenv.shell}
 
           ${config.script}
-        '');
+        '') ];
 
         serviceConfig.Label = mkDefault "${cfg.labelPrefix}.${name}";
         serviceConfig.ProgramArguments = mkIf (config.command != "") [

--- a/modules/services/autossh.nix
+++ b/modules/services/autossh.nix
@@ -40,8 +40,9 @@ in
               '';
             };
             extraArguments = mkOption {
-              type = types.str;
-              example = "-N -D4343 bill@socks.example.net";
+              type = types.listOf types.str;
+              default = [ ];
+              example = [ "-N" "-D4343" "bill@socks.example.net" ];
               description = ''
                 Arguments to be passed to AutoSSH and retransmitted to SSH
                 process. Some meaningful options include -N (don't run remote
@@ -91,7 +92,7 @@ in
               # How often AutoSSH checks the network, in seconds
               environment.AUTOSSH_POLL="30";
 
-              command = "${pkgs.autossh}/bin/autossh -M ${toString mport} ${s.extraArguments}";
+              command = [ (lib.getExe pkgs.autossh) "-M" "${toString mport}" ] ++ s.extraArguments;
 
               serviceConfig = {
                   KeepAlive = true;

--- a/modules/services/karabiner-elements/default.nix
+++ b/modules/services/karabiner-elements/default.nix
@@ -70,7 +70,7 @@ in
     };
 
     launchd.daemons.Karabiner-DriverKit-VirtualHIDDeviceClient = {
-      command = "\"${pkgs.karabiner-elements.driver}/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-DriverKit-VirtualHIDDeviceClient.app/Contents/MacOS/Karabiner-DriverKit-VirtualHIDDeviceClient\"";
+      command = [ "${pkgs.karabiner-elements.driver}/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-DriverKit-VirtualHIDDeviceClient.app/Contents/MacOS/Karabiner-DriverKit-VirtualHIDDeviceClient" ];
       serviceConfig.ProcessType = "Interactive";
       serviceConfig.Label = "org.pqrs.Karabiner-DriverKit-VirtualHIDDeviceClient";
       serviceConfig.KeepAlive = true;

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -13,7 +13,7 @@ in
         default = false;
         description = "Whether to enable the lorri service.";
       };
-      
+
       logFile = mkOption {
         type = types.nullOr types.path;
         default = null;
@@ -31,7 +31,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.lorri ];
     launchd.user.agents.lorri = {
-      command = with pkgs; "${lorri}/bin/lorri daemon";
+      command = [ (lib.getExe pkgs.lorri) "daemon" ];
       path = with pkgs; [ config.nix.package git gnutar gzip ];
       serviceConfig = {
         KeepAlive = true;

--- a/modules/services/mail/offlineimap.nix
+++ b/modules/services/mail/offlineimap.nix
@@ -50,7 +50,7 @@ in {
     environment.etc."offlineimaprc".text = cfg.extraConfig;
     launchd.user.agents.offlineimap = {
       path                            = [ cfg.package ];
-      command                         = "${cfg.package}/bin/offlineimap -c /etc/offlineimaprc" + optionalString (cfg.runQuick) " -q";
+      command                         = [ (lib.getExe cfg.package) "-c" "/etc/offlineimaprc" ] ++ optional cfg.runQuick "-q";
       serviceConfig.KeepAlive         = false;
       serviceConfig.RunAtLoad         = true;
       serviceConfig.StartInterval     = cfg.startInterval;

--- a/modules/services/nix-daemon.nix
+++ b/modules/services/nix-daemon.nix
@@ -44,7 +44,7 @@ in
     nix.useDaemon = true;
 
     launchd.daemons.nix-daemon = {
-      command = lib.getExe' config.nix.package "nix-daemon";
+      command = [ (lib.getExe' config.nix.package "nix-daemon") ];
       serviceConfig.ProcessType = config.nix.daemonProcessType;
       serviceConfig.LowPriorityIO = config.nix.daemonIOLowPriority;
       serviceConfig.Label = "org.nixos.nix-daemon"; # must match daemon installed by Nix regardless of the launchd label Prefix

--- a/modules/services/nix-gc/default.nix
+++ b/modules/services/nix-gc/default.nix
@@ -46,9 +46,9 @@ in
       };
 
       options = mkOption {
-        default = "";
-        example = "--max-freed $((64 * 1024**3))";
-        type = types.str;
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "--max-freed" "$((64 * 1024**3))" ];
         description = ''
           Options given to {file}`nix-collect-garbage` when the
           garbage collector is run automatically.
@@ -65,7 +65,7 @@ in
   config = mkIf cfg.automatic {
 
     launchd.daemons.nix-gc = {
-      command = "${config.nix.package}/bin/nix-collect-garbage ${cfg.options}";
+      command = [ (lib.getExe' config.nix.package "nix-collect-garbage") ] ++ cfg.options;
       environment.NIX_REMOTE = optionalString config.nix.useDaemon "daemon";
       serviceConfig.RunAtLoad = false;
       serviceConfig.StartCalendarInterval = cfg.interval;

--- a/modules/services/nix-optimise/default.nix
+++ b/modules/services/nix-optimise/default.nix
@@ -62,7 +62,7 @@ in
 
     launchd.daemons.nix-optimise = {
       environment.NIX_REMOTE = optionalString config.nix.useDaemon "daemon";
-      command = "${lib.getExe' config.nix.package "nix-store"} --optimise";
+      command = [ (lib.getExe' config.nix.package "nix-store") "--optimise" ];
       serviceConfig = {
         RunAtLoad = false;
         StartCalendarInterval = cfg.interval;

--- a/modules/services/privoxy/default.nix
+++ b/modules/services/privoxy/default.nix
@@ -57,9 +57,7 @@ in
 
     launchd.user.agents.privoxy = {
       path = [ config.environment.systemPath ];
-      command = ''
-      ${cfg.package}/bin/privoxy /etc/privoxy-config
-      '';
+      command = [ (lib.getExe cfg.package) "/etc/privoxy-config" ];
       serviceConfig.KeepAlive = true;
     };
   };

--- a/modules/services/redis/default.nix
+++ b/modules/services/redis/default.nix
@@ -65,7 +65,7 @@ in
     environment.systemPackages = [ cfg.package ];
 
     launchd.user.agents.redis = {
-      command = "${cfg.package}/bin/redis-server /etc/redis.conf";
+      command = [ (lib.getExe' cfg.package "redis-server") "/etc/redis.conf" ];
       serviceConfig.KeepAlive = true;
     };
 

--- a/modules/services/synapse-bt.nix
+++ b/modules/services/synapse-bt.nix
@@ -63,7 +63,7 @@ in
 
     launchd.user.agents.synapse-bt =
       { path = [ cfg.package ];
-        command = "${cfg.package}/bin/synapse --config ${configFile}";
+        command = [ (lib.getExe' cfg.package "synapse") "--config" configFile ];
         serviceConfig.KeepAlive = true;
         serviceConfig.RunAtLoad = true;
       };

--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -54,7 +54,7 @@ in
     launchd.daemons.tailscaled = {
       # derived from
       # https://github.com/tailscale/tailscale/blob/main/cmd/tailscaled/install_darwin.go#L30
-      command = lib.getExe' cfg.package "tailscaled";
+      command = [ (lib.getExe' cfg.package "tailscaled") ];
       serviceConfig = {
         Label = "com.tailscale.tailscaled";
         RunAtLoad = true;

--- a/tests/autossh.nix
+++ b/tests/autossh.nix
@@ -1,19 +1,19 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.autossh.sessions = [
     {
       name = "foo";
       user = "jfelice";
-      extraArguments = "-i /some/key -T -N bar.eraserhead.net";
+      extraArguments = [ "-i" "/some/key" "-T" "-N" "bar.eraserhead.net" ];
     }
   ];
 
   test = ''
     plist=${config.out}/Library/LaunchDaemons/org.nixos.autossh-foo.plist
     test -f $plist
-    grep '<string>/bin/wait4path /nix/store &amp;&amp; exec /nix/store/.*/bin/autossh ' $plist
-    grep '<string>/bin/wait4path /nix/store &amp;&amp; exec.*-i /some/key ' $plist
+    grep '<string>.* /nix/store/.*/bin/autossh ' $plist
+    grep '<string>.* -i /some/key ' $plist
     tr -d '\n\t ' <$plist |grep '<key>KeepAlive</key><true */>'
   '';
 }

--- a/tests/launchd-daemons.nix
+++ b/tests/launchd-daemons.nix
@@ -1,9 +1,9 @@
 { config, pkgs, ... }:
 
 {
-  launchd.daemons.foo.command = "foo";
-  launchd.agents.bar.command = "bar";
-  launchd.user.agents.baz.command = "baz";
+  launchd.daemons.foo.command = [ "foo" ];
+  launchd.agents.bar.command = [ "bar" ];
+  launchd.user.agents.baz.command = [ "baz" ];
 
   test = ''
     echo "checking launchd load in /activate" >&2

--- a/tests/services-nix-gc.nix
+++ b/tests/services-nix-gc.nix
@@ -6,14 +6,14 @@ in
 
 {
   nix.gc.automatic = true;
-  nix.gc.options = "--delete-older-than 30d";
+  nix.gc.options = [ "--delete-older-than" "30d" ];
   nix.gc.user = "nixuser";
   nix.package = nix;
 
   test = ''
     echo checking nix-gc service in /Library/LaunchDaemons >&2
     grep "<string>org.nixos.nix-gc</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
-    grep "<string>/bin/wait4path /nix/store &amp;&amp; exec ${nix}/bin/nix-collect-garbage --delete-older-than 30d</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
+    grep '<string>.* ${nix}/bin/nix-collect-garbage --delete-older-than 30d</string>' ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
     grep "<key>UserName</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
     grep "<string>nixuser</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-gc.plist
 

--- a/tests/services-nix-optimise.nix
+++ b/tests/services-nix-optimise.nix
@@ -13,7 +13,7 @@ in
     echo checking nix-optimise service in /Library/LaunchDaemons >&2
     grep "<string>org.nixos.nix-optimise</string>" \
       ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist
-    grep "<string>/bin/wait4path /nix/store &amp;&amp; exec ${nix}/bin/nix-store --optimise</string>" \
+    grep "<string>.* ${nix}/bin/nix-store --optimise</string>" \
       ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist
     grep "<key>UserName</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist
     grep "<string>nixuser</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-optimise.plist


### PR DESCRIPTION
@emilazy should I just deprecate setting `command` to a string with a warning?