### PR TITLE
darwin-rebuild: Align usage description with implementation

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -9,11 +9,15 @@ showSyntax() {
   echo "               [--list-generations] [{--profile-name | -p} name] [--rollback]" >&2
   echo "               [{--switch-generation | -G} generation] [--verbose...] [-v...]" >&2
   echo "               [-Q] [{--max-jobs | -j} number] [--cores number] [--dry-run]" >&2
-  echo "               [--keep-going] [-k] [--keep-failed] [-K] [--fallback] [--show-trace]" >&2
-  echo "               [-I path] [--option name value] [--arg name value] [--argstr name value]" >&2
-  echo "               [--flake flake] [--no-flake] [--update-input input flake] [--impure]" >&2
-  echo "               [--recreate-lock-file] [--no-update-lock-file] [--refresh]" >&2
-  echo "               [--offline] [--substituters substituters-list] ..." >&2
+  echo "               [--keep-going | -k] [--keep-failed | -K] [--fallback] [--show-trace]" >&2
+  echo "               [--print-build-logs | -L] [--impure] [-I path]" >&2
+  echo "               [--option name value] [--arg name value] [--argstr name value]" >&2
+  echo "               [--no-flake | [--flake flake]" >&2
+  echo "                             [--commit-lock-file] [--recreate-lock-file]" >&2
+  echo "                             [--no-update-lock-file] [--no-write-lock-file]" >&2
+  echo "                             [--override-input input flake] [--update-input input]" >&2
+  echo "                             [--no-registries] [--offline] [--refresh]]" >&2
+  echo "               [--substituters substituters-list] ..." >&2
   exit 1
 }
 


### PR DESCRIPTION
This change updates the usage description of `darwin-rebuild.sh` as follows:

 * Add options:

     * `--print-build-logs` / `-L`
     * `--no-registries`
     * `--commit-lock-file`
     * `--no-write-lock-file`
    * ` --override-input`

 * Specify that `--no-flake` and the flake related options are mutually exclusive.

 * Specify that `--keep-going` and `-k` are aliases.

 * Specify that `--keep-failed` and `-K` are aliases.

 * Correct the description of `--update-input`; only one value follows.

The `--no-build-hook` argument remains undocumented, like for `nix`.