### PR TITLE
Update nextdns to use `command`

### DIFF
--- a/modules/services/nextdns/default.nix
+++ b/modules/services/nextdns/default.nix
@@ -30,8 +30,7 @@ in {
 
     launchd.daemons.nextdns = {
       path = [ nextdns ];
-      serviceConfig.ProgramArguments =
-        [ "${pkgs.nextdns}/bin/nextdns" "run" ] ++ cfg.arguments;
+      command = concatStringsSep " " (["${pkgs.nextdns}/bin/nextdns run"] ++ cfg.arguments);
       serviceConfig.KeepAlive = true;
       serviceConfig.RunAtLoad = true;
     };


### PR DESCRIPTION
Following up on #1052, I updated the nextdns service to use `command` in order for it to wait for the nix store to be available.