### PR TITLE
module: add prometheus-node-exporter service

### DIFF
--- a/modules/misc/ids.nix
+++ b/modules/misc/ids.nix
@@ -38,10 +38,12 @@ in
 
     ids.uids = {
       nixbld = lib.mkDefault 350;
+      _prometheus-node-exporter = 534;
     };
 
     ids.gids = {
       nixbld = lib.mkDefault (if config.system.stateVersion < 5 then 30000 else 350);
+      _prometheus-node-exporter = 534;
     };
 
   };

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -74,6 +74,7 @@
   ./services/mopidy.nix
   ./services/monitoring/telegraf.nix
   ./services/monitoring/netdata.nix
+  ./services/monitoring/prometheus-node-exporter.nix
   ./services/netbird.nix
   ./services/nix-daemon.nix
   ./services/nix-gc

--- a/modules/services/monitoring/prometheus-node-exporter.nix
+++ b/modules/services/monitoring/prometheus-node-exporter.nix
@@ -1,0 +1,117 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatStringsSep
+    escapeShellArgs
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    mkRemovedOptionModule
+    types
+  ;
+
+  cfg = config.services.prometheus.exporters.node;
+in {
+  imports = [
+    (mkRemovedOptionModule [ "services" "prometheus" "exporters" "node" "openFirewall" ] "No nix-darwin equivalent to this NixOS option.")
+    (mkRemovedOptionModule [ "services" "prometheus" "exporters" "node" "firewallFilter" ] "No nix-darwin equivalent to this NixOS option.")
+    (mkRemovedOptionModule [ "services" "prometheus" "exporters" "node" "firewallRules" ] "No nix-darwin equivalent to this NixOS option.")
+  ];
+
+  options = {
+    services.prometheus.exporters.node = {
+      enable = mkEnableOption "Prometheus Node exporter";
+
+      package = mkPackageOption pkgs "prometheus-node-exporter" { };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "";
+        example = "0.0.0.0";
+        description = ''
+          Address where Node exporter exposes its HTTP interface. Leave empty to bind to all addresses.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 9100;
+        description = ''
+          Port where the Node exporter exposes its HTTP interface.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "--log.level=debug" ];
+        description = ''
+          Extra commandline options to pass to the Node exporter executable.
+        '';
+      };
+
+      enabledCollectors = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Collectors to enable in addition to the ones that are [enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default).
+        '';
+      };
+
+      disabledCollectors = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "boottime" ];
+        description = ''
+          Collectors to disable from the list of collectors that are [enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default).
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users._prometheus-node-exporter = {
+      uid = config.ids.uids._prometheus-node-exporter;
+      gid = config.ids.gids._prometheus-node-exporter;
+      home = "/var/empty";
+      shell = "/usr/bin/false";
+      description = "System user for the Prometheus Node exporter";
+    };
+
+    users.groups._prometheus-node-exporter = {
+      gid = config.ids.gids._prometheus-node-exporter;
+      description = "System group for the Prometheus Node exporter";
+    };
+
+    users.knownGroups = [ "_prometheus-node-exporter" ];
+    users.knownUsers = [ "_prometheus-node-exporter" ];
+
+    launchd.daemons.prometheus-node-exporter = {
+      script = concatStringsSep " "
+        ([
+          (getExe cfg.package)
+          "--web.listen-address"
+          "${cfg.listenAddress}:${toString cfg.port}"
+        ]
+        ++ (map (collector: "--collector.${collector}") cfg.enabledCollectors)
+        ++ (map (collector: "--no-collector.${collector}") cfg.disabledCollectors)
+      ) + escapeShellArgs cfg.extraFlags;
+      serviceConfig = {
+        KeepAlive = true;
+        RunAtLoad = true;
+        StandardErrorPath = "/var/log/prometheus-node-exporter.log";
+        StandardOutPath = "/var/log/prometheus-node-exporter.log";
+        GroupName = "_prometheus-node-exporter";
+        UserName = "_prometheus-node-exporter";
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR adds a module for the Prometheus Node Exporter, which I want to use in the nixos.org infra.

I will test this shortly, but it is probably good enough for a review.

Options are similar to [NixOS](https://search.nixos.org/options?channel=24.05&show=services.prometheus.exporters.node.extraFlags&from=0&size=50&sort=relevance&type=packages&query=exporters.node), but I chose a different namespace, since what NixOS has is probably overkill.