### PR TITLE
environment: remove misleading `environment.loginShell` option 

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -18,6 +18,11 @@ in
 {
   imports = [
     (mkRenamedOptionModule ["environment" "postBuild"] ["environment" "extraSetup"])
+    (mkRemovedOptionModule [ "environment" "loginShell" ] ''
+      This option was only used to change the default command in tmux.
+
+      This has been removed in favour of changing the default command or default shell in tmux directly.
+    '')
   ];
 
   options = {
@@ -72,12 +77,6 @@ in
         NOTE: Changing this requires running {command}`darwin-rebuild switch -I darwin-config=/path/to/configuration.nix`
         the first time to make darwin-rebuild aware of the custom location.
       '';
-    };
-
-    environment.loginShell = mkOption {
-      type = types.str;
-      default = "$SHELL -l";
-      description = "Configure default login shell.";
     };
 
     environment.variables = mkOption {

--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -277,7 +277,6 @@
     zle -N up-line-or-beginning-search
   '';
 
-  environment.loginShell = "${pkgs.zsh}/bin/zsh -l";
   environment.variables.SHELL = "${pkgs.zsh}/bin/zsh";
 
   environment.variables.LANG = "en_US.UTF-8";

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -41,6 +41,7 @@ in
 {
   imports = [
     (mkRenamedOptionModule [ "programs" "tmux" "tmuxConfig" ] [ "programs" "tmux" "extraConfig" ])
+    (mkRemovedOptionModule [ "programs" "tmux" "defaultCommand" ] "Use `programs.tmux.extraConfig` to configure the default command instead. If unset, tmux will default to using your system configured login shell.")
   ];
   options = {
     programs.tmux.enable = mkOption {
@@ -84,11 +85,6 @@ in
       description = "Cater to iTerm2 and its tmux integration, as appropriate.";
     };
 
-    programs.tmux.defaultCommand = mkOption {
-      type = types.either types.str types.package;
-      description = "The default command to use for tmux panes.";
-    };
-
     programs.tmux.tmuxOptions = mkOption {
       internal = true;
       type = types.attrsOf (types.submodule text);
@@ -118,12 +114,6 @@ in
       ${cfg.extraConfig}
 
       source-file -q /etc/tmux.conf.local
-    '';
-
-    programs.tmux.defaultCommand = mkDefault config.environment.loginShell;
-
-    programs.tmux.tmuxOptions.login-shell.text = ''
-      set -g default-command "${cfg.defaultCommand}"
     '';
 
     programs.tmux.tmuxOptions.sensible.text = mkIf cfg.enableSensible ''


### PR DESCRIPTION
This is a source of confusion as this option was only used to configure tmux's default command, rather than `users.users.<user>.shell` which is what most people actually wanted which wasn't working very reliably prior to #1120 

I also chose to remove `programs.tmux.defaultCommand` as I suspect that most users want it to default to their login shell and very few need to change it.

Closes #361

See #151, #779 