### PR TITLE
power: restartAfterPowerFailure option is carried out conditionally

### DIFF
--- a/modules/power/default.nix
+++ b/modules/power/default.nix
@@ -15,6 +15,8 @@ in
       default = null;
       description = ''
         Whether to restart the computer after a power failure.
+
+        Option is not supported on all devices.
       '';
     };
 
@@ -33,8 +35,10 @@ in
       echo "configuring power..." >&2
 
       ${lib.optionalString (cfg.restartAfterPowerFailure != null) ''
-        systemsetup -setRestartPowerFailure \
-          '${onOff cfg.restartAfterPowerFailure}' &> /dev/null
+        if ! systemsetup -getRestartPowerFailure | grep -q "Not supported"; then
+          systemsetup -setRestartPowerFailure \
+            '${onOff cfg.restartAfterPowerFailure}' &> /dev/null
+        fi
       ''}
 
       ${lib.optionalString (cfg.restartAfterFreeze != null) ''

--- a/modules/power/default.nix
+++ b/modules/power/default.nix
@@ -35,10 +35,8 @@ in
       echo "configuring power..." >&2
 
       ${lib.optionalString (cfg.restartAfterPowerFailure != null) ''
-        if ! systemsetup -getRestartPowerFailure | grep -q "Not supported"; then
-          systemsetup -setRestartPowerFailure \
-            '${onOff cfg.restartAfterPowerFailure}' &> /dev/null
-        fi
+        systemsetup -setRestartPowerFailure \
+          '${onOff cfg.restartAfterPowerFailure}' &> /dev/null
       ''}
 
       ${lib.optionalString (cfg.restartAfterFreeze != null) ''

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -312,8 +312,8 @@ let
   # some mac devices, notably notebook do not support restartAfterPowerFailure option
   restartAfterPowerFailureIsSupported = ''
     if sudo /usr/sbin/systemsetup -getRestartPowerFailure | grep -q "Not supported"; then
-       echo "[1;31merror: Your system do not support the restartAfterPowerFailure feature[0m" >&2
-       echo "Please ensure that power.restartAfterPowerFailure is not set." >&2
+       printf >&2 "�[1;31merror: restarting after power failure is not supported on your machine�[0m\n" >&2
+       printf >&2 "Please ensure that `power.restartAfterPowerFailure` is not set.\n" >&2
        exit 2
     fi
   '';

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -308,6 +308,15 @@ let
         exit 2
     fi
   '';
+
+  # some mac devices, notably notebook do not support restartAfterPowerFailure option
+  restartAfterPowerFailureIsSupported = ''
+    if sudo /usr/sbin/systemsetup -getRestartPowerFailure | grep -q "Not supported"; then
+       echo "[1;31merror: Your system do not support the restartAfterPowerFailure feature[0m" >&2
+       echo "Please ensure that power.restartAfterPowerFailure is not set." >&2
+       exit 2
+    fi
+  '';
 in
 
 {
@@ -357,6 +366,7 @@ in
       (mkIf cfg.verifyNixPath nixPath)
       oldSshAuthorizedKeysDirectory
       (mkIf config.homebrew.enable homebrewInstalled)
+      (mkIf (config.power.restartAfterPowerFailure != null) restartAfterPowerFailureIsSupported)
     ];
 
     system.activationScripts.checks.text = ''


### PR DESCRIPTION
This should fix the issue reported in https://github.com/LnL7/nix-darwin/issues/1236

Changed the generated activation script fragment to check if the option is actually supported by the machine.
Also added to the option description info that the option could not work on some devices.