### PR TITLE
power: quote in string triggered shellcheck SC2016

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -312,8 +312,8 @@ let
   # some mac devices, notably notebook do not support restartAfterPowerFailure option
   restartAfterPowerFailureIsSupported = ''
     if sudo /usr/sbin/systemsetup -getRestartPowerFailure | grep -q "Not supported"; then
-       printf >&2 "�[1;31merror: restarting after power failure is not supported on your machine�[0m\n" >&2
-       printf >&2 "Please ensure that `power.restartAfterPowerFailure` is not set.\n" >&2
+       printf >&2 "\e[1;31merror: restarting after power failure is not supported on your machine\e[0m\n" >&2
+       printf >&2 "Please ensure that \`power.restartAfterPowerFailure\` is not set.\n" >&2
        exit 2
     fi
   '';


### PR DESCRIPTION
One of the printed string in [PR](https://github.com/LnL7/nix-darwin/pull/1241)  was triggering https://www.shellcheck.net/wiki/SC2016.
This should fix the issue.

Sorry for that, I should have checked the suggested change.