### PR TITLE
Add --ignore-dependencies option for casks

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -396,6 +396,9 @@ let
       no_binaries = mkNullOrBoolOption {
         description = "Whether to disable linking of helper executables.";
       };
+      ignore_dependencies = mkNullOrBoolOption {
+        description = "Ignore casks dependencies in case you manage them extrenally";
+      };
 
       brewfileLine = mkInternalOption { type = types.nullOr types.str; };
     };


### PR DESCRIPTION
Some casks have extrenal dependencies managed by brew, neovide for examples declares neovim as a dependency, a problem arises when you want to use a nix managed neovim instead