### PR TITLE
github-runner: Fix labels for different nixpkgs versions

### DIFF
--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -94,6 +94,10 @@ in
 
         script =
           let
+            # https://github.com/NixOS/nixpkgs/pull/333744 introduced an inconsistency with different
+            # versions of nixpkgs. Use the old version of escapeShellArg to make sure that labels
+            # are always escaped to avoid https://www.shellcheck.net/wiki/SC2054
+            escapeShellArgAlways = string: "'${replaceStrings ["'"] ["'\\''"] (toString string)}'";
             configure = pkgs.writeShellApplication {
               name = "configure-github-runner-${name}";
               text = /*bash*/''
@@ -104,7 +108,7 @@ in
                   --disableupdate
                   --work ${escapeShellArg workDir}
                   --url ${escapeShellArg cfg.url}
-                  --labels "${escapeShellArg (concatStringsSep "," cfg.extraLabels)}"
+                  --labels ${escapeShellArgAlways (concatStringsSep "," cfg.extraLabels)}
                   ${optionalString (cfg.name != null ) "--name ${escapeShellArg cfg.name}"}
                   ${optionalString cfg.replace "--replace"}
                   ${optionalString (cfg.runnerGroup != null) "--runnergroup ${escapeShellArg cfg.runnerGroup}"}


### PR DESCRIPTION
Changes to escapeShellArg introduced in https://github.com/NixOS/nixpkgs/pull/333744 made different versions of nixpkgs behave differently. If current nix-darwin is used with nixpkgs before that change, labels end up having labels quoted twice (see https://github.com/LnL7/nix-darwin/issues/1085), but without changes from https://github.com/LnL7/nix-darwin/pull/1055, with new nixpkgs, labels end up not quoted at all, and ShellCheck ends up complaining that commas might have been used as array item separator (see https://www.shellcheck.net/wiki/SC2054).
Use the old version of escapeShellArg to always escape the list of labels and make nix-darwin work with both old and new versions of nixpkgs.

Fixes https://github.com/LnL7/nix-darwin/issues/1085

Cc @Gabriella439

