### PR TITLE
defaults: expose-group-by-app -> expose-group-apps

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -9,6 +9,9 @@ let
     "defaults write ${domain} '${key}' $'${strings.escape [ "'" ] (generators.toPlist { } value)}'";
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
+  # Filter out options to not pass through
+  # dock has alias options that we need to ignore
+  dockFiltered = (builtins.removeAttrs cfg.dock ["expose-group-by-app"]);
 
   # defaults
   alf = defaultsToList "/Library/Preferences/com.apple.alf" cfg.alf;
@@ -21,7 +24,7 @@ let
   LaunchServices = defaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
   NSGlobalDomain = defaultsToList "-g" cfg.NSGlobalDomain;
   menuExtraClock = defaultsToList "com.apple.menuextra.clock" cfg.menuExtraClock;
-  dock = defaultsToList "com.apple.dock" cfg.dock;
+  dock = defaultsToList "com.apple.dock" dockFiltered;
   finder = defaultsToList "com.apple.finder" cfg.finder;
   hitoolbox = defaultsToList "com.apple.HIToolbox" cfg.hitoolbox;
   magicmouse = defaultsToList "com.apple.AppleMultitouchMouse" cfg.magicmouse;

--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -6,6 +6,10 @@ let
   # Should only be used with options that previously used floats defined as strings.
   inherit (config.lib.defaults.types) floatWithDeprecationError;
 in {
+  imports = [
+    (mkRenamedOptionModule [ "system" "defaults" "dock" "expose-group-by-app" ] [ "system" "defaults" "dock" "expose-group-apps" ])
+  ];
+
   options = {
 
     system.defaults.dock.appswitcher-all-displays = mkOption {
@@ -67,11 +71,11 @@ in {
       '';
     };
 
-    system.defaults.dock.expose-group-by-app = mkOption {
+    system.defaults.dock.expose-group-apps = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
-        Whether to group windows by application in Mission Control's Exposé. The default is true.
+        Whether to group windows by application in Mission Control's Exposé. The default is false.
       '';
     };
 
@@ -220,7 +224,6 @@ in {
         Magnified icon size on hover. The default is 16.
       '';
     };
-   
 
     system.defaults.dock.wvous-tl-corner = mkOption {
       type = types.nullOr types.ints.positive;

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -235,6 +235,11 @@ defaults write com.apple.dock 'autohide-delay' $'<?xml version="1.0" encoding="U
 <plist version="1.0">
 <real>0.240000</real>
 </plist>'
+defaults write com.apple.dock 'expose-group-apps' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<true/>
+</plist>'
 defaults write com.apple.dock 'orientation' $'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -46,6 +46,7 @@
   system.defaults.menuExtraClock.Show24Hour = false;
   system.defaults.menuExtraClock.ShowDayOfWeek = true;
   system.defaults.menuExtraClock.ShowDate = 2;
+  system.defaults.dock.expose-group-apps = true;
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;
   system.defaults.dock.orientation = "left";


### PR DESCRIPTION
Noticed option wasn't doing anything and saw it was renamed in previous macOS releases. 

Not sure why the rename trace is being triggered a couple times, I don't see it referenced anywhere. 