### PR TITLE
ci: extend timeout and remove `tmate`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ env:
 jobs:
   test-stable:
     runs-on: macos-13
-    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Install nix corresponding to latest stable channel
@@ -22,7 +21,6 @@ jobs:
 
   test-unstable:
     runs-on: macos-13
-    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Install nix from current unstable channel
@@ -33,7 +31,6 @@ jobs:
 
   install-against-stable:
     runs-on: macos-13
-    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Install nix corresponding to latest stable channel
@@ -82,12 +79,6 @@ jobs:
         nix run .#darwin-uninstaller.tests.uninstaller \
           --extra-experimental-features "nix-command flakes" \
           --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
-    - name: Debugging tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-      with:
-        limit-access-to-actor: true
 
   install-against-unstable:
     runs-on: macos-13
@@ -140,16 +131,9 @@ jobs:
         nix run .#darwin-uninstaller.tests.uninstaller \
            --extra-experimental-features "nix-command flakes" \
            --override-input nixpkgs nixpkgs/nixpkgs-unstable
-    - name: Debugging tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-      with:
-        limit-access-to-actor: true
 
   install-flake-against-stable:
     runs-on: macos-13
-    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Install nix version corresponding to latest stable channel


### PR DESCRIPTION
`test-stable` takes around 30 minutes now so fails fairly often now