### PR TITLE
darwin-rebuild: Don't prompt for sudo multiple times

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -225,6 +225,11 @@ fi
 
 if [ "$action" = switch ] || [ "$action" = activate ] || [ "$action" = rollback ]; then
   if [ "$USER" != root ]; then
+    # Running `$systemConfig/activate-user` causes subsequent sudo invocations to prompt
+    # for the password even if we previously ran sudo in the same session; indeed, by this
+    # point we've already run `nix-env --set` as sudo. To avoid prompting a second time,
+    # we become root *before* running activate-user and then drop down to the user to
+    # invoke it. This way, the call to activate doesn't require a password.
     sudo @shell@ -c "su $USER -c $systemConfig/activate-user && $systemConfig/activate"
   else
     "$systemConfig/activate-user"

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -224,11 +224,10 @@ if [ "$action" = switch ]; then
 fi
 
 if [ "$action" = switch ] || [ "$action" = activate ] || [ "$action" = rollback ]; then
-  "$systemConfig/activate-user"
-
   if [ "$USER" != root ]; then
-    sudo "$systemConfig/activate"
+    sudo @shell@ -c "su $USER -c $systemConfig/activate-user && $systemConfig/activate"
   else
+    "$systemConfig/activate-user"
     "$systemConfig/activate"
   fi
 fi


### PR DESCRIPTION
I've found that `darwin-rebuild switch` always asks me for sudo permissions twice — once when it runs `sudo nix-env --set` and the second time when it runs `sudo $systemConfig/activate` — even though I have a reasonable (default) `timestamp_timeout`.

In debugging this, I realized that the call to `brew bundle` within `activate-user` was somehow making it so that the next `sudo` invocation would require a password again. I'm honestly not sure of the root cause behind this strange behavior exhibited by `brew bundle`, but as a workaround I realized that if we 1) elevate privileges, 2) drop down to call `activate-user`, and 3) call `activate` in the elevated context, we don't need to `sudo` again since we're already root.

FWIW I'm open to input here, especially as a new nix-darwin user: is this issue specific to me or is everyone just used to authenticating twice? But Brew Bundle aside, this PR does work around the general issue where arbitrary user scripts in `activate-user` can result in sudo prompting again, so I think this might be worth merging regardless of the root cause.