### PR TITLE
nix: don't allow using `auto-optimise-store` as it can corrupt the store

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -404,7 +404,7 @@ in
           { darwin-config = "${config.environment.darwinConfig}"; }
           "/nix/var/nix/profiles/per-user/root/channels"
         ];
-        
+
         defaultText = lib.literalExpression ''
           lib.optionals cfg.channel.enable [
             # Include default path <darwin-config>.
@@ -527,8 +527,10 @@ in
               description = ''
                 If set to true, Nix automatically detects files in the store that have
                 identical contents, and replaces them with hard links to a single copy.
-                This saves disk space. If set to false (the default), you can still run
-                nix-store --optimise to get rid of duplicate files.
+                This saves disk space. If set to false (the default), you can enable
+                {option}`nix.optimise.automatic` to run {command}`nix-store --optimise`
+                periodically to get rid of duplicate files. You can also run
+                {command}`nix-store --optimise` manually.
               '';
             };
 
@@ -761,6 +763,13 @@ in
         { assertion = elem "nixbld" config.users.knownGroups -> elem "nixbld" createdGroups; message = "refusing to delete group nixbld in users.knownGroups, this would break nix"; }
         { assertion = elem "_nixbld1" config.users.knownGroups -> elem "_nixbld1" createdUsers; message = "refusing to delete user _nixbld1 in users.knownUsers, this would break nix"; }
         { assertion = config.users.groups ? "nixbld" -> config.users.groups.nixbld.members != []; message = "refusing to remove all members from nixbld group, this would break nix"; }
+
+        {
+          # Should be fixed in Lix by https://gerrit.lix.systems/c/lix/+/2100
+          # As `isNixAtLeast "2.92.0" "2.92.0-devpre20241107" == false`, we need to explicitly check if the user is running Lix 2.92.0
+          assertion = cfg.settings.auto-optimise-store -> (cfg.package.pname == "lix" && (isNixAtLeast "2.92.0-devpre20241107" || cfg.package.version == "2.92.0"));
+          message = "`nix.settings.auto-optimise-store` is known to corrupt the Nix Store, please use `nix.optimise.automatic` instead.";
+        }
       ];
 
     # Not in NixOS module


### PR DESCRIPTION
Upstream issue at https://github.com/NixOS/nix/issues/7273

Should be fixed by https://gerrit.lix.systems/c/lix/+/2100

Tested the version check with Nix, Lix `2.91.0` (`pkgs.lixVersions.latest`), Lix `2.92.0-devpre20241106_1ecfff9` (`github:lix-project/lix/1ecfff9c37f64871661d615e407ec3571489eff7`, doesn't include the fix) and Lix `2.92.0-devpre20241107_72cce7b` (`github:lix-project/lix`) which does include the change

Closes #484 