### PR TITLE
github-runner: fix service not starting

### DIFF
--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -3,7 +3,9 @@
 , ...
 }:
 
-with lib;
+let
+  inherit (lib) literalExpression mkOption mkPackageOption types;
+in
 {
   options.services.github-runners = mkOption {
     description = ''

--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -90,6 +90,9 @@ in
 
             Changing this option or the `tokenFile`’s content triggers a new runner registration.
 
+            You can also manually trigger a new runner registration by deleting
+            {file}`/var/lib/github-runners/<name>/.runner` and restarting the service.
+
             We suggest using the fine-grained PATs. A runner registration token is valid
             only for 1 hour after creation, so the next time the runner configuration changes
             this will give you hard-to-debug HTTP 404 errors in the configure step.

--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -1,6 +1,10 @@
 { config, lib, pkgs, ... }:
-with lib;
+
 let
+  inherit (lib) any attrValues boolToString concatStringsSep escapeShellArg
+    flatten flip getExe hasAttr hasPrefix mapAttrsToList mapAttrs' mkBefore
+    mkDefault mkIf mkMerge nameValuePair optionalAttrs optionalString replaceStrings;
+
   mkSvcName = name: "github-runner-${name}";
   mkStateDir = cfg: "/var/lib/github-runners/${cfg.name}";
   mkLogDir = cfg: "/var/log/github-runners/${cfg.name}";

--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -59,6 +59,8 @@ in
             ${getExe' pkgs.coreutils "chown"} ${user}:${group} ${escapeShellArg (mkStateDir cfg)}
 
             ${getExe' pkgs.coreutils "mkdir"} -p ${escapeShellArg (mkLogDir cfg)}
+            # launchd will fail to start the service if the outer direction doesn't have sufficient permissions
+            ${getExe' pkgs.coreutils "chmod"} o+rx ${escapeShellArg (mkLogDir { name = ""; })}
             ${getExe' pkgs.coreutils "chown"} ${user}:${group} ${escapeShellArg (mkLogDir cfg)}
 
             ${optionalString (cfg.workDir == null) ''


### PR DESCRIPTION
https://github.com/LnL7/nix-darwin/commit/3b738c765de1bb4ecc4993fa092b27dd46d495ed made `/var/log/github-runner` have `o=`, however the launch daemon fails to redirect stdout/stderr if the parent directory doesn't have `o=rx`, even if the inner directory has `o=rx`