### PR TITLE
ci: don't override nixpkgs when building the manual

### DIFF
--- a/.github/workflows/update-manual.yml
+++ b/.github/workflows/update-manual.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Build manual
       run: |
-        nix build .#manualHTML --override-input nixpkgs nixpkgs/nixpkgs-24.05-darwin
+        nix build .#manualHTML
 
     - name: Push update to manual
       run: |


### PR DESCRIPTION
This causes `nix-darwin` to not have `rev` or `dirtyRev`