### PR TITLE
treewide: use NIX_SSL_CERT_FILE instead of pkgs.cacert

### DIFF
--- a/modules/examples/hydra.nix
+++ b/modules/examples/hydra.nix
@@ -3,7 +3,7 @@
 let
   environment = lib.concatStringsSep " "
     [ "NIX_REMOTE=daemon"
-      "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "NIX_SSL_CERT_FILE=${config.environment.variables.NIX_SSL_CERT_FILE}"
     ];
 in
 

--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -63,7 +63,7 @@
   # launchd.user.agents.fetch-nixpkgs-updates = {
   #   command = "/usr/bin/sandbox-exec -f ${config.security.sandbox.profiles.fetch-nixpkgs-updates.profile} ${pkgs.git}/bin/git -C ${toString ~/Code/nixos/nixpkgs} fetch origin master";
   #   environment.HOME = "";
-  #   environment.NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  #   environment = { inherit (config.environment.variables) NIX_SSL_CERT_FILE; };
   #   serviceConfig.KeepAlive = false;
   #   serviceConfig.ProcessType = "Background";
   #   serviceConfig.StartInterval = 360;

--- a/modules/services/cachix-agent.nix
+++ b/modules/services/cachix-agent.nix
@@ -61,7 +61,7 @@ in {
       path = [ config.nix.package pkgs.coreutils config.environment.systemPath ];
 
       environment = {
-        NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        inherit (config.environment.variables) NIX_SSL_CERT_FILE;
         USER = "root";
       };
 

--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -551,7 +551,7 @@ in
     launchd.daemons.gitlab-runner = {
       environment = { #config.networking.proxy.envVars // {
         HOME = "${config.users.users.gitlab-runner.home}";
-        NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        inherit (config.environment.variables) NIX_SSL_CERT_FILE;
       } // (if config.nix.useDaemon then { NIX_REMOTE = "daemon"; } else {});
       path = with pkgs; [
         bash

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -27,7 +27,7 @@ in
 
       path = [ config.nix.package config.environment.systemPath ];
       environment = {
-        NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        inherit (config.environment.variables) NIX_SSL_CERT_FILE;
       };
 
       serviceConfig.KeepAlive = true;

--- a/modules/services/ofborg/default.nix
+++ b/modules/services/ofborg/default.nix
@@ -63,7 +63,7 @@ in
       path = [ config.nix.package pkgs.bash pkgs.coreutils pkgs.curl pkgs.git ];
       environment =
         { RUST_BACKTRACE = "1";
-          NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+          inherit (config.environment.variables) NIX_SSL_CERT_FILE;
         };
 
       serviceConfig.KeepAlive = true;


### PR DESCRIPTION
Based on the discussion in https://github.com/LnL7/nix-darwin/pull/675 this seems to be the preferred style.