### PR TITLE
darwin-rebuild: pass `${extraBuildFlags[@]}` to `nix-instantiate`

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -171,8 +171,8 @@ if [ "$action" != build ]; then
 fi
 
 if [ "$action" = edit ]; then
-  darwinConfig=$(nix-instantiate --find-file darwin-config)
   if [ -z "$flake" ]; then
+    darwinConfig=$(nix-instantiate "${extraBuildFlags[@]}" --find-file darwin-config)
     exec "${EDITOR:-vi}" "$darwinConfig"
   else
     exec nix "${flakeFlags[@]}" edit "${extraLockFlags[@]}" -- "$flake#$flakeAttr"


### PR DESCRIPTION
Theoretically required for `darwin-rebuild edit -I darwin-config=…`, I guess. We also shouldn’t run it for flake‐based setups.