### PR TITLE
nix: fix Lix version detection in auto-optimise-store assertion

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -763,8 +763,8 @@ in
 
         {
           # Should be fixed in Lix by https://gerrit.lix.systems/c/lix/+/2100
-          # As `isNixAtLeast "2.92.0" "2.92.0-devpre20241107" == false`, we need to explicitly check if the user is running Lix 2.92.0
-          assertion = cfg.settings.auto-optimise-store -> (cfg.package.pname == "lix" && (isNixAtLeast "2.92.0-devpre20241107" || cfg.package.version == "2.92.0"));
+          # Lix 2.92.0 will set `VERSION_SUFFIX` to `""`; `lib.versionAtLeast "" "pre20241107"` will return `true`.
+          assertion = cfg.settings.auto-optimise-store -> (cfg.package.pname == "lix" && (isNixAtLeast "2.92.0" && versionAtLeast (strings.removePrefix "-" cfg.package.VERSION_SUFFIX) "pre20241107"));
           message = "`nix.settings.auto-optimise-store` is known to corrupt the Nix Store, please use `nix.optimise.automatic` instead.";
         }
       ];


### PR DESCRIPTION
#1152 added an assertion to prevent use of `nix.settings.auto-optimise-store` on buggy versions of Nix/Lix. This check breaks with the Lix package provided by the [Lix nixos-module flake](https://git.lix.systems/lix-project/nixos-module/src/branch/main/flake.nix) as it has a different version string:

```
$ git clone https://git.lix.systems/lix-project/nixos-module && cd nixos-module
$ nix repl
Lix 2.91.1
Type :? for help.
nix-repl> :lf .
Added 18 variables.

nix-repl> packages.x86_64-darwin.default.version
"2.92.0-dev-pre20241115-c859d03"

nix-repl> packages.x86_64-darwin.default.VERSION_SUFFIX
"-pre20241115-c859d03"
```

```
$ git clone https://git.lix.systems/lix-project/lix && cd lix
$ nix repl
Lix 2.91.1
Type :? for help.
nix-repl> :lf .
Added 20 variables.

nix-repl> packages.x86_64-darwin.default.version
"2.92.0-devpre20241129_2e5780e"

nix-repl> packages.x86_64-darwin.default.VERSION_SUFFIX
"pre20241129_2e5780e"
```

Use the `VERSION_SUFFIX` attribute in the version check as it's more consistent than `version`.