### PR TITLE
checks: remove `darwinChanges`

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -8,22 +8,6 @@ let
 
   cfg = config.system.checks;
 
-  darwinChanges = ''
-    darwinChanges=/dev/null
-    if test -e /run/current-system/darwin-changes; then
-      darwinChanges=/run/current-system/darwin-changes
-    fi
-
-    darwinChanges=$(diff --changed-group-format='%>' --unchanged-group-format= /run/current-system/darwin-changes $systemConfig/darwin-changes 2> /dev/null) || true
-    if test -n "$darwinChanges"; then
-      echo >&2
-      echo "[1;1mCHANGELOG[0m" >&2
-      echo >&2
-      echo "$darwinChanges" >&2
-      echo >&2
-    fi
-  '';
-
   macOSVersion = ''
     IFS=. read -ra osVersion <<<"$(sw_vers --productVersion)"
     if (( osVersion[0] < 11 || (osVersion[0] == 11 && osVersion[1] < 3) )); then
@@ -368,7 +352,6 @@ in
   config = {
 
     system.checks.text = mkMerge [
-      darwinChanges
       (mkIf cfg.verifyMacOSVersion macOSVersion)
       (mkIf (cfg.verifyBuildUsers && !config.nix.configureBuildUsers) oldBuildUsers)
       (mkIf cfg.verifyBuildUsers buildUsers)


### PR DESCRIPTION
It seems like this has been broken since 26bab2fd3290b42a3df54db291f0d8775f128857 from 2018; macOS `diff(1)` does not support these arguments and the `$PATH` has been fixed since that point. Before that, it would presumably only have worked if you added GNU diffutils to `environment.systemPackages`.

Proactively notifying users about breaking changes isn’t a bad idea, but the activation script doesn’t seem like the right place for it, and as it’s non‐blocking it’s likely that even if it worked it would get drowned out by the later output anyway. I’d like to move the changelog into release notes as part of the manual, which would requires changes to this anyway. Since it’s been broken for almost seven years anyway, let’s just drop it for now and revisit later.