### PR TITLE
fix: remove deprecated lib.mdDoc

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -176,7 +176,7 @@ in {
     system.defaults.dock.slow-motion-allowed = mkOption {
       type = types.nullOr types.bool;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Allow for slow-motion minimize effect while holding Shift key. The default is false.
       '';
     };


### PR DESCRIPTION
Fixes trace warning introduced by https://github.com/LnL7/nix-darwin/pull/1094

> trace: evaluation warning: lib.mdDoc will be removed from nixpkgs in 24.11. Option descriptions are now in Markdown by default; you can remove any remaining uses of lib.mdDoc

