### PR TITLE
uninstaller: improve

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,9 +66,12 @@ jobs:
         darwin-rebuild switch -I darwin=.
     - name: Test uninstallation of nix-darwin
       run: |
-        export NIX_PATH=$HOME/.nix-defexpr/channels
-        nix-shell -A uninstaller
-        nix-shell -A uninstaller.check
+        nix run .#darwin-uninstaller \
+          --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }} \
+          --extra-experimental-features "nix-command flakes"
+        nix run .#darwin-uninstaller.tests.uninstaller \
+          --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }} \
+          --extra-experimental-features "nix-command flakes"
     - name: Debugging tmate session
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
@@ -111,9 +114,12 @@ jobs:
         darwin-rebuild switch -I darwin=.
     - name: Test uninstallation of nix-darwin
       run: |
-        export NIX_PATH=$HOME/.nix-defexpr/channels
-        nix-shell -A uninstaller
-        nix-shell -A uninstaller.check
+        nix run .#darwin-uninstaller \
+          --override-input nixpkgs nixpkgs/nixpkgs-unstable \
+          --extra-experimental-features "nix-command flakes"
+        nix run .#darwin-uninstaller.tests.uninstaller \
+          --override-input nixpkgs nixpkgs/nixpkgs-unstable \
+          --extra-experimental-features "nix-command flakes"
     - name: Debugging tmate session
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,12 +114,13 @@ jobs:
         darwin-rebuild switch -I darwin=.
     - name: Test uninstallation of nix-darwin
       run: |
+        # A regression in Nix 2.19 means we need to put `--extra-experimental-features` before `--override-input`
         nix run .#darwin-uninstaller \
-          --override-input nixpkgs nixpkgs/nixpkgs-unstable \
-          --extra-experimental-features "nix-command flakes"
+           --extra-experimental-features "nix-command flakes" \
+           --override-input nixpkgs nixpkgs/nixpkgs-unstable
         nix run .#darwin-uninstaller.tests.uninstaller \
-          --override-input nixpkgs nixpkgs/nixpkgs-unstable \
-          --extra-experimental-features "nix-command flakes"
+           --extra-experimental-features "nix-command flakes" \
+           --override-input nixpkgs nixpkgs/nixpkgs-unstable
     - name: Debugging tmate session
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,10 @@ jobs:
       run: |
         . /etc/static/bashrc
         darwin-rebuild build --flake ./modules/examples/flake#simple --override-input nix-darwin . --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
+    - name: Test uninstallation of nix-darwin
+      run: |
+        nix run .#darwin-uninstaller --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
+        nix run .#darwin-uninstaller.tests.uninstaller --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
 
   install-flake-against-unstable:
     runs-on: macos-13
@@ -184,3 +188,7 @@ jobs:
       run: |
         . /etc/static/bashrc
         darwin-rebuild build --flake ./modules/examples/flake#simple --override-input nix-darwin . --override-input nixpkgs nixpkgs/nixpkgs-unstable
+    - name: Test uninstallation of nix-darwin
+      run: |
+        nix run .#darwin-uninstaller --override-input nixpkgs nixpkgs/nixpkgs-unstable
+        nix run .#darwin-uninstaller.tests.uninstaller --override-input nixpkgs nixpkgs/nixpkgs-unstable

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 with lib;
 
@@ -33,18 +33,6 @@ with lib;
             sudo cp /nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist /Library/LaunchDaemons/org.nixos.nix-daemon.plist
             sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist
         fi
-
-        if ! grep -q etc/profile.d/nix-daemon.sh /etc/bashrc; then
-            echo >&2 "Found no nix-daemon.sh reference in /etc/bashrc"
-            echo >&2 "add this snippet back to /etc/bashrc:"
-            echo >&2
-            echo >&2 "    # Nix"
-            echo >&2 "    if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then"
-            echo >&2 "      . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'"
-            echo >&2 "    fi"
-            echo >&2 "    # End Nix"
-            echo >&2
-        fi
     fi
 
     # grep will return 1 when no lines matched which makes this line fail with `set -eo pipefail`
@@ -56,5 +44,9 @@ with lib;
 
       dscl . -create /Users/"$user" UserShell /bin/zsh
     done
+
+    while IFS= read -r -d "" file; do
+      mv "$file" "''${file%.*}"
+    done < <(find /etc -name '*.before-nix-darwin' -follow -print0)
   '';
 }

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -46,5 +46,15 @@ with lib;
             echo >&2
         fi
     fi
+
+    # grep will return 1 when no lines matched which makes this line fail with `set -eo pipefail`
+    dscl . -list /Users UserShell | { grep "\s/run/" || true; } | awk '{print $1}' | while read -r user; do
+      shell=$(dscl . -read /Users/"$user" UserShell)
+      if [[ "$shell" != */bin/zsh ]]; then
+        echo >&2 "warning: changing $user's shell from $shell to /bin/zsh"
+      fi
+
+      dscl . -create /Users/"$user" UserShell /bin/zsh
+    done
   '';
 }

--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -7,31 +7,29 @@ with lib;
   assertions = mkForce [];
   system.activationScripts.checks.text = mkForce "";
 
-  # Disable etc, launchd, ...
   environment.etc = mkForce {};
   launchd.agents = mkForce {};
   launchd.daemons = mkForce {};
   launchd.user.agents = mkForce {};
 
   system.activationScripts.postUserActivation.text = mkAfter ''
-    if test -L ~/.nix-defexpr/channels/darwin; then
+    if [[ -L ~/.nix-defexpr/channels/darwin ]]; then
         nix-channel --remove darwin || true
     fi
   '';
 
   system.activationScripts.postActivation.text = mkAfter ''
-    if test -L /Applications/Nix\ Apps; then
+    if [[ -L /Applications/Nix\ Apps ]]; then
         rm /Applications/Nix\ Apps
     fi
 
-    if test -L /etc/static; then
+    if [[ -L /etc/static ]]; then
         rm /etc/static
     fi
 
-    if test -O /nix/store; then
-        if ! test -e /Library/LaunchDaemons/org.nixos.nix-daemon.plist; then
-            sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist || true
-            sudo launchctl remove org.nixos.nix-daemon 2> /dev/null || true
+    # If the Nix Store is owned by root then we're on a multi-user system
+    if [[ -O /nix/store ]]; then
+        if [[ -e /nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist ]]; then
             sudo cp /nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist /Library/LaunchDaemons/org.nixos.nix-daemon.plist
             sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist
         fi

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -81,12 +81,14 @@ in writeShellApplication {
       test -e /etc/static && exit 1
       echo >&2 "checking /run/current-system"
       test -e /run/current-system && exit 1
-      echo >&2 "checking nix-daemon service (assuming a multi-user install)"
-      sudo launchctl list | grep org.nixos.nix-daemon || echo "FIXME? sudo launchctl list | grep org.nixos.nix-daemon"
-      pgrep -l nix-daemon || echo "FIXME? pgrep -l nix-daemon"
-      readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist || echo "FIXME? readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist"
-      grep /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /Library/LaunchDaemons/org.nixos.nix-daemon.plist || echo "FIXME? grep /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /Library/LaunchDaemons/org.nixos.nix-daemon.plist"
-      echo >&2 ok
+      if [[ $(stat -f '%Su' /nix/store) == "root" ]]; then
+        echo >&2 "checking nix-daemon service"
+        launchctl print system/org.nixos.nix-daemon
+        pgrep -l nix-daemon
+        test -e /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+        [[ "$(shasum -a 256 /Library/LaunchDaemons/org.nixos.nix-daemon.plist | awk '{print $1}')" == "$(shasum -a 256 /Library/LaunchDaemons/org.nixos.nix-daemon.plist | awk '{print $1}')" ]]
+        echo >&2 ok
+      fi
     '';
   };
 }

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, pkgs }:
+{ lib, path, stdenv, writeShellApplication }:
 
 let
   uninstallSystem = import ../../eval-config.nix {
@@ -6,39 +6,23 @@ let
     modules = [
       ./configuration.nix
       {
-        nixpkgs.source = pkgs.path;
-        nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
+        nixpkgs.source = path;
+        nixpkgs.hostPlatform = stdenv.hostPlatform.system;
         system.includeUninstaller = false;
       }
     ];
   };
-in
-
-stdenv.mkDerivation {
+in writeShellApplication {
   name = "darwin-uninstaller";
-  preferLocalBuild = true;
-
-  unpackPhase = ":";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    echo "$shellHook" > $out/bin/darwin-uninstaller
-    chmod +x $out/bin/darwin-uninstaller
-  '';
-
-  shellHook = ''
-    #!${stdenv.shell}
-    set -e
-
-    action=switch
+  text = ''
     while [ "$#" -gt 0 ]; do
-        i="$1"; shift 1
-        case "$i" in
-            --help)
-                echo "darwin-uninstaller: [--help]"
-                exit
-                ;;
-        esac
+      i="$1"; shift 1
+      case "$i" in
+        --help)
+          echo "darwin-uninstaller: [--help]"
+          exit
+          ;;
+      esac
     done
 
     echo >&2
@@ -50,15 +34,15 @@ stdenv.mkDerivation {
     echo >&2 "    - restore daemon service from nix installer (only when this is a multi-user install)"
     echo >&2
 
-    if test -t 0; then
-        read -p "Proceed? [y/n] " i
-        case "$i" in
-            y|Y)
-                ;;
-            *)
-                exit 3
-                ;;
-        esac
+    if [[ -t 0 ]]; then
+      read -r -p "Proceed? [y/n] " i
+      case "$i" in
+        y|Y)
+          ;;
+        *)
+          exit 3
+          ;;
+      esac
     fi
 
     ${uninstallSystem.system}/sw/bin/darwin-rebuild activate
@@ -83,29 +67,26 @@ stdenv.mkDerivation {
     echo >&2
     echo >&2 "Done!"
     echo >&2
-    exit
   '';
 
-  passthru.check = stdenv.mkDerivation {
-     name = "run-darwin-test";
-     shellHook = ''
-        set -e
-        echo >&2 "running uninstaller tests..."
-        echo >&2
+  derivationArgs.passthru.tests.uninstaller = writeShellApplication {
+    name = "post-uninstall-test";
+    text = ''
+      echo >&2 "running uninstaller tests..."
+      echo >&2
 
-        echo >&2 "checking darwin channel"
-        ! test -e ~/.nix-defexpr/channels/darwin
-        echo >&2 "checking /etc"
-        ! test -e /etc/static
-        echo >&2 "checking /run/current-system"
-        ! test -e /run/current-system
-        echo >&2 "checking nix-daemon service (assuming a multi-user install)"
-        sudo launchctl list | grep org.nixos.nix-daemon || echo "FIXME? sudo launchctl list | grep org.nixos.nix-daemon"
-        pgrep -l nix-daemon || echo "FIXME? pgrep -l nix-daemon"
-        readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist || echo "FIXME? readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist"
-        grep /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /Library/LaunchDaemons/org.nixos.nix-daemon.plist || echo "FIXME? grep /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /Library/LaunchDaemons/org.nixos.nix-daemon.plist"
-        echo >&2 ok
-        exit
+      echo >&2 "checking darwin channel"
+      test -e ~/.nix-defexpr/channels/darwin && exit 1
+      echo >&2 "checking /etc"
+      test -e /etc/static && exit 1
+      echo >&2 "checking /run/current-system"
+      test -e /run/current-system && exit 1
+      echo >&2 "checking nix-daemon service (assuming a multi-user install)"
+      sudo launchctl list | grep org.nixos.nix-daemon || echo "FIXME? sudo launchctl list | grep org.nixos.nix-daemon"
+      pgrep -l nix-daemon || echo "FIXME? pgrep -l nix-daemon"
+      readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist || echo "FIXME? readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist"
+      grep /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /Library/LaunchDaemons/org.nixos.nix-daemon.plist || echo "FIXME? grep /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /Library/LaunchDaemons/org.nixos.nix-daemon.plist"
+      echo >&2 ok
     '';
   };
 }

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -63,8 +63,19 @@ stdenv.mkDerivation {
 
     ${uninstallSystem.system}/sw/bin/darwin-rebuild activate
 
-    if test -L /run/current-system; then
+    if [[ -L /run/current-system ]]; then
       sudo rm /run/current-system
+    fi
+
+    if [[ -L /run ]]; then
+      if [[ -e /etc/synthetic.conf ]]; then
+        sudo sed -i -E '/^run[[:space:]]/d' /etc/synthetic.conf
+        sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B &>/dev/null || true
+        sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t &>/dev/null || true
+        echo >&2 "NOTE: the /run symlink will be removed on reboot"
+      else
+        sudo rm /run
+      fi
     fi
 
     echo >&2


### PR DESCRIPTION
Closes #730

- [ ] test this PR
- [ ] add check to ensure `/etc/bashrc`, `/etc/zshrc`, `/etc/shells` got restored correctly
- [ ] add check to ensure no users have shells pointing to `/run/*`
- [ ] run checks to let users know if uninstallation didn't work correctly and direct users to file an issue
- [ ] add check to ensure `run` symlink is no longer getting set up