### PR TITLE
Allow configuring the fn key action

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -21,6 +21,7 @@
   ./system/defaults/clock.nix
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
+  ./system/defaults/hitoolbox.nix
   ./system/defaults/screencapture.nix
   ./system/defaults/screensaver.nix
   ./system/defaults/alf.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -23,6 +23,7 @@ let
   menuExtraClock = defaultsToList "com.apple.menuextra.clock" cfg.menuExtraClock;
   dock = defaultsToList "com.apple.dock" cfg.dock;
   finder = defaultsToList "com.apple.finder" cfg.finder;
+  hitoolbox = defaultsToList "com.apple.HIToolbox" cfg.hitoolbox;
   magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;
   magicmouseBluetooth = defaultsToList "com.apple.driver.AppleMultitouchMouse.mouse" cfg.magicmouse;
   screencapture = defaultsToList "com.apple.screencapture" cfg.screencapture;
@@ -76,6 +77,7 @@ in
         menuExtraClock
         dock
         finder
+        hitoolbox
         magicmouse
         magicmouseBluetooth
         screencapture
@@ -99,6 +101,7 @@ in
         ${concatStringsSep "\n" menuExtraClock}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
+        ${concatStringsSep "\n" hitoolbox}
         ${concatStringsSep "\n" magicmouse}
         ${concatStringsSep "\n" magicmouseBluetooth}
         ${concatStringsSep "\n" screencapture}

--- a/modules/system/defaults/hitoolbox.nix
+++ b/modules/system/defaults/hitoolbox.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+
+{
+  options = {
+
+    system.defaults.hitoolbox.AppleFnUsageType = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum [
+        "Do Nothing"
+        "Change Input Source"
+        "Show Emoji & Symbols"
+        "Start Dictation"
+      ]);
+      apply = key: if key == null then null else {
+        "Do Nothing" = 0;
+        "Change Input Source" = 1;
+        "Show Emoji & Symbols" = 2;
+        "Start Dictation" = 3;
+      }.${key};
+      default = null;
+      description = ''
+        Chooses what happens when you press the Fn key on the keyboard. A restart is required for
+        this setting to take effect.
+
+        The default is unset ("Show Emoji & Symbols").
+      '';
+    };
+
+  };
+}

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -354,6 +354,11 @@ defaults write com.apple.finder '_FXSortFoldersFirst' $'<?xml version="1.0" enco
 <plist version="1.0">
 <true/>
 </plist>'
+defaults write com.apple.HIToolbox 'AppleFnUsageType' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<integer>2</integer>
+</plist>'
 
 
 defaults write com.apple.screencapture 'location' $'<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -61,6 +61,7 @@
   system.defaults.finder._FXShowPosixPathInTitle = true;
   system.defaults.finder._FXSortFoldersFirst = true;
   system.defaults.finder.FXEnableExtensionChangeWarning = false;
+  system.defaults.hitoolbox.AppleFnUsageType = "Show Emoji & Symbols";
   system.defaults.screencapture.location = "/tmp";
   system.defaults.screensaver.askForPassword = true;
   system.defaults.screensaver.askForPasswordDelay = 5;


### PR DESCRIPTION
See values here: https://macos-defaults.com/keyboard/applefnusagetype.html

Wasn't sure if it made sense to create a file for one option but seemed okay. All com.apple.HIToolbox available options I see are:
```
    "com.apple.HIToolbox" =     {
        AppleCurrentKeyboardLayoutInputSourceID = "com.apple.keylayout.US";
        AppleDictationAutoEnable = 0;
        AppleEnabledInputSources =         (
                        {
                InputSourceKind = "Keyboard Layout";
                "KeyboardLayout ID" = 0;
                "KeyboardLayout Name" = "U.S.";
            },
                        {
                "Bundle ID" = "com.apple.CharacterPaletteIM";
                InputSourceKind = "Non Keyboard Input Method";
            }
        );
        AppleFnUsageType = 2;
        AppleSelectedInputSources =         (
                        {
                InputSourceKind = "Keyboard Layout";
                "KeyboardLayout ID" = 0;
                "KeyboardLayout Name" = "U.S.";
            }
        );
    };
```