### PR TITLE
Make release branches a thing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,42 +6,42 @@ on:
       - master
 
 env:
-  CURRENT_STABLE_CHANNEL: nixpkgs-24.11-darwin
+  NIXPKGS_BRANCH: nixpkgs-unstable
+  NIX_DARWIN_BRANCH: master
+  NIX_VERSION: 2.24.11
 
 jobs:
+  # The `test-stable` and `install-against-stable` job names are
+  # load‐bearing, despite their inaccuracy on the unstable branch, as
+  # they are set as required checks in the repository configuration,
+  # which only repository admins can change.
+  #
+  # TODO: Change them once the repository configuration is updated.
+
   test-stable:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
-    - name: Install nix corresponding to latest stable channel
+    - name: Install Nix
       uses: cachix/install-nix-action@v30
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.18.8/install
-    - run: nix flake check --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
-
-  test-unstable:
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v30
-      with:
-        install_url: https://releases.nixos.org/nix/nix-2.24.9/install
-    - run: nix flake check --override-input nixpkgs nixpkgs/nixpkgs-unstable
+        install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
+    - run: nix flake check --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
 
   install-against-stable:
     runs-on: macos-13
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
-    - name: Install nix corresponding to latest stable channel
+    - name: Install Nix
       uses: cachix/install-nix-action@v30
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.18.8/install
-        nix_path: nixpkgs=channel:${{ env.CURRENT_STABLE_CHANNEL }}
+        install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
+        nix_path: nixpkgs=channel:${{ env.NIXPKGS_BRANCH }}
     - name: Install channels
       run: |
-        nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
-        nix-channel --add https://nixos.org/channels/${{ env.CURRENT_STABLE_CHANNEL }} nixpkgs
+        nix-channel --add https://github.com/LnL7/nix-darwin/archive/${{ env.NIX_DARWIN_BRANCH }}.tar.gz darwin
+        nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_BRANCH }} nixpkgs
         nix-channel --update
     - name: Install nix-darwin
       run: |
@@ -75,71 +75,20 @@ jobs:
         # `cachix/install-nix-action` but not by our default config above
         nix run .#darwin-uninstaller \
           --extra-experimental-features "nix-command flakes" \
-          --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
+          --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
         nix run .#darwin-uninstaller.tests.uninstaller \
           --extra-experimental-features "nix-command flakes" \
-          --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
+          --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
 
-  install-against-unstable:
+  install-flake:
     runs-on: macos-13
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
-    - name: Install nix from current unstable channel
+    - name: Install Nix
       uses: cachix/install-nix-action@v30
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.24.9/install
-        nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Install channels
-      run: |
-        nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
-        nix-channel --update
-    - name: Install nix-darwin
-      run: |
-        export NIX_PATH=$HOME/.nix-defexpr/channels
-
-        mkdir -p ~/.config/nix-darwin
-        cp modules/examples/simple.nix ~/.config/nix-darwin/configuration.nix
-
-        nixConfHash=$(shasum -a 256 /etc/nix/nix.conf | cut -d ' ' -f 1)
-        /usr/bin/sed -i.bak \
-          "s/# programs.fish.enable = true;/nix.settings.access-tokens = [ \"github.com=\${{ secrets.GITHUB_TOKEN }}\" ]; environment.etc.\"nix\/nix.conf\".knownSha256Hashes = [ \"$nixConfHash\" ];/" \
-          ~/.config/nix-darwin/configuration.nix
-
-        nix run .#darwin-rebuild \
-          -- switch \
-          -I darwin-config=$HOME/.config/nix-darwin/configuration.nix
-    - name: Switch to new configuration
-      run: |
-        . /etc/bashrc
-
-        /usr/bin/sed -i.bak \
-          "s/pkgs.vim/pkgs.hello/" \
-          ~/.config/nix-darwin/configuration.nix
-
-        darwin-rebuild switch -I darwin=.
-
-        hello
-    - name: Test uninstallation of nix-darwin
-      run: |
-        # We need to specify `--extra-experimental-features` because `experimental-features` is set by
-        # `cachix/install-nix-action` but not by our default config above
-        nix run .#darwin-uninstaller \
-           --extra-experimental-features "nix-command flakes" \
-           --override-input nixpkgs nixpkgs/nixpkgs-unstable
-        nix run .#darwin-uninstaller.tests.uninstaller \
-           --extra-experimental-features "nix-command flakes" \
-           --override-input nixpkgs nixpkgs/nixpkgs-unstable
-
-  install-flake-against-stable:
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install nix version corresponding to latest stable channel
-      uses: cachix/install-nix-action@v30
-      with:
-        install_url: https://releases.nixos.org/nix/nix-2.18.8/install
+        install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
     - name: Install nix-darwin
       run: |
         mkdir -p ~/.config/nix-darwin
@@ -157,7 +106,7 @@ jobs:
         nix run .#darwin-rebuild -- \
           switch --flake ~/.config/nix-darwin#simple \
           --override-input nix-darwin . \
-          --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
+          --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
     - name: Switch to new configuration
       run: |
         . /etc/bashrc
@@ -168,55 +117,10 @@ jobs:
 
         darwin-rebuild switch --flake ~/.config/nix-darwin#simple \
           --override-input nix-darwin . \
-          --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
+          --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
 
         hello
     - name: Test uninstallation of nix-darwin
       run: |
-        nix run .#darwin-uninstaller --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
-        nix run .#darwin-uninstaller.tests.uninstaller --override-input nixpkgs nixpkgs/${{ env.CURRENT_STABLE_CHANNEL }}
-
-  install-flake-against-unstable:
-    runs-on: macos-13
-    timeout-minutes: 30
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install nix from current unstable channel
-      uses: cachix/install-nix-action@v30
-      with:
-        install_url: https://releases.nixos.org/nix/nix-2.24.9/install
-    - name: Install nix-darwin
-      run: |
-        mkdir -p ~/.config/nix-darwin
-        darwin=$(pwd)
-        pushd ~/.config/nix-darwin
-          nix flake init -t $darwin
-          nixConfHash=$(shasum -a 256 /etc/nix/nix.conf | cut -d ' ' -f 1)
-          /usr/bin/sed -i.bak \
-            "s/# programs.fish.enable = true;/nix.settings.access-tokens = [ \"github.com=\${{ secrets.GITHUB_TOKEN }}\" ]; environment.etc.\"nix\/nix.conf\".knownSha256Hashes = [ \"$nixConfHash\" ];/" \
-            flake.nix
-          /usr/bin/sed -i.bak \
-            's/nixpkgs.hostPlatform = "aarch64-darwin";/nixpkgs.hostPlatform = "'$(nix eval --expr builtins.currentSystem --impure --raw)'";/' \
-            flake.nix
-        popd
-        nix run .#darwin-rebuild -- \
-          switch --flake ~/.config/nix-darwin#simple \
-          --override-input nix-darwin . \
-          --override-input nixpkgs nixpkgs/nixpkgs-unstable
-    - name: Switch to new configuration
-      run: |
-        . /etc/bashrc
-
-        /usr/bin/sed -i.bak \
-          "s/pkgs.vim/pkgs.hello/" \
-          ~/.config/nix-darwin/flake.nix
-
-        darwin-rebuild switch --flake ~/.config/nix-darwin#simple \
-          --override-input nix-darwin . \
-          --override-input nixpkgs nixpkgs/nixpkgs-unstable
-
-        hello
-    - name: Test uninstallation of nix-darwin
-      run: |
-        nix run .#darwin-uninstaller --override-input nixpkgs nixpkgs/nixpkgs-unstable
-        nix run .#darwin-uninstaller.tests.uninstaller --override-input nixpkgs nixpkgs/nixpkgs-unstable
+        nix run .#darwin-uninstaller --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
+        nix run .#darwin-uninstaller.tests.uninstaller --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ If you don't have an existing `configuration.nix`, you can run the following com
 ```bash
 mkdir -p ~/.config/nix-darwin
 cd ~/.config/nix-darwin
-nix flake init -t nix-darwin
+
+# To use Nixpkgs unstable:
+nix flake init -t nix-darwin/master
+# To use Nixpkgs 24.11:
+nix flake init -t nix-darwin/nix-darwin-24.11
+
 sed -i '' "s/simple/$(scutil --get LocalHostName)/" flake.nix
 ```
 
@@ -57,8 +62,10 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
   description = "John's darwin system";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
-    nix-darwin.url = "github:LnL7/nix-darwin";
+    # Use `github:NixOS/nixpkgs/nixpkgs-24.11-darwin` to use Nixpkgs 24.11.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Use `github:LnL7/nix-darwin/nix-darwin-24.11` to use Nixpkgs 24.11.
+    nix-darwin.url = "github:LnL7/nix-darwin/master";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 
@@ -122,8 +129,12 @@ Copy the [simple](./modules/examples/simple.nix) example to `~/.config/nix-darwi
 ### Step 2. Adding `nix-darwin` channel
 
 ```bash
-nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
-nix-channel --update
+# If you use Nixpkgs unstable (the default):
+sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
+# If you use Nixpkgs 24.11:
+sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/nix-darwin-24.11.tar.gz darwin
+
+sudo nix-channel --update
 ```
 
 ### Step 3. Installing `nix-darwin`
@@ -131,7 +142,11 @@ nix-channel --update
 To install `nix-darwin`, you can just run `darwin-rebuild switch` to install nix-darwin. As `darwin-rebuild` won't be installed in your `PATH` yet, you can use the following command:
 
 ```bash
+# If you use Nixpkgs unstable (the default):
 nix-build https://github.com/LnL7/nix-darwin/archive/master.tar.gz -A darwin-rebuild
+# If you use Nixpkgs 24.11:
+nix-build https://github.com/LnL7/nix-darwin/archive/nix-darwin-24.11.tar.gz -A darwin-rebuild
+
 ./result/bin/darwin-rebuild switch -I darwin-config=$HOME/.config/nix-darwin/configuration.nix
 ```
 
@@ -145,10 +160,10 @@ darwin-rebuild switch
 
 ### Step 5. Updating `nix-darwin`
 
-You can update `nix-darwin` using the following command:
+You can update Nixpkgs and `nix-darwin` using the following command:
 
 ```bash
-nix-channel --update darwin
+sudo nix-channel --update
 ```
 </details>
 

--- a/eval-config.nix
+++ b/eval-config.nix
@@ -1,9 +1,71 @@
+let
+  nixDarwinVersion = builtins.fromJSON (builtins.readFile ./version.json);
+
+  checkRelease = lib:
+    # Avoid breaking configurations when the unstable Nixpkgs version
+    # rolls over.
+    #
+    # TODO: Something more refined than this would be ideal, as this
+    # still means you could be using unstable nix-darwin 25.05 with
+    # Nixpkgs 26.05, which would be unfortunate.
+    if nixDarwinVersion.isReleaseBranch then
+      lib.trivial.release == nixDarwinVersion.release
+    else
+      lib.versionAtLeast lib.trivial.release nixDarwinVersion.release;
+in
+
 { lib
 , modules
 , baseModules ? import ./modules/module-list.nix
 , specialArgs ? { }
 , check ? true
+, enableNixpkgsReleaseCheck ? true
 }@args:
+
+assert enableNixpkgsReleaseCheck -> checkRelease lib || throw ''
+
+  nix-darwin now uses release branches that correspond to Nixpkgs releases.
+  The nix-darwin and Nixpkgs branches in use must match, but you are currently
+  using nix-darwin ${nixDarwinVersion.release} with Nixpkgs ${lib.trivial.release}.
+
+  On macOS, you should use either the `nixpkgs-unstable` or
+  `nixpkgs-YY.MM-darwin` branches of Nixpkgs. These correspond to the
+  `master` and `nix-darwin-YY.MM` branches of nix-darwin, respectively. Check
+  <https://status.nixos.org/> for the currently supported Nixpkgs releases.
+
+  If you’re using flakes, make sure your inputs look like this:
+
+      inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/NIXPKGS-BRANCH";
+        nix-darwin.url = "github:LnL7/nix-darwin/NIX-DARWIN-BRANCH";
+        nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+        # …
+      };
+
+  If you’re using channels, you can check your current channels with:
+
+      $ sudo nix-channel --list
+      nixpkgs https://nixos.org/channels/NIXPKGS-BRANCH
+      darwin https://github.com/LnL7/nix-darwin/archive/NIX-DARWIN-BRANCH.tar.gz
+      …
+      $ nix-channel --list
+      …
+
+  If `darwin` or `nixpkgs` are present in `nix-channel --list` (without
+  `sudo`), you should delete them with `nix-channel --remove NAME`. These can
+  contribute to version mismatch problems.
+
+  You can then fix your channels like this:
+
+      $ sudo nix-channel --add https://nixos.org/channels/NIXPKGS-BRANCH nixpkgs
+      $ sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/NIX-DARWIN-BRANCH.tar.gz darwin
+      $ sudo nix-channel --update
+
+  After that, activating your system again should work correctly. If it
+  doesn’t, please open an issue at
+  <https://github.com/LnL7/nix-darwin/issues/new> and include as much
+  information as possible.
+'';
 
 let
   argsModule = {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718149104,
-        "narHash": "sha256-Ds1QpobBX2yoUDx9ZruqVGJ/uQPgcXoYuobBguyKEh8=",
+        "lastModified": 1736241350,
+        "narHash": "sha256-CHd7yhaDigUuJyDeX0SADbTM9FXfiWaeNyY34FL1wQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e913ae340076bbb73d9f4d3d065c2bca7caafb16",
+        "rev": "8c9fd3e564728e90829ee7dbac6edc972971cd0f",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,10 @@
 {
   description = "A collection of darwin modules";
 
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
   outputs = { self, nixpkgs }: let
     forAllSystems = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
     forDarwinSystems = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-darwin" ];

--- a/modules/examples/flake/flake.nix
+++ b/modules/examples/flake/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.url = "github:LnL7/nix-darwin/master";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -211,8 +211,8 @@ let
     if ! test -e "$darwinPath"; then
         echo "[1;31merror: Changed <darwin> but target does not exist, aborting activation[0m" >&2
         echo "Add the darwin repo as a channel or set nix.nixPath:" >&2
-        echo "$ nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin" >&2
-        echo "$ nix-channel --update" >&2
+        echo "$ sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin" >&2
+        echo "$ sudo nix-channel --update" >&2
         echo >&2
         echo "or set" >&2
         echo >&2
@@ -225,8 +225,8 @@ let
     if ! test -e "$nixpkgsPath"; then
         echo "[1;31merror: Changed <nixpkgs> but target does not exist, aborting activation[0m" >&2
         echo "Add a nixpkgs channel or set nix.nixPath:" >&2
-        echo "$ nix-channel --add http://nixos.org/channels/nixpkgs-unstable nixpkgs" >&2
-        echo "$ nix-channel --update" >&2
+        echo "$ sudo nix-channel --add http://nixos.org/channels/nixpkgs-unstable nixpkgs" >&2
+        echo "$ sudo nix-channel --update" >&2
         echo >&2
         echo "or set" >&2
         echo >&2

--- a/modules/system/version.nix
+++ b/modules/system/version.nix
@@ -59,11 +59,18 @@ in
       description = "Label to be used in the names of generated outputs.";
     };
 
+    system.darwinRelease = mkOption {
+      readOnly = true;
+      type = types.str;
+      default = (lib.importJSON ../../version.json).release;
+      description = "The nix-darwin release (e.g. `24.11`).";
+    };
+
     system.darwinVersion = mkOption {
       internal = true;
       type = types.str;
-      default = "darwin${toString cfg.stateVersion}${cfg.darwinVersionSuffix}";
-      description = "The full darwin version (e.g. `darwin4.2abdb5a`).";
+      default = cfg.darwinRelease + cfg.darwinVersionSuffix;
+      description = "The full nix-darwin version (e.g. `24.11.2abdb5a`).";
     };
 
     system.darwinVersionSuffix = mkOption {
@@ -72,7 +79,7 @@ in
       default = if cfg.darwinRevision != null
         then ".${substring 0 7 cfg.darwinRevision}"
         else "";
-      description = "The short darwin version suffix (e.g. `.2abdb5a`).";
+      description = "The short nix-darwin version suffix (e.g. `.2abdb5a`).";
     };
 
     system.darwinRevision = mkOption {
@@ -86,14 +93,15 @@ in
       readOnly = true;
       type = types.str;
       default = lib.trivial.release;
-      description = "The nixpkgs release (e.g. `16.03`).";
+      description = "The nixpkgs release (e.g. `24.11`).";
     };
 
+    # TODO: Shouldn’t mismatch the Darwin release, rethink all this…
     system.nixpkgsVersion = mkOption {
       internal = true;
       type = types.str;
       default = cfg.nixpkgsRelease + cfg.nixpkgsVersionSuffix;
-      description = "The full nixpkgs version (e.g. `16.03.1160.f2d4ee1`).";
+      description = "The full nixpkgs version (e.g. `24.11.1160.f2d4ee1`).";
     };
 
     system.nixpkgsVersionSuffix = mkOption {
@@ -124,7 +132,7 @@ in
   config = {
     # This default is set here rather than up there so that the options
     # documentation is not reprocessed on every commit
-    system.darwinLabel = mkDefault "${cfg.nixpkgsVersion}+${cfg.darwinVersion}";
+    system.darwinLabel = mkDefault cfg.darwinVersion;
 
     assertions = [
       {

--- a/version.json
+++ b/version.json
@@ -1,0 +1,4 @@
+{
+  "release": "25.05",
+  "isReleaseBranch": false
+}


### PR DESCRIPTION
Finally!

Once this is approved, I will cut a `nix-darwin-24.11` branch and PR the appropriate changes.

Left as future work:

* Building a seperate manual for each release, moving content from `README.md` and `CHANGELOG` to the manual, and linking an index page with the manuals for each version from `README.md`.

* Infrastructure for automated backports.

* Writing a checklist for the release process (or better, automating it).

* Perhaps having a bot automatically update our `flake.lock` so we can just tell people to use nix-darwin’s Nixpkgs input rather than bringing their own (and risking mismatches).

Closes: #727