### PR TITLE
users: prevent deleting the user calling `darwin-rebuild`

### DIFF
--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -166,8 +166,8 @@ in
 
         if [[ "$fullDiskAccess" != true ]]; then
           printf >&2 '\e[1;31merror: users cannot be deleted without Full Disk Access, aborting activation\e[0m\n'
-          printf >&2 'The user %s could not be deleted as `darwin-rebuild` was not executed with Full Disk Access.' "$1"
-
+          printf >&2 'The user %s could not be deleted as `darwin-rebuild` was not executed with Full Disk Access.\n' "$1"
+          printf >&2 '\n'
           printf >&2 'Opening "Privacy & Security" > "Full Disk Access" in System Settings\n'
           printf >&2 '\n'
           # This command will fail if run as root and System Settings is already running

--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -189,8 +189,10 @@ in
 
         requireFDA "$1" deleted
 
-        sysadminctl -deleteUser "$1" 2> /dev/null
+        dscl . -delete "/Users/$1" 2> /dev/null
 
+        # `dscl . -delete` should exit with a non-zero exit code when there's an error, but we'll leave
+        # this code here just in case and for when we switch to `sysadminctl -deleteUser`
         # We need to check as `sysadminctl -deleteUser` still exits with exit code 0 when there's an error
         if id "$1" &> /dev/null; then
           printf >&2 '\e[1;31merror: failed to delete user %s, aborting activation\e[0m\n', "$1"


### PR DESCRIPTION
`sysadminctl -deleteUser` will only prevent you from deleting the current user if it's not the last admin and not the last secure token user, otherwise it will happily oblige.