### PR TITLE
Add support for `AppleAccentColor`

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -47,6 +47,25 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain.AppleAccentColor = mkOption {
+      type = types.nullOr (types.enum [ -1 0 1 2 3 4 5 6 ]);
+      default = null;
+      description = ''
+        Specifies the accent color used throughout the system interface. The value can be one of the following:
+
+        -1: Graphite
+        0: Red
+        1: Orange
+        2: Yellow
+        3: Green
+        4: Blue
+        5: Purple
+        6: Pink
+        
+        Set this option to change the system-wide accent color. If not set, the default accent color will be used.
+      '';
+    };
+
     system.defaults.NSGlobalDomain.AppleInterfaceStyleSwitchesAutomatically = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -5,6 +5,7 @@
   system.defaults.NSGlobalDomain.AppleEnableMouseSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleEnableSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleFontSmoothing = 1;
+  system.defaults.NSGlobalDomain.AppleAccentColor = 4;
   system.defaults.NSGlobalDomain.AppleICUForce24HourTime = true;
   system.defaults.NSGlobalDomain.AppleKeyboardUIMode = 3;
   system.defaults.NSGlobalDomain.ApplePressAndHoldEnabled = true;


### PR DESCRIPTION
Introduces the option to configure the system-wide accent color (`AppleAccentColor`) in `NSGlobalDomain`.