### PR TITLE
Add known hash for determinate-nixd 0.3.0

### DIFF
--- a/doc/known-files/8a9ebee68a25f8e1a74f510059e4690f6c2c36842e9bad065060cacb178b3670
+++ b/doc/known-files/8a9ebee68a25f8e1a74f510059e4690f6c2c36842e9bad065060cacb178b3670
@@ -1,0 +1,21 @@
+# DETERMINATE NIX CONFIG
+# do not modify! this file will be replaced!
+# user modification can go in nix.custom.conf
+
+!include nix.custom.conf
+
+max-jobs = auto
+bash-prompt-prefix = (nix:$name)\040
+extra-experimental-features = nix-command flakes
+
+netrc-file = /nix/var/determinate/netrc
+post-build-hook = /nix/var/determinate/post-build-hook.sh
+
+always-allow-substitutes = true
+extra-substituters = https://cache.flakehub.com
+extra-trusted-public-keys = cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM= cache.flakehub.com-4:Asi8qIv291s0aYLyH6IOnr5Kf6+OF14WVjkE6t3xMio= cache.flakehub.com-5:zB96CRlL7tiPtzA9/WKyPkp3A2vqxqgdgyTVNGShPDU= cache.flakehub.com-6:W4EGFwAGgBj3he7c5fNh9NkOXw0PUVaxygCVKeuvaqU= cache.flakehub.com-7:mvxJ2DZVHn/kRxlIaxYNMuDG1OvMckZu32um1TadOR8= cache.flakehub.com-8:moO+OVS0mnTjBTcOUh2kYLQEd59ExzyoW1QgQ8XAARQ= cache.flakehub.com-9:wChaSeTI6TeCuV/Sg2513ZIM9i0qJaYsF+lZCXg0J6o= cache.flakehub.com-10:2GqeNlIp6AKp4EF2MVbE1kBOp9iBSyo0UPR9KoR0o1Y=
+
+upgrade-nix-store-path-url = https://install.determinate.systems/nix-upgrade/stable/universal
+
+extra-nix-path = nixpkgs=flake:https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/*.tar.gz
+ssl-cert-file = /etc/nix/macos-keychain.crt

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -706,6 +706,7 @@ in
       "6bb8d6b0dd16b44ee793a9b8382dac76c926e4c16ffb8ddd2bb4884d1ca3f811"  # DeterminateSystems Nix installer 0.34.0
       "24797ac05542ff8b52910efc77870faa5f9e3275097227ea4e50c430a5f72916"  # lix-installer 0.17.1 with flakes
       "b027b5cad320b5b8123d9d0db9f815c3f3921596c26dc3c471457098e4d3cc40"  # lix-installer 0.17.1 without flakes
+      "8a9ebee68a25f8e1a74f510059e4690f6c2c36842e9bad065060cacb178b3670"  # determinate-nixd 0.3.0
     ];
 
     environment.etc."nix/registry.json".text = builtins.toJSON {


### PR DESCRIPTION
Hey,

I bumped into the same issue as in #1044 but for the `determinate-nixd` instead of the DetSys installer.

How to repeat:

1. Install Determinate nixd from: https://docs.determinate.systems/getting-started/
2. Try to install a nix-darwin from a flake:
```
$ nix run --extra-experimental-features "nix-command flakes" nix-darwin -- switch --flake .
building the system configuration...
warning: 'https://cache.flakehub.com' does not appear to be a binary cache
error: Unexpected files in /etc, aborting activation
The following files have unrecognized content and would be overwritten:

  /etc/nix/nix.conf

Please check there is nothing critical in these files, rename them by adding .before-nix-darwin to the end, and then try again.
```
3. Fork this repository and clone it locally:
```
$ git clone https://github.com/LnL7/nix-darwin/
$ cd nix-darwin
```
4. Copy the /etc/nix/nix.conf from the `determinate-nixd`:
```
cp /etc/nix/nix.conf ./doc/known-files/$(sha256sum /etc/nix/nix.conf | cut -d " " -f1)
```
5. Add the known sha256 hash into `modules/nix/default.nix`
6. Commit and Create the pr:
```
$ git add . && git commit -am "Add known hash for determinate-nixd $(determinate-nixd --version)"
$ gh pr create
```