### PR TITLE
readme: add --extra-experimental-features flag to creating flake.nix …

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ sudo chown $(id -nu):$(id -ng) /etc/nix-darwin
 cd /etc/nix-darwin
 
 # To use Nixpkgs unstable:
-nix flake init -t nix-darwin/master
+nix flake init -t nix-darwin/master --extra-experimental-features "nix-command flakes"
 # To use Nixpkgs 24.11:
-nix flake init -t nix-darwin/nix-darwin-24.11
+nix flake init -t nix-darwin/nix-darwin-24.11 --extra-experimental-features "nix-command flakes"
 
 sed -i '' "s/simple/$(scutil --get LocalHostName)/" flake.nix
 ```


### PR DESCRIPTION
I noticed that the `--extra-experimental-features` flag was missing in [Step 1. Creating `flake.nix`](https://github.com/LnL7/nix-darwin?tab=readme-ov-file#step-1-creating-flakenix) of the Getting started in the README.

(Sorry if this isn't a good pull request. I'm new to Nix and this is my first time really making a pull request to a public repository)