### PR TITLE
darwin-uninstaller: remove `darwin` channel from `root` too

### DIFF
--- a/pkgs/darwin-uninstaller/configuration.nix
+++ b/pkgs/darwin-uninstaller/configuration.nix
@@ -16,12 +16,12 @@ with lib;
   nix.useDaemon = mkForce false;
 
   system.activationScripts.postUserActivation.text = mkAfter ''
-    if [[ -L ~/.nix-defexpr/channels/darwin ]]; then
-        nix-channel --remove darwin || true
-    fi
+    nix-channel --remove darwin || true
   '';
 
   system.activationScripts.postActivation.text = mkAfter ''
+    nix-channel --remove darwin || true
+
     if [[ -L /Applications/Nix\ Apps ]]; then
         rm /Applications/Nix\ Apps
     fi

--- a/pkgs/darwin-uninstaller/default.nix
+++ b/pkgs/darwin-uninstaller/default.nix
@@ -77,7 +77,7 @@ in writeShellApplication {
       echo >&2
 
       echo >&2 "checking darwin channel"
-      test -e ~/.nix-defexpr/channels/darwin && exit 1
+      nix-instantiate --find-file darwin && exit 1
       echo >&2 "checking /etc"
       test -e /etc/static && exit 1
       echo >&2 "checking /run/current-system"


### PR DESCRIPTION
Handle this now that we recommend people use `sudo nix-channel --add`. I’m not sure `~/.nix-defexpr` is always used (e.g. with XDG directories?), so we just remove it unconditionally in both user and system activation and hope the warning isn’t too bothersome, but maybe we could do something smarter here.

@Enzime I don’t suppose you have any idea what the `[[ "$(shasum -a 256 /Library/LaunchDaemons/org.nixos.nix-daemon.plist | awk '{print $1}')" == "$(shasum -a 256 /Library/LaunchDaemons/org.nixos.nix-daemon.plist | awk '{print $1}')" ]]` thing from 3a89b614321ab8dad3962d79fc3a29bace9a8486 is about?