### PR TITLE
Adding option for slow-motion-allowed

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -147,6 +147,14 @@ in {
       '';
     };
 
+    system.defaults.dock.slow-motion-allowed = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = lib.mdDoc ''
+        Allow for slow-motion minimize effect while holding Shift key. The default is false.
+      '';
+    };
+
     system.defaults.dock.static-only = mkOption {
       type = types.nullOr types.bool;
       default = null;


### PR DESCRIPTION
This patch was inspired by a recent [Daring Fireball post][l] where I was
reminded about this feature and how it's missing from being able to configure it
in Nix-Darwin.

The command I had run to get this working is outlined in the post & below.

```sh
default write com.apple.dock slow-motion-allowed -bool YES;
```

[l]: https://daringfireball.net/linked/2024/09/28/hidden-pref-to-restore-slow-motion-dock-minimizing-on-macos
