### PR TITLE
[24.11] eval-config: omit `enableNixpkgsReleaseCheck` from `lib.evalModules`

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -77,7 +77,7 @@ let
     };
   };
 
-  eval = lib.evalModules (builtins.removeAttrs args [ "lib" ] // {
+  eval = lib.evalModules (builtins.removeAttrs args [ "lib" "enableNixpkgsReleaseCheck" ] // {
     class = "darwin";
     modules = modules ++ [ argsModule ] ++ baseModules;
     specialArgs = { modulesPath = builtins.toString ./modules; } // specialArgs;


### PR DESCRIPTION
Backport of https://github.com/LnL7/nix-darwin/pull/1290.