### PR TITLE
dock: allow setting spacer tiles

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -134,10 +134,14 @@ in {
       description = ''
         Persistent applications in the dock.
       '';
-      apply = value:
-        if !(isList value)
-        then value
-        else map (app: { tile-data = { file-data = { _CFURLString = app; _CFURLStringType = 0; }; }; }) value;
+      apply =
+      let
+        tileTypes = ["spacer-tile" "small-spacer-tile"];
+        toSpecialTile = type: { tile-data = {}; tile-type = type; };
+        toAppTile = cfurl: { tile-data = { file-data = { _CFURLString = cfurl; _CFURLStringType = 0; }; }; };
+        toTile = s: if elem s tileTypes then toSpecialTile s else toAppTile s;
+      in
+      value: if isList value then map toTile value else value;
     };
 
     system.defaults.dock.persistent-others = mkOption {

--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -128,20 +128,72 @@ in {
     };
 
     system.defaults.dock.persistent-apps = mkOption {
-      type = types.nullOr (types.listOf (types.either types.path types.str));
+      type = let
+        taggedType = types.attrTag {
+              app = mkOption {
+                description = "An application to be added to the dock.";
+                type = types.str;
+              };
+              file = mkOption {
+                description = "A file to be added to the dock.";
+                type = types.str;
+              };
+              folder = mkOption {
+                description = "A folder to be added to the dock.";
+                type = types.str;
+              };
+              spacer = mkOption {
+                description = "A spacer to be added to the dock. Can be small or regular size.";
+                type = types.submodule {
+                  options.small = mkOption {
+                    description = "Whether the spacer is small.";
+                    type = types.bool;
+                    default = false;
+                  };
+                };
+              };
+            };
+
+        simpleType = types.either types.str types.path;
+        toTagged = path: { app = path; };
+        in
+      types.nullOr (types.listOf (types.coercedTo simpleType toTagged taggedType));
       default = null;
-      example = [ "/Applications/Safari.app" "/System/Applications/Utilities/Terminal.app" ];
+      example = [
+        { app = "/Applications/Safari.app"; }
+        { spacer = { small = false; }; }
+        { spacer = { small = true; }; }
+        { folder = "/System/Applications/Utilities"; }
+        { file = "/User/example/Downloads/test.csv"; }
+      ];
       description = ''
-        Persistent applications in the dock.
+        Persistent applications, spacers, files, and folders in the dock.
       '';
       apply =
       let
-        tileTypes = ["spacer-tile" "small-spacer-tile"];
-        toSpecialTile = type: { tile-data = {}; tile-type = type; };
-        toAppTile = cfurl: { tile-data = { file-data = { _CFURLString = cfurl; _CFURLStringType = 0; }; }; };
-        toTile = s: if elem s tileTypes then toSpecialTile s else toAppTile s;
+        toTile = item: if item ? app then {
+        tile-data.file-data = {
+          _CFURLString = item.app;
+          _CFURLStringType = 0;
+        };
+        } else if item ? spacer then {
+          tile-data = { };
+          tile-type = if item.spacer.small then "small-spacer-tile" else "spacer-tile";
+        } else if item ? folder then {
+          tile-data.file-data = {
+            _CFURLString = "file://" + item.folder;
+            _CFURLStringType = 15;
+          };
+          tile-type = "directory-tile";
+        } else if item ? file then {
+          tile-data.file-data = {
+            _CFURLString = "file://" + item.file;
+            _CFURLStringType = 15;
+          };
+          tile-type = "file-tile";
+        } else item;
       in
-      value: if isList value then map toTile value else value;
+      value: if value == null then null else map toTile value;
     };
 
     system.defaults.dock.persistent-others = mkOption {

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -255,7 +255,7 @@ defaults write com.apple.dock 'persistent-apps' $'<?xml version="1.0" encoding="
 			<key>file-data</key>
 			<dict>
 				<key>_CFURLString</key>
-				<string>MyApp.app</string>
+				<string>/Applications/MyApp.app</string>
 				<key>_CFURLStringType</key>
 				<integer>0</integer>
 			</dict>
@@ -267,7 +267,7 @@ defaults write com.apple.dock 'persistent-apps' $'<?xml version="1.0" encoding="
 			<key>file-data</key>
 			<dict>
 				<key>_CFURLString</key>
-				<string>Cool.app</string>
+				<string>/Applications/Cool.app</string>
 				<key>_CFURLStringType</key>
 				<integer>0</integer>
 			</dict>
@@ -288,6 +288,34 @@ defaults write com.apple.dock 'persistent-apps' $'<?xml version="1.0" encoding="
 		</dict>
 		<key>tile-type</key>
 		<string>spacer-tile</string>
+	</dict>
+	<dict>
+		<key>tile-data</key>
+		<dict>
+			<key>file-data</key>
+			<dict>
+				<key>_CFURLString</key>
+				<string>file:///Applications/Utilities</string>
+				<key>_CFURLStringType</key>
+				<integer>15</integer>
+			</dict>
+		</dict>
+		<key>tile-type</key>
+		<string>directory-tile</string>
+	</dict>
+	<dict>
+		<key>tile-data</key>
+		<dict>
+			<key>file-data</key>
+			<dict>
+				<key>_CFURLString</key>
+				<string>file:///Users/example/Downloads/test.csv</string>
+				<key>_CFURLStringType</key>
+				<integer>15</integer>
+			</dict>
+		</dict>
+		<key>tile-type</key>
+		<string>file-tile</string>
 	</dict>
 </array>
 </plist>'

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -273,6 +273,22 @@ defaults write com.apple.dock 'persistent-apps' $'<?xml version="1.0" encoding="
 			</dict>
 		</dict>
 	</dict>
+	<dict>
+		<key>tile-data</key>
+		<dict>
+
+		</dict>
+		<key>tile-type</key>
+		<string>small-spacer-tile</string>
+	</dict>
+	<dict>
+		<key>tile-data</key>
+		<dict>
+
+		</dict>
+		<key>tile-type</key>
+		<string>spacer-tile</string>
+	</dict>
 </array>
 </plist>'
 defaults write com.apple.dock 'persistent-others' $'<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -50,7 +50,14 @@
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";
-  system.defaults.dock.persistent-apps = ["MyApp.app" "Cool.app" "small-spacer-tile" "spacer-tile"];
+  system.defaults.dock.persistent-apps = [
+    "/Applications/MyApp.app"
+    { app = "/Applications/Cool.app"; }
+    { spacer = { small = true; }; }
+    { spacer = { small = false; }; }
+    { folder = "/Applications/Utilities"; }
+    { file = "/Users/example/Downloads/test.csv"; }
+  ];
   system.defaults.dock.persistent-others = ["~/Documents" "~/Downloads/file.txt"];
   system.defaults.dock.scroll-to-open = false;
   system.defaults.finder.AppleShowAllFiles = true;

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -50,7 +50,7 @@
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";
-  system.defaults.dock.persistent-apps = ["MyApp.app" "Cool.app"];
+  system.defaults.dock.persistent-apps = ["MyApp.app" "Cool.app" "small-spacer-tile" "spacer-tile"];
   system.defaults.dock.persistent-others = ["~/Documents" "~/Downloads/file.txt"];
   system.defaults.dock.scroll-to-open = false;
   system.defaults.finder.AppleShowAllFiles = true;


### PR DESCRIPTION
You can create spacer tiles in the dock by passing empty tile-data with specific tile-types.

Used to do this in my old dotfiles and have been meaning to upstream a change to support doing this in nix-darwin. 
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/cb9aeb3d-0016-458d-b58f-aac842dfe2d2">
