### PR TITLE
Add EnableTiledWindowMargins

### DIFF
--- a/modules/system/defaults/WindowManager.nix
+++ b/modules/system/defaults/WindowManager.nix
@@ -72,5 +72,13 @@ with lib;
         Hide widgets in Stage Manager.
       '';
     };
+
+    system.defaults.WindowManager.EnableTiledWindowMargins = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Tiled windows have margins. Default is true
+      '';
+    };
   };
 }


### PR DESCRIPTION
macOS Sequoia introduced window tiling. By default, tiled windows have margins.

Margins can be disabled through System Settings > Desktop & Dock > Tiled windows have margins (under 'Windows').

This sets `com.apple.WindowManager.EnableTiledWindowMargins` to 0

```
➜  ~ defaults read com.apple.WindowManager
{
    AppWindowGroupingBehavior = 1;
    AutoHide = 0;
    EnableTiledWindowMargins = 0;
    EnableTilingByEdgeDrag = 0;
    EnableTilingOptionAccelerator = 0;
    EnableTopTilingByEdgeDrag = 0;
    HasDisplayedShowDesktopEducation = 1;
    HideDesktop = 1;
    "LastHeartbeatDateString.daily" = "2024-11-24T17:11:47Z";
    StageManagerHideWidgets = 0;
    StandardHideWidgets = 0;
}
```

You can also disable it by issuing this command
```zsh
➜  ~ defaults write com.apple.WindowManager EnableTiledWindowMargins -bool false
```

Adding this options allows Nix-Darwin users to set this option declaratively.