### PR TITLE
homebrew: use `mas` from Nixpkgs

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -708,9 +708,6 @@ in
       description = ''
         Applications to install from Mac App Store using {command}`mas`.
 
-        When this option is used, `"mas"` is automatically added to
-        [](#opt-homebrew.brews).
-
         Note that you need to be signed into the Mac App Store for {command}`mas` to
         successfully install and upgrade applications, and that unfortunately apps removed from this
         option will not be uninstalled automatically even if
@@ -768,8 +765,7 @@ in
     ];
 
     homebrew.brews =
-      optional (cfg.masApps != { }) "mas"
-      ++ optional (cfg.whalebrews != [ ]) "whalebrew";
+      optional (cfg.whalebrews != [ ]) "whalebrew";
 
     homebrew.brewfile =
       "# Created by `nix-darwin`'s `homebrew` module\n\n"
@@ -789,7 +785,8 @@ in
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
       if [ -f "${cfg.brewPrefix}/brew" ]; then
-        PATH="${cfg.brewPrefix}":$PATH ${cfg.onActivation.brewBundleCmd}
+        PATH="${cfg.brewPrefix}:${lib.makeBinPath [ pkgs.mas ]}:$PATH" \
+          ${cfg.onActivation.brewBundleCmd}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2
       fi


### PR DESCRIPTION
Currently, setting `homebrew.masApps` causes `"mas"` to automatically be added to `homebrew.brews`. Users who want to use Homebrew only for managing App Store apps and casks, like me, can override this by setting `homebrew.brews = lib.mkForce [ ];` and adding Nixpkgs’ `mas` to their `environment.systemPackages`.

When the activation script path no longer depends on the built configuration’s `environment.systemPackages`, this will no longer work. Since this was originally added before `mas` was packaged in Nixpkgs and we now have a perfectly serviceable binary package, we can add it to the `$PATH` when invoking Homebrew and skip the automatic formula installation.

As the Homebrew `bin` directory still comes first, users who specifically want the formula can restore the previous behaviour by explicitly adding `"mas"` to `homebrew.brews`.

Closes: #1314

---

This should probably wait until https://github.com/NixOS/nixpkgs/pull/379858 is merged since the Nixpkgs `mas` package is quite old right now (although it’s been working fine for me). I’ll take a look at that PR in the next couple days if nobody else gets around to it.

cc @sellout