### PR TITLE
Revert "nixpkgs: make config.nixpkgs.{buildPlatform,hostPlatform} write only"

### DIFF
--- a/modules/nix/nixpkgs.nix
+++ b/modules/nix/nixpkgs.nix
@@ -73,10 +73,7 @@ let
   defaultPkgs =
     if opt.hostPlatform.isDefined then
       let
-        isCross =
-          !(lib.systems.equals (lib.systems.elaborate cfg.buildPlatform) (
-            lib.systems.elaborate cfg.hostPlatform
-          ));
+        isCross = cfg.buildPlatform != cfg.hostPlatform;
         systemArgs =
           if isCross then
             {
@@ -168,10 +165,13 @@ in
     };
 
     hostPlatform = lib.mkOption {
-      type = lib.types.either lib.types.str lib.types.attrs;
+      type = lib.types.either lib.types.str lib.types.attrs; # TODO utilize lib.systems.parsedPlatform
       example = {
         system = "aarch64-darwin";
       };
+      # Make sure that the final value has all fields for sake of other modules
+      # referring to this. TODO make `lib.systems` itself use the module system.
+      apply = lib.systems.elaborate;
       description = ''
         Specifies the platform where the nix-darwin configuration will run.
 
@@ -182,13 +182,22 @@ in
     };
 
     buildPlatform = lib.mkOption {
-      type = lib.types.either lib.types.str lib.types.attrs;
+      type = lib.types.either lib.types.str lib.types.attrs; # TODO utilize lib.systems.parsedPlatform
       default = cfg.hostPlatform;
       example = {
         system = "x86_64-darwin";
       };
       # Make sure that the final value has all fields for sake of other modules
       # referring to this.
+      apply =
+        inputBuildPlatform:
+        let
+          elaborated = lib.systems.elaborate inputBuildPlatform;
+        in
+        if lib.systems.equals elaborated cfg.hostPlatform then
+          cfg.hostPlatform # make identical, so that `==` equality works; see https://github.com/NixOS/nixpkgs/issues/278001
+        else
+          elaborated;
       defaultText = lib.literalExpression ''config.nixpkgs.hostPlatform'';
       description = ''
         Specifies the platform on which nix-darwin should be built.
@@ -310,16 +319,6 @@ in
 
           Defined in:
           ${lib.concatMapStringsSep "\n" (file: "  - ${file}") opt.config.files}
-        '';
-      }
-      {
-        assertion =
-          (opt.hostPlatform.isDefined -> builtins.isAttrs cfg.buildPlatform -> !(cfg.buildPlatform ? parsed))
-          && (opt.hostPlatform.isDefined -> builtins.isAttrs cfg.hostPlatform -> !(cfg.hostPlatform ? parsed));
-        message = ''
-          Passing fully elaborated systems to `nixpkgs.localSystem`, `nixpkgs.crossSystem`, `nixpkgs.buildPlatform`
-          or `nixpkgs.hostPlatform` will break composability of package sets in nixpkgs. For example, pkgs.pkgsStatic
-          would not work in modules anymore.
         '';
       }
     ];


### PR DESCRIPTION
This was reverted upstream in 0b47fba23078cc01251b136c7af0127abd57112b.

This reverts commit 7c72c013b160627540b8b465a05ba258f47a16d8.

---

Keeping the module in sync with NixOS. This should only be merged once https://nixpk.gs/pr-tracker.html?pr=379615 is green on all channels, since otherwise it’ll break people’s systems again.