### PR TITLE
zsh: enable by default as zsh is the default shell on macOS

### DIFF
--- a/modules/examples/flake/flake.nix
+++ b/modules/examples/flake/flake.nix
@@ -23,8 +23,7 @@
       # Necessary for using flakes on this system.
       nix.settings.experimental-features = "nix-command flakes";
 
-      # Create /etc/zshrc that loads the nix-darwin environment.
-      programs.zsh.enable = true;  # default shell on catalina
+      # Enable alternative shell support in nix-darwin.
       # programs.fish.enable = true;
 
       # Set Git commit hash for darwin-version.

--- a/modules/examples/simple.nix
+++ b/modules/examples/simple.nix
@@ -15,8 +15,7 @@
   # services.nix-daemon.enable = true;
   # nix.package = pkgs.nix;
 
-  # Create /etc/zshrc that loads the nix-darwin environment.
-  programs.zsh.enable = true;  # default shell on catalina
+  # Enable alternative shell support in nix-darwin.
   # programs.fish.enable = true;
 
   # Used for backwards compatibility, please read the changelog before changing.

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -18,7 +18,7 @@ in
   options = {
     programs.zsh.enable = mkOption {
       type = types.bool;
-      default = false;
+      default = true;
       description = "Whether to configure zsh as an interactive shell.";
     };
 


### PR DESCRIPTION
Historically this was a footgun because users would not always have this enabled leading to `darwin-rebuild` and other programs not being found.

See #177, #922 and #1003