### PR TITLE
fix: allow users to disable the homebrew check

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -297,7 +297,7 @@ let
   '';
 
   homebrewInstalled = ''
-    if [[ ! -f ${escapeShellArg config.homebrew.brewPrefix}/brew ]]; then
+    if [[ ! -f ${escapeShellArg config.homebrew.brewPrefix}/brew && -z "''${INSTALLING_HOMEBREW:-}" ]]; then
         echo "[1;31merror: Using the homebrew module requires homebrew installed, aborting activation[0m" >&2
         echo "Homebrew doesn't seem to be installed. Please install homebrew separately." >&2
         echo "You can install homebrew using the following command:" >&2


### PR DESCRIPTION
With the recent addition of https://github.com/LnL7/nix-darwin/pull/961, this unintentionally broke [nix-homebrew](https://github.com/zhaofengli/nix-homebrew) see [the issue](https://github.com/zhaofengli/nix-homebrew/issues/45). Thus this PR implments `system.checks.verifyHomebrewInstall` as a way to disable the check allowing nix-homebrew to function normally if users disable it.