### PR TITLE
activation-scripts: add `/usr/sbin` and `/sbin` for user activation

### DIFF
--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -91,7 +91,7 @@ in
       #! ${stdenv.shell}
       set -e
       set -o pipefail
-      export PATH="${pkgs.gnugrep}/bin:${pkgs.coreutils}/bin:@out@/sw/bin:/usr/bin:/bin"
+      export PATH="${pkgs.gnugrep}/bin:${pkgs.coreutils}/bin:@out@/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
       systemConfig=@out@
 


### PR DESCRIPTION
Some binaries inside these folders can be run without `sudo` like `softwareupdate`.