### PR TITLE
fix(aerospace): allow startup commands

### DIFF
--- a/modules/services/aerospace/default.nix
+++ b/modules/services/aerospace/default.nix
@@ -36,7 +36,8 @@ in
             after-startup-command = lib.mkOption {
               type = listOf str;
               default = [ ];
-              description = "Do not use AeroSpace to run commands after startup. (Managed by launchd instead)";
+              description = "Add commands that run after AeroSpace startup";
+              example = [ "layout tiles" ];
             };
             enable-normalization-flatten-containers = lib.mkOption {
               type = bool;
@@ -140,10 +141,6 @@ in
         }
         {
           assertion = cfg.settings.after-login-command == [ ];
-          message = "AeroSpace will not run these commands as it does not start itself.";
-        }
-        {
-          assertion = cfg.settings.after-startup-command == [ ];
           message = "AeroSpace will not run these commands as it does not start itself.";
         }
       ];

--- a/tests/services-aerospace.nix
+++ b/tests/services-aerospace.nix
@@ -8,6 +8,7 @@ in
   services.aerospace.enable = true;
   services.aerospace.package = aerospace;
   services.aerospace.settings = {
+    after-startup-command = [ "layout tiles" ];
     gaps = {
       outer.left = 8;
       outer.bottom = 8;
@@ -31,6 +32,16 @@ in
       ${config.out}/user/Library/LaunchAgents/org.nixos.aerospace.plist`
 
     echo >&2 "checking config in $conf"
-    if [ `cat $conf | wc -l` -eq "27" ]; then echo "aerospace.toml config correctly contains 27 lines"; else return 1; fi
+    grep 'after-startup-command = \["layout tiles"\]' $conf
+
+    grep 'bottom = 8' $conf
+    grep 'left = 8' $conf
+    grep 'right = 8' $conf
+    grep 'top = 8' $conf
+
+    grep 'alt-h = "focus left"' $conf
+    grep 'alt-j = "focus down"' $conf
+    grep 'alt-k = "focus up"' $conf
+    grep 'alt-l = "focus right"' $conf
   '';
 }


### PR DESCRIPTION
The `after-startup-command` is disabled by mistake. While it's true that the `after-login-command` doesn't work, the startup commands work just fine (see [relevant code](https://github.com/nikitabobko/AeroSpace/blob/de93349dc342175b0f8332d2db4c41c433378eb1/Sources/AppBundle/initAppBundle.swift#L30-L33))
