### PR TITLE
Add new option for double clicking the window title bar

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -7,6 +7,21 @@ let
   inherit (config.lib.defaults.types) floatWithDeprecationError;
 in {
   options = {
+    system.defaults.NSGlobalDomain.AppleActionOnDoubleClick = mkOption {
+      type = types.nullOr (
+        types.enum [
+          "Minimize"
+          "Zoom"
+          "Fill"
+          "None"
+        ]
+      );
+      default = null;
+      description = ''
+        Behaviour of double clicking a windows title bar.
+      '';
+    };
+
     system.defaults.NSGlobalDomain.AppleShowAllFiles = mkOption {
       type = types.nullOr types.bool;
       default = null;

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -1,3 +1,8 @@
+defaults write -g 'AppleActionOnDoubleClick' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<string>Minimize</string>
+</plist>'
 defaults write -g 'AppleEnableMouseSwipeNavigateWithScrolls' $'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -1,6 +1,7 @@
 { config, pkgs, lib, ... }:
 
 {
+  system.defaults.NSGlobalDomain.AppleActionOnDoubleClick = "Minimize";
   system.defaults.NSGlobalDomain.AppleShowAllFiles = true;
   system.defaults.NSGlobalDomain.AppleEnableMouseSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleEnableSwipeNavigateWithScrolls = false;


### PR DESCRIPTION
Couldn't find this option already. 
Found the option using `defaults read` and exporting the results to a file, then comparing the different values after changing the setting
This was done on macOS Sequoia 15.2

![Screenshot 2025-01-20 at 21 04 40](https://github.com/user-attachments/assets/b088a798-ff5e-4f69-8622-8922353c89e1)
