### PR TITLE
consul: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -61,6 +61,7 @@
   ./services/buildkite-agents.nix
   ./services/chunkwm.nix
   ./services/cachix-agent.nix
+  ./services/consul.nix
   ./services/dnsmasq.nix
   ./services/emacs.nix
   ./services/eternal-terminal.nix

--- a/modules/services/consul.nix
+++ b/modules/services/consul.nix
@@ -1,0 +1,117 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+
+  dataDir = "/var/lib/consul";
+  cfg = config.services.consul;
+
+  configOptions = {
+    data_dir = dataDir;
+    ui_config = {
+      enabled = cfg.webUi;
+    };
+  } // cfg.extraConfig;
+
+  configFiles = [
+    "/etc/consul.json"
+  ] ++ cfg.extraConfigFiles;
+in
+{
+  meta.maintainers = [ lib.maintainers.mjm or "mjm" ];
+
+  options = {
+    services.consul = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enables the consul daemon.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "consul" { };
+
+      webUi = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enables the web interface on the consul http port.
+        '';
+      };
+
+      extraConfig = lib.mkOption {
+        default = { };
+        type = lib.types.attrsOf lib.types.anything;
+        description = ''
+          Extra configuration options which are serialized to json and added
+          to the config.json file.
+        '';
+      };
+
+      extraConfigFiles = lib.mkOption {
+        default = [ ];
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          Additional configuration files to pass to consul
+          NOTE: These will not trigger the service to be restarted when altered.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.consul = {
+      uid = lib.mkDefault 560;
+      gid = config.users.groups.consul.gid;
+      description = "Consul agent daemon user";
+      home = dataDir;
+      createHome = true;
+      # The shell is needed for health checks
+      shell = "/run/current-system/sw/bin/bash";
+    };
+    users.groups.consul = {
+      gid = lib.mkDefault 560;
+    };
+    users.knownUsers = [ "consul" ];
+    users.knownGroups = [ "consul" ];
+
+    environment = {
+      etc."consul.json".text = builtins.toJSON configOptions;
+      # We need consul.d to exist for consul to start
+      etc."consul.d/dummy.json".text = "{ }";
+      systemPackages = [ cfg.package ];
+    };
+
+    launchd.daemons.consul = {
+      path = [ cfg.package ];
+      script = lib.concatStringsSep " " (
+        [
+          "consul"
+          "agent"
+          "-config-dir"
+          "/etc/consul.d"
+        ]
+        ++ lib.concatMap (n: [
+          "-config-file"
+          n
+        ]) configFiles
+      );
+      serviceConfig =
+        let
+          logPath = "${dataDir}/consul.log";
+        in
+        {
+          KeepAlive = true;
+          RunAtLoad = true;
+          StandardErrorPath = logPath;
+          StandardOutPath = logPath;
+          GroupName = "consul";
+          UserName = "consul";
+        };
+    };
+  };
+}


### PR DESCRIPTION
Adds a module for running a Consul agent on macOS.

This is mostly a stripped-down version of the NixOS module. It removes some complexity around advertising addresses because I both didn't need it and didn't want to figure out how to reimplement it for macOS. I think in most cases, the go-sockaddr support in Consul is good enough.