### PR TITLE
zsh: only run shell initialization in /etc/zshenv when RCs are enabled

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -136,16 +136,18 @@ in
       if [ -n "''${__ETC_ZSHENV_SOURCED-}" ]; then return; fi
       __ETC_ZSHENV_SOURCED=1
 
-      if [ -z "''${__NIX_DARWIN_SET_ENVIRONMENT_DONE-}" ]; then
-        . ${config.system.build.setEnvironment}
+      if [[ -o rcs ]]; then
+        if [ -z "''${__NIX_DARWIN_SET_ENVIRONMENT_DONE-}" ]; then
+          . ${config.system.build.setEnvironment}
+        fi
+
+        # Tell zsh how to find installed completions
+        for p in ''${(z)NIX_PROFILES}; do
+          fpath=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions $fpath)
+        done
+
+        ${cfg.shellInit}
       fi
-
-      # Tell zsh how to find installed completions
-      for p in ''${(z)NIX_PROFILES}; do
-        fpath=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions $fpath)
-      done
-
-      ${cfg.shellInit}
 
       # Read system-wide modifications.
       if test -f /etc/zshenv.local; then


### PR DESCRIPTION
## background

As of 470f87c1827b51169ed4f91cdbdfd48417bfff3d, `programs.zsh.enable` defaults to true. This means that `/etc/zshenv` has the normal nix-darwin initialization, including setting `__NIX_DARWIN_SET_ENVIRONMENT_DONE=1`.

***

On a related note, `man zsh` says:
> Commands are first read from /etc/zshenv; this cannot be overridden.

and
> As /etc/zshenv is run for all instances of zsh, it is important that it be kept as small as possible.  In particular, it is a good idea to put code that does not need to be run for every single shell behind a test of the form `if [[ -o rcs ]]; then ...` so that it will not be executed when zsh is invoked with the `-f` option.

***

Separately, when Alacritty launches a shell on macOS, [it runs the shell through three layers of indirection](https://github.com/alacritty/alacritty/blob/1063706f8e8a84139e5d2b464a4978e9d840ea17/alacritty_terminal/src/tty/unix.rs#L165-L183). To use me as an example: my username is `sam` and my shell is `/run/current-system/sw/bin/bash`. In this case, Alacritty launches bash like so:
```
/usr/bin/login -flp sam /bin/zsh -fc "exec -a -bash /run/current-system/sw/bin/bash"
```

## the problem

Due to all of these factors, when your login shell is set to Bash and you open Alacritty, `__NIX_DARWIN_SET_ENVIRONMENT_DONE` is already set and thus the Bash setup does not run properly, resulting in (perhaps among other things) the PATH variable being wrong. Specifically, instead of the (correct)
```
/Users/sam/.mint/bin
/Users/sam/.cargo/bin
/Users/sam/.local/bin
/run/wrappers/bin
/Users/sam/.nix-profile/bin
/etc/profiles/per-user/sam/bin
/run/current-system/sw/bin
/nix/var/nix/profiles/default/bin
/usr/local/bin
/usr/bin
/usr/sbin
/bin
/sbin
/opt/local/bin
/opt/local/sbin
/Users/sam/Library/Application Support/JetBrains/Toolbox/scripts
/Users/sam/.local/x86_64-unknown-linux-gnu/bin
```
I get
```
/Users/sam/.mint/bin
/Users/sam/.cargo/bin
/Users/sam/.local/bin
/usr/local/bin
/System/Cryptexes/App/usr/bin
/usr/bin
/bin
/usr/sbin
/sbin
/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin
/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin
/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
/Library/Apple/usr/bin
/Library/TeX/texbin
/Applications/Wireshark.app/Contents/MacOS
/Applications/CotEditor.app/Contents/SharedSupport/bin
/opt/local/bin
/opt/local/sbin
/Applications/Alacritty.app/Contents/MacOS
/run/wrappers/bin
/Users/sam/.nix-profile/bin
/etc/profiles/per-user/sam/bin
/run/current-system/sw/bin
/nix/var/nix/profiles/default/bin
/opt/local/bin
/opt/local/sbin
/Users/sam/Library/Application Support/JetBrains/Toolbox/scripts
/Users/sam/.local/x86_64-unknown-linux-gnu/bin
```
The difference is that the content of `/etc/paths` and every file in `/etc/paths.d/` are inserted in the middle of my PATH var.

## the solution

This wraps most of the content of `/etc/zshenv` in an if statement that checks the `rcs` option, as described in `man zsh`. This fixes my specific issue, and is also more correct behavior anyway.