### PR TITLE
add FlashDateSeparators for time separator config

### DIFF
--- a/modules/system/defaults/clock.nix
+++ b/modules/system/defaults/clock.nix
@@ -65,5 +65,13 @@ with lib;
       '';
     };
 
+    system.defaults.menuExtraClock.FlashDateSeparators = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When enabled, the time separators will flash on and off each second.
+      '';
+    };
+
   };
 }


### PR DESCRIPTION
This adds the option to flash the time separators. Found the details around it here https://macos-defaults.com/menubar/flashdateseparators.html#set-to-false-default-value and was able to get it working in my config under:

```
CustomUserPreferences = {
  "com.apple.menuextra.clock" = {
    FlashDateSeparators = true;
  };
};
```

With this change you should now be able to do:

```
menuExtraClock = {
  FlashDateSeparators = true;
};
```