### PR TITLE
nix-tools: drop `nixPackage`, overwrite `$PATH` rather than prepending, set `$NIX_PATH`

### DIFF
--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -4,6 +4,7 @@ let
   nix-tools = pkgs.callPackage ../../pkgs/nix-tools {
     inherit (config.system) profile;
     inherit (config.environment) systemPath;
+    nixPath = lib.concatStringsSep ":" config.nix.nixPath;
   };
 
   darwin-uninstaller = pkgs.callPackage ../../pkgs/darwin-uninstaller { };

--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -4,7 +4,6 @@ let
   nix-tools = pkgs.callPackage ../../pkgs/nix-tools {
     inherit (config.system) profile;
     inherit (config.environment) systemPath;
-    nixPackage = config.nix.package;
   };
 
   darwin-uninstaller = pkgs.callPackage ../../pkgs/darwin-uninstaller { };

--- a/pkgs/nix-tools/darwin-option.sh
+++ b/pkgs/nix-tools/darwin-option.sh
@@ -1,7 +1,9 @@
 #! @shell@
 set -e
 set -o pipefail
+
 export PATH=@path@
+export NIX_PATH=${NIX_PATH:-@nixPath@}
 
 evalNix() {
   nix-instantiate --eval --strict "${extraEvalFlags[@]}" -E "with import <darwin> {}; $*" 2>/dev/null

--- a/pkgs/nix-tools/darwin-option.sh
+++ b/pkgs/nix-tools/darwin-option.sh
@@ -1,7 +1,7 @@
 #! @shell@
 set -e
 set -o pipefail
-export PATH=@path@:$PATH
+export PATH=@path@
 
 evalNix() {
   nix-instantiate --eval --strict "${extraEvalFlags[@]}" -E "with import <darwin> {}; $*" 2>/dev/null

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -1,8 +1,7 @@
 #! @shell@
 set -e
 set -o pipefail
-export PATH=@path@:$PATH
-
+export PATH=@path@
 
 showSyntax() {
   echo "darwin-rebuild [--help] {edit | switch | activate | build | check | changelog}" >&2

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -1,7 +1,9 @@
 #! @shell@
 set -e
 set -o pipefail
+
 export PATH=@path@
+export NIX_PATH=${NIX_PATH:-@nixPath@}
 
 showSyntax() {
   echo "darwin-rebuild [--help] {edit | switch | activate | build | check | changelog}" >&2

--- a/pkgs/nix-tools/default.nix
+++ b/pkgs/nix-tools/default.nix
@@ -5,7 +5,22 @@
 , substituteAll
 , stdenv
 , profile ? "/nix/var/nix/profiles/system"
-, systemPath ? "$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+, # This should be kept in sync with the default
+  # `environment.systemPath`. We err on side of including conditional
+  # things like the profile directories, since they’re more likely to
+  # help than hurt, and this default is mostly used for fresh
+  # installations anyway.
+  systemPath ? lib.concatStringsSep ":" [
+  "$HOME/.nix-profile/bin"
+  "/etc/profiles/per-user/$USER/bin"
+  "/run/current-system/sw/bin"
+  "/nix/var/nix/profiles/default/bin"
+  "/usr/local/bin"
+  "/usr/bin"
+  "/bin"
+  "/usr/sbin"
+  "/sbin"
+]
 }:
 
 let

--- a/pkgs/nix-tools/default.nix
+++ b/pkgs/nix-tools/default.nix
@@ -5,12 +5,11 @@
 , substituteAll
 , stdenv
 , profile ? "/nix/var/nix/profiles/system"
-, nixPackage ? "/nix/var/nix/profiles/default"
 , systemPath ? "$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 }:
 
 let
-  extraPath = lib.makeBinPath [ nixPackage coreutils jq git ];
+  extraPath = lib.makeBinPath [ coreutils jq git ];
 
   writeProgram = name: env: src:
     substituteAll ({

--- a/pkgs/nix-tools/default.nix
+++ b/pkgs/nix-tools/default.nix
@@ -21,6 +21,11 @@
   "/usr/sbin"
   "/sbin"
 ]
+, # This should be kept in sync with the default `nix.nixPath`.
+  nixPath ? lib.concatStringsSep ":" [
+  "darwin-config=/etc/nix-darwin/configuration.nix"
+  "/nix/var/nix/profiles/per-user/root/channels"
+]
 }:
 
 let
@@ -39,14 +44,14 @@ in
 {
   darwin-option = writeProgram "darwin-option"
     {
-      inherit path;
+      inherit path nixPath;
       inherit (stdenv) shell;
     }
     ./darwin-option.sh;
 
   darwin-rebuild = writeProgram "darwin-rebuild"
     {
-      inherit path profile;
+      inherit path nixPath profile;
       inherit (stdenv) shell;
       postInstall = ''
         mkdir -p $out/share/zsh/site-functions


### PR DESCRIPTION
I wonder if we actually want nix-darwin specific things like `/etc/profiles/per-user/$USER/bin` in the default path here. Probably it doesn’t hurt to, especially for the uninstaller, but I guess it could cause issues with reinstalling after a weird half‐uninstalled nix-darwin setup or something. It’ll refer to `root`’s packages soon enough anyway…