### PR TITLE
Add exp-features option to run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Unlike NixOS, `nix-darwin` does not have an installer, you can just run `darwin-
 
 ```bash
 # To use Nixpkgs unstable:
-nix run nix-darwin/master#darwin-rebuild -- switch
+nix --extra-experimental-features "nix-command flakes" run nix-darwin/master#darwin-rebuild -- switch
 # To use Nixpkgs 24.11:
-nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch
+nix --extra-experimental-features "nix-command flakes" run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch
 ```
 
 ### Step 3. Using `nix-darwin`


### PR DESCRIPTION
As of early 2025, after a fresh nix install, `flakes` and `nix-command` are active. One can manually activate them in `/etc/nix/nix.conf` but that will cause a conflict during the `nix-darwin` install, which might be confusing to beginners. 

Assuming most people will follow this tutorial after coming from a fresh nix install, having the options inlined in the example command is probably the best approach.