### PR TITLE
Add keepalive flag for emacs service

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -44,9 +44,11 @@ in {
 
     launchd.user.agents.emacs = {
       path = cfg.additionalPath ++ [ config.environment.systemPath ];
-      serviceConfig.ProgramArguments =
-        [ "${cfg.package}/bin/${cfg.exec}" "--fg-daemon" ];
-      serviceConfig.RunAtLoad = true;
+      serviceConfig = {
+        ProgramArguments = [ "${cfg.package}/bin/${cfg.exec}" "--fg-daemon" ];
+        RunAtLoad = true;
+        KeepAlive = true;
+      };
     };
 
   };


### PR DESCRIPTION
Otherwise, the service will never recover after the daemon dies for any reason.