### PR TITLE
{environment,readme}: default configuration path to `/etc/nix-darwin`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,13 +43,11 @@ jobs:
         nix-channel --update
     - name: Install nix-darwin
       run: |
-        export NIX_PATH=$HOME/.nix-defexpr/channels
-
-        mkdir -p ~/.config/nix-darwin
-        cp modules/examples/simple.nix ~/.config/nix-darwin/configuration.nix
+        sudo mkdir -p /etc/nix-darwin
+        sudo cp modules/examples/simple.nix /etc/nix-darwin/configuration.nix
 
         nixConfHash=$(shasum -a 256 /etc/nix/nix.conf | cut -d ' ' -f 1)
-        /usr/bin/sed -i.bak \
+        sudo /usr/bin/sed -i.bak \
           "s/# programs.fish.enable = true;/ \
             imports = [ \
               ({ options, ... }: { \
@@ -61,19 +59,18 @@ jobs:
               }) \
             ]; \
           /" \
-          ~/.config/nix-darwin/configuration.nix
+          /etc/nix-darwin/configuration.nix
 
-        nix run .#darwin-rebuild \
-          -- switch \
+        nix run .#darwin-rebuild -- switch \
           -I darwin=. \
-          -I darwin-config=$HOME/.config/nix-darwin/configuration.nix
+          -I darwin-config=/etc/nix-darwin/configuration.nix
     - name: Switch to new configuration
       run: |
         . /etc/bashrc
 
-        /usr/bin/sed -i.bak \
+        sudo /usr/bin/sed -i.bak \
           "s/pkgs.vim/pkgs.hello/" \
-          ~/.config/nix-darwin/configuration.nix
+          /etc/nix-darwin/configuration.nix
 
         darwin-rebuild switch
 
@@ -100,31 +97,33 @@ jobs:
         install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
     - name: Install nix-darwin
       run: |
-        mkdir -p ~/.config/nix-darwin
+        sudo mkdir -p /etc/nix-darwin
         darwin=$(pwd)
-        pushd ~/.config/nix-darwin
-          nix flake init -t $darwin
+        pushd /etc/nix-darwin
+          sudo nix flake init -t $darwin
           nixConfHash=$(shasum -a 256 /etc/nix/nix.conf | cut -d ' ' -f 1)
-          /usr/bin/sed -i.bak \
+          sudo /usr/bin/sed -i.bak \
             "s/# programs.fish.enable = true;/nix.settings.access-tokens = [ \"github.com=\${{ secrets.GITHUB_TOKEN }}\" ]; environment.etc.\"nix\/nix.conf\".knownSha256Hashes = [ \"$nixConfHash\" ];/" \
             flake.nix
-          /usr/bin/sed -i.bak \
+          sudo /usr/bin/sed -i.bak \
+            's/darwinConfigurations."simple"/darwinConfigurations."'$(scutil --get LocalHostName)'"/g' \
+            flake.nix
+          sudo /usr/bin/sed -i.bak \
             's/nixpkgs.hostPlatform = "aarch64-darwin";/nixpkgs.hostPlatform = "'$(nix eval --expr builtins.currentSystem --impure --raw)'";/' \
             flake.nix
         popd
-        nix run .#darwin-rebuild -- \
-          switch --flake ~/.config/nix-darwin#simple \
+        nix run .#darwin-rebuild -- switch \
           --override-input nix-darwin . \
           --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
     - name: Switch to new configuration
       run: |
         . /etc/bashrc
 
-        /usr/bin/sed -i.bak \
+        sudo /usr/bin/sed -i.bak \
           "s/pkgs.vim/pkgs.hello/" \
-          ~/.config/nix-darwin/flake.nix
+          /etc/nix-darwin/flake.nix
 
-        darwin-rebuild switch --flake ~/.config/nix-darwin#simple \
+        darwin-rebuild switch \
           --override-input nix-darwin . \
           --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2025-01-18
+- The default configuration path for all new installations
+  is `/etc/nix-darwin`. This was already the undocumented
+  default for `darwin-rebuild switch` when using flakes. This
+  is implemented by setting `environment.darwinConfig` to
+  `"/etc/nix-darwin/configuration.nix"` by default when
+  `system.stateVersion` ≥ 6.
+
 2024-09-10
 - The default Nix build user group ID is now set to 350 when
   `system.stateVersion` ≥ 5, to reflect the default for new Nix

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ Make sure to set `nixpkgs.hostPlatform` in your `configuration.nix` to either `x
 Unlike NixOS, `nix-darwin` does not have an installer, you can just run `darwin-rebuild switch` to install nix-darwin. As `darwin-rebuild` won't be installed in your `PATH` yet, you can use the following command:
 
 ```bash
-nix run nix-darwin -- switch
+# To use Nixpkgs unstable:
+nix run nix-darwin/master#darwin-rebuild -- switch
+# To use Nixpkgs 24.11:
+nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch
 ```
 
 ### Step 3. Using `nix-darwin`

--- a/README.md
+++ b/README.md
@@ -142,11 +142,7 @@ sudo nix-channel --update
 To install `nix-darwin`, you can just run `darwin-rebuild switch` to install nix-darwin. As `darwin-rebuild` won't be installed in your `PATH` yet, you can use the following command:
 
 ```bash
-# If you use Nixpkgs unstable (the default):
-nix-build https://github.com/LnL7/nix-darwin/archive/master.tar.gz -A darwin-rebuild
-# If you use Nixpkgs 24.11:
-nix-build https://github.com/LnL7/nix-darwin/archive/nix-darwin-24.11.tar.gz -A darwin-rebuild
-
+nix-build '<darwin>' -A darwin-rebuild
 ./result/bin/darwin-rebuild switch -I darwin-config=$HOME/.config/nix-darwin/configuration.nix
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ Despite being an experimental feature in Nix currently, nix-darwin recommends th
 <summary>Getting started from scratch</summary>
 <p></p>
 
-If you don't have an existing `configuration.nix`, you can run the following commands to generate a basic `flake.nix` inside `~/.config/nix-darwin`:
+If you don't have an existing `configuration.nix`, you can run the following commands to generate a basic `flake.nix` inside `/etc/nix-darwin`:
 
 ```bash
-mkdir -p ~/.config/nix-darwin
-cd ~/.config/nix-darwin
+sudo mkdir -p /etc/nix-darwin
+sudo chown $(id -nu):$(id -ng) /etc/nix-darwin
+cd /etc/nix-darwin
 
 # To use Nixpkgs unstable:
 nix flake init -t nix-darwin/master
@@ -88,7 +89,7 @@ Make sure to set `nixpkgs.hostPlatform` in your `configuration.nix` to either `x
 Unlike NixOS, `nix-darwin` does not have an installer, you can just run `darwin-rebuild switch` to install nix-darwin. As `darwin-rebuild` won't be installed in your `PATH` yet, you can use the following command:
 
 ```bash
-nix run nix-darwin -- switch --flake ~/.config/nix-darwin
+nix run nix-darwin -- switch
 ```
 
 ### Step 3. Using `nix-darwin`
@@ -96,7 +97,7 @@ nix run nix-darwin -- switch --flake ~/.config/nix-darwin
 After installing, you can run `darwin-rebuild` to apply changes to your system:
 
 ```bash
-darwin-rebuild switch --flake ~/.config/nix-darwin
+darwin-rebuild switch
 ```
 
 #### Using flake inputs
@@ -124,7 +125,7 @@ nix-darwin.lib.darwinSystem {
 
 ### Step 1. Creating `configuration.nix`
 
-Copy the [simple](./modules/examples/simple.nix) example to `~/.config/nix-darwin/configuration.nix`.
+Copy the [simple](./modules/examples/simple.nix) example to `/etc/nix-darwin/configuration.nix`.
 
 ### Step 2. Adding `nix-darwin` channel
 
@@ -143,7 +144,7 @@ To install `nix-darwin`, you can just run `darwin-rebuild switch` to install nix
 
 ```bash
 nix-build '<darwin>' -A darwin-rebuild
-./result/bin/darwin-rebuild switch -I darwin-config=$HOME/.config/nix-darwin/configuration.nix
+./result/bin/darwin-rebuild switch -I darwin-config=/etc/nix-darwin/configuration.nix
 ```
 
 ### Step 4. Using `nix-darwin`

--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -67,8 +67,24 @@ in
     };
 
     environment.darwinConfig = mkOption {
-      type = types.either types.path types.str;
-      default = "$HOME/.nixpkgs/darwin-configuration.nix";
+      type = types.nullOr (types.either types.path types.str);
+      default =
+        if config.nixpkgs.flake.setNixPath then
+          # Don’t set this for flake‐based systems.
+          null
+        else if config.system.stateVersion >= 6 then
+          "/etc/nix-darwin/configuration.nix"
+        else
+          "$HOME/.nixpkgs/darwin-configuration.nix";
+      defaultText = literalExpression ''
+        if config.nixpkgs.flake.setNixPath then
+          # Don’t set this for flake‐based systems.
+          null
+        else if config.system.stateVersion >= 6 then
+          "/etc/nix-darwin/configuration.nix"
+        else
+          "$HOME/.nixpkgs/darwin-configuration.nix"
+      '';
       description = ''
         The path of the darwin configuration.nix used to configure the system,
         this updates the default darwin-config entry in NIX_PATH. Since this

--- a/modules/examples/flake/flake.nix
+++ b/modules/examples/flake/flake.nix
@@ -27,7 +27,7 @@
 
       # Used for backwards compatibility, please read the changelog before changing.
       # $ darwin-rebuild changelog
-      system.stateVersion = 5;
+      system.stateVersion = 6;
 
       # The platform the configuration will be used on.
       nixpkgs.hostPlatform = "aarch64-darwin";

--- a/modules/examples/hydra.nix
+++ b/modules/examples/hydra.nix
@@ -43,5 +43,5 @@ in
     echo "ok"
   '';
 
-  system.stateVersion = 5;
+  system.stateVersion = 6;
 }

--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -199,7 +199,7 @@
   programs.zsh.enableFzfGit = true;
   programs.zsh.enableFzfHistory = true;
 
-  programs.zsh.variables.cfg = "$HOME/.config/nixpkgs/darwin/configuration.nix";
+  programs.zsh.variables.cfg = "/etc/nix-darwin/configuration.nix";
   programs.zsh.variables.darwin = "$HOME/.nix-defexpr/darwin";
   programs.zsh.variables.nixpkgs = "$HOME/.nix-defexpr/nixpkgs";
 
@@ -322,5 +322,5 @@
   nix.configureBuildUsers = true;
   nix.nrBuildUsers = 32;
 
-  system.stateVersion = 5;
+  system.stateVersion = 6;
 }

--- a/modules/examples/simple.nix
+++ b/modules/examples/simple.nix
@@ -7,13 +7,10 @@
     [ pkgs.vim
     ];
 
-  # Use custom location for configuration.nix.
-  environment.darwinConfig = "$HOME/.config/nix-darwin/configuration.nix";
-
   # Enable alternative shell support in nix-darwin.
   # programs.fish.enable = true;
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
-  system.stateVersion = 5;
+  system.stateVersion = 6;
 }

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -193,7 +193,7 @@ let
     darwinConfig=$(NIX_PATH=$nixPath nix-instantiate --find-file darwin-config) || true
     if ! test -e "$darwinConfig"; then
         echo "[1;31merror: Changed <darwin-config> but target does not exist, aborting activation[0m" >&2
-        echo "Create ''${darwinConfig:-~/.nixpkgs/darwin-configuration.nix} or set environment.darwinConfig:" >&2
+        echo "Create ''${darwinConfig:-/etc/nix-darwin/configuration.nix} or set environment.darwinConfig:" >&2
         echo >&2
         echo "    environment.darwinConfig = \"$(nix-instantiate --find-file darwin-config 2> /dev/null || echo '***')\";" >&2
         echo >&2

--- a/modules/system/version.nix
+++ b/modules/system/version.nix
@@ -51,7 +51,7 @@ in
     system.maxStateVersion = mkOption {
       internal = true;
       type = types.int;
-      default = 5;
+      default = 6;
     };
 
     system.darwinLabel = mkOption {


### PR DESCRIPTION
Split off from The Plan stack, where it becomes more important, but a good idea anyway given our general direction and to align the default between flake‐ and channel‐based setups. This is not a breaking change thanks to the `system.stateVersion` conditional (unless anyone is looking at `environment.darwinConfig` on a flake‐based setup, which I guess is possible although seems inadvisable), so we can do it now.