### PR TITLE
ci: don't run tests twice for PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: "Test"
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 env:
   CURRENT_STABLE_CHANNEL: nixpkgs-24.05-darwin


### PR DESCRIPTION
By only triggering on pushes to `master`, when users push to non-`master` branches on forks, this workflow won't get triggered and will only get triggered when users make a PR to the main repo.