### PR TITLE
[24.11] Add support for additional window tiling options

### DIFF
--- a/modules/system/defaults/WindowManager.nix
+++ b/modules/system/defaults/WindowManager.nix
@@ -56,11 +56,36 @@ with lib;
         Hide items in Stage Manager.
       '';
     };
+
+    system.defaults.WindowManager.EnableTilingByEdgeDrag = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Enable dragging windows to screen edges to tile them. The default is true.
+      '';
+    };
+
+    system.defaults.WindowManager.EnableTopTilingByEdgeDrag = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Enable dragging windows to the menu bar to fill the screen. The default is true.
+      '';
+    };
+
+    system.defaults.WindowManager.EnableTilingOptionAccelerator = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Enable holding alt to tile windows. The default is true.
+      '';
+    };
+
     system.defaults.WindowManager.EnableTiledWindowMargins = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = ''
-        Enable Window Margins. The default is true.
+        Enable window margins when tiling windows. The default is true.
       '';
     };
 

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -524,6 +524,21 @@ defaults write com.apple.WindowManager 'EnableTiledWindowMargins' $'<?xml versio
 <plist version="1.0">
 <true/>
 </plist>'
+defaults write com.apple.WindowManager 'EnableTilingByEdgeDrag' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<true/>
+</plist>'
+defaults write com.apple.WindowManager 'EnableTilingOptionAccelerator' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<true/>
+</plist>'
+defaults write com.apple.WindowManager 'EnableTopTilingByEdgeDrag' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<true/>
+</plist>'
 defaults write com.apple.WindowManager 'GloballyEnabled' $'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -96,6 +96,9 @@
   system.defaults.WindowManager.AppWindowGroupingBehavior = true;
   system.defaults.WindowManager.StandardHideDesktopIcons = false;
   system.defaults.WindowManager.HideDesktop = false;
+  system.defaults.WindowManager.EnableTilingByEdgeDrag = true;
+  system.defaults.WindowManager.EnableTopTilingByEdgeDrag = true;
+  system.defaults.WindowManager.EnableTilingOptionAccelerator = true;
   system.defaults.WindowManager.EnableTiledWindowMargins = true;
   system.defaults.WindowManager.StandardHideWidgets = true;
   system.defaults.WindowManager.StageManagerHideWidgets = true;


### PR DESCRIPTION
This adds support for the following defaults:

- com.apple.WindowManager.EnableTilingByEdgeDrag
- com.apple.WindowManager.EnableTopTilingByEdgeDrag
- com.apple.WindowManager.EnableTilingOptionAccelerator

(cherry picked from commit 4075a3c23aa7996acc960e61df9f21038136d08a)