### PR TITLE
jankyborders service option order above or below

### DIFF
--- a/modules/services/jankyborders/default.nix
+++ b/modules/services/jankyborders/default.nix
@@ -80,6 +80,15 @@ in {
       '';
     };
 
+    order = mkOption {
+      type = types.str;
+      default = "below";
+      example = "above";
+      description = ''
+        Specifies whether borders should be drawn above or below windows.
+      '';
+    };
+
     blur_radius = mkOption {
       type = types.float;
       default = 0.0;
@@ -149,7 +158,8 @@ in {
           else "off"
         ))
         ++ (optionalArg "blacklist" (joinStrings cfg.blacklist))
-        ++ (optionalArg "whitelist" (joinStrings cfg.whitelist));
+        ++ (optionalArg "whitelist" (joinStrings cfg.whitelist))
+        ++ (optionalArg "order" cfg.order);
       serviceConfig.KeepAlive = true;
       serviceConfig.RunAtLoad = true;
     };

--- a/modules/services/jankyborders/default.nix
+++ b/modules/services/jankyborders/default.nix
@@ -81,7 +81,7 @@ in {
     };
 
     order = mkOption {
-      type = types.str;
+      type = types.enum [ "above" "below" ];
       default = "below";
       example = "above";
       description = ''

--- a/tests/services-jankyborders.nix
+++ b/tests/services-jankyborders.nix
@@ -12,8 +12,7 @@ in
   services.jankyborders.width = 5.0;
   services.jankyborders.hidpi = true;
   services.jankyborders.active_color = "0xFFFFFFFF";
-
-
+  services.jankyborders.order = "below";
 
   test = ''
     echo >&2 "checking jankyborders service in ~/Library/LaunchAgents"
@@ -24,6 +23,6 @@ in
     grep "width=5.000000" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
     grep "hidpi=on" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
     grep "active_color=0xFFFFFFFF" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
-
+    grep "order=below" ${config.out}/user/Library/LaunchAgents/org.nixos.jankyborders.plist
   '';
 }


### PR DESCRIPTION
Adds undocumented JankyBorders option `order` which can be set to `above` or `below`. Defaults to `below` because it causes issues for some users (hence the reason for not being documented). Helpful for covering the window frame on macos.