### PR TITLE
fix(zsh): correct the path of zsh-fast-syntax-highlighting

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -204,7 +204,7 @@ in
       }
 
       ${optionalString cfg.enableFastSyntaxHighlighting
-        "source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh-fast-syntax-highlighting/zsh-fast-syntax-highlighting.zsh"
+        "source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh"
       }
 
       ${optionalString cfg.enableFzfCompletion "source ${fzfCompletion}"}


### PR DESCRIPTION
check [zsh-fast-syntax-highlighting source](https://github.com/NixOS/nixpkgs/blob/394571358ce82dff7411395829aa6a3aad45b907/pkgs/by-name/zs/zsh-fast-syntax-highlighting/package.nix#L23)