### PR TITLE
activate-system: remove `enable` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Furthermore there's `darwin-option` to introspect the settings of a system and i
 > NOTE: `darwin-option` is only available to non-flake installations.
 
 ```
-$ darwin-option services.activate-system.enable
+$ darwin-option nix.linux-builder.enable
 Value:
 true
 
@@ -180,10 +180,10 @@ Default:
 false
 
 Example:
-no example
+true
 
 Description:
-Whether to activate system at boot time.
+Whether to enable Linux builder.
 ```
 
 There's also a small wiki https://github.com/LnL7/nix-darwin/wiki about

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -774,7 +774,6 @@ in
 
     # Not in NixOS module
     warnings = [
-      (mkIf (!config.services.activate-system.enable && cfg.distributedBuilds) "services.activate-system is not enabled, a reboot could cause distributed builds to stop working.")
       (mkIf (!cfg.distributedBuilds && cfg.buildMachines != []) "nix.distributedBuilds is not enabled, build machines won't be configured.")
     ];
 

--- a/modules/services/activate-system/default.nix
+++ b/modules/services/activate-system/default.nix
@@ -1,22 +1,11 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
-let
-  cfg = config.services.activate-system;
-in
-
 {
-  options = {
-    services.activate-system.enable = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Whether to activate system at boot time.";
-    };
-  };
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "activate-system" "enable" ] "The `activate-system` service is now always enabled as it is necessary for a working `nix-darwin` setup.")
+  ];
 
-  config = mkIf cfg.enable {
-
+  config = {
     launchd.daemons.activate-system = {
       script = ''
         set -e
@@ -41,6 +30,5 @@ in
       serviceConfig.RunAtLoad = true;
       serviceConfig.KeepAlive.SuccessfulExit = false;
     };
-
   };
 }

--- a/tests/services-activate-system-changed-label-prefix.nix
+++ b/tests/services-activate-system-changed-label-prefix.nix
@@ -1,7 +1,6 @@
 { config, pkgs, ... }:
 
 {
-  services.activate-system.enable = true;
   launchd.labelPrefix = "org.nix-darwin";
 
   test = ''

--- a/tests/services-activate-system.nix
+++ b/tests/services-activate-system.nix
@@ -1,8 +1,6 @@
 { config, pkgs, ... }:
 
 {
-  services.activate-system.enable = true;
-
   test = ''
     echo checking activation service in /Library/LaunchDaemons >&2
     grep "org.nixos.activate-system" ${config.out}/Library/LaunchDaemons/org.nixos.activate-system.plist


### PR DESCRIPTION
Disabling this is not supported as `/run` gets cleared out on every reboot so it is necessary for ensuring that the `/run/current-system` symlink exists.

<img width="857" alt="Screenshot 2024-11-15 at 2 11 57 pm" src="https://github.com/user-attachments/assets/4df38c43-9aeb-4700-ab7c-d51af12394a7">
