### PR TITLE
defaults: add screencapture.target option

### DIFF
--- a/modules/system/defaults/screencapture.nix
+++ b/modules/system/defaults/screencapture.nix
@@ -48,5 +48,20 @@ with lib;
         Show thumbnail after screencapture before writing to file. The default is true.
       '';
     };
+
+    system.defaults.screencapture.target = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Target to which screencapture should save screenshot to. The default is "file".
+        Valid values include:
+
+        * `file`: Saves as a file in location specified by `system.defaults.screencapture.location`
+        * `clipboard`: Saves screenshot to clipboard
+        * `preview`: Opens screenshot in Preview app
+        * `mail`
+        * `messages`
+      '';
+    };
   };
 }

--- a/modules/system/defaults/screencapture.nix
+++ b/modules/system/defaults/screencapture.nix
@@ -50,7 +50,7 @@ with lib;
     };
 
     system.defaults.screencapture.target = mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr (types.enum [ "file" "clipboard" "preview" "mail" "messages" ]);
       default = null;
       description = ''
         Target to which screencapture should save screenshot to. The default is "file".

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -426,6 +426,11 @@ defaults write com.apple.screencapture 'location' $'<?xml version="1.0" encoding
 <plist version="1.0">
 <string>/tmp</string>
 </plist>'
+defaults write com.apple.screencapture 'target' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<string>file</string>
+</plist>'
 defaults write com.apple.screensaver 'askForPassword' $'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -74,6 +74,7 @@
   system.defaults.finder.ShowRemovableMediaOnDesktop = false;
   system.defaults.hitoolbox.AppleFnUsageType = "Show Emoji & Symbols";
   system.defaults.screencapture.location = "/tmp";
+  system.defaults.screencapture.target = "file";
   system.defaults.screencapture.include-date = true;
   system.defaults.screensaver.askForPassword = true;
   system.defaults.screensaver.askForPasswordDelay = 5;


### PR DESCRIPTION
Adds the ability to set `com.apple.screencapture.target` default, which tells screencapture to output screenshot to e.g. clipboard. I prefer to put my screenshots directly into my clipboard, and there wasn't an option to do that through nix-darwin, so i've made the PR :)

Tested it using different valid values on Sequoia, valid values were observed by setting different "Save to" settings and reading using `defaults read com.apple.screencapture target`:

![untitled](https://github.com/user-attachments/assets/0a71bf8c-bd45-44bf-92ce-c864ddb835b6)
