### PR TITLE
nix: place `extra-`prefixed settings after their non-prefixed variants

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -51,13 +51,16 @@ let
 
       mkKeyValuePairs = attrs: concatStringsSep "\n" (mapAttrsToList mkKeyValue attrs);
 
+      isExtra = key: hasPrefix "extra-" key;
+
     in
     pkgs.writeTextFile {
       name = "nix.conf";
       text = ''
         # WARNING: this file is generated from the nix.* options in
         # your nix-darwin configuration. Do not edit it!
-        ${mkKeyValuePairs cfg.settings}
+        ${mkKeyValuePairs (filterAttrs (key: value: !(isExtra key)) cfg.settings)}
+        ${mkKeyValuePairs (filterAttrs (key: value: isExtra key) cfg.settings)}
         ${cfg.extraOptions}
       '';
       checkPhase =


### PR DESCRIPTION
Fixes #626.

Essentially a copy of NixOS's workaround: https://github.com/NixOS/nixpkgs/pull/278064

#### Description

Nix has somewhat surprising semantics when `extra-`prefixed settings are used in the same file as their non-prefixed siblings. Any `extra-`prefixed setting is ignored if it is placed _before_ its respective non-prefixed setting.

#### Reproduce

Add an extra substituter to your config:

```nix
{
  nix.settings.extra-substituters = [
    "https://devenv.cachix.org"
  ];
}
```

The `nix.conf` in `/etc/nix/nix.conf` will be sorted alphabetically:
```
# WARNING: this file is generated from the nix.* options in
# your nix-darwin configuration. Do not edit it!
...
extra-substituters = https://devenv.cachix.org
...
substituters = https://cache.nixos.org
```

Verify that the extra substituter is missing with `nix config show`.

Nix ignores the `--extra`-prefixed keys if they're followed by their non-prefixed siblings, as documented in https://github.com/NixOS/nix/issues/9487.