### PR TITLE
Add `pam-watchid` authentication to `sudo` command

### DIFF
--- a/modules/security/pam.nix
+++ b/modules/security/pam.nix
@@ -35,6 +35,17 @@ in
         '';
       };
 
+      watchIdAuth = lib.mkEnableOption "" // {
+        description = ''
+          Use Apple Watch for sudo authentication, for devices without Touch ID or 
+          laptops with lids closed, consider using this.
+
+          When enabled, you can use your Apple Watch to authenticate sudo commands.
+          If this doesn't work, you can go into `System Settings > Touch ID & Password`
+          and toggle the switch for your Apple Watch.
+        '';
+      };
+
       reattach = lib.mkEnableOption "" // {
         description = ''
           Whether to enable reattaching a program to the user's bootstrap session.
@@ -53,6 +64,7 @@ in
     security.pam.services.sudo_local.text = lib.concatLines (
       (lib.optional cfg.reattach "auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so")
       ++ (lib.optional cfg.touchIdAuth "auth       sufficient     pam_tid.so")
+      ++ (lib.optional cfg.watchIdAuth "auth       sufficient     ${pkgs.pam-watchid}/lib/pam_watchid.so")
     );
 
     environment.etc."pam.d/sudo_local" = {


### PR DESCRIPTION
With projects like [pam-watchid](https://github.com/Logicer16/pam-watchid), it's now possible to enable apple watches to authenticate `sudo` commands, alongside with `TouchID`. This is mostly a raw idea, but I would love to see something like this in `nix-darwin`.

Because this is used to present an idea, there are couple things to note:
1. I did not add any tests
2. I straight up embedded a package in the source code
3. The `x86` part fails to compile for some reason so that's now commented out so I'll need some help with that

I would love for others to pick this up as this is my first time contributing to the project, and I am unfamiliar with:
1. How to use apple's toolchains when building packages
2. Which packages should I include
3. The best practices