### PR TITLE
[24.11] treewide: add checks for `nix.enable`

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -154,6 +154,14 @@ let
     })
   ];
 
+  managedDefault = name: default: {
+    default = if cfg.enable then default else throw ''
+      ${name}: accessed when `nix.enable` is off; this is a bug in
+      nix-darwin or a third‐party module
+    '';
+    defaultText = default;
+  };
+
 in
 
 {
@@ -211,9 +219,7 @@ in
 
       package = mkOption {
         type = types.package;
-        default = warnIf (!cfg.enable)
-          "nix.package: accessed when `nix.enable` is off; this is a bug"
-          pkgs.nix;
+        inherit (managedDefault "nix.package" pkgs.nix) default;
         defaultText = literalExpression "pkgs.nix";
         description = ''
           This option specifies the Nix package instance to use throughout the system.
@@ -242,7 +248,7 @@ in
 
       distributedBuilds = mkOption {
         type = types.bool;
-        default = false;
+        inherit (managedDefault "nix.distributedBuilds" false) default defaultText;
         description = ''
           Whether to distribute builds to the machines listed in
           {option}`nix.buildMachines`.
@@ -252,7 +258,7 @@ in
       # Not in NixOS module
       daemonProcessType = mkOption {
         type = types.enum [ "Background" "Standard" "Adaptive" "Interactive" ];
-        default = "Standard";
+        inherit (managedDefault "nix.daemonProcessType" "Standard") default defaultText;
         description = ''
           Nix daemon process resource limits class. These limits propagate to
           build processes. `Standard` is the default process type
@@ -267,7 +273,7 @@ in
       # Not in NixOS module
       daemonIOLowPriority = mkOption {
         type = types.bool;
-        default = false;
+        inherit (managedDefault "nix.daemonIOLowPriority" false) default defaultText;
         description = ''
           Whether the Nix daemon process should considered to be low priority when
           doing file system I/O.
@@ -395,7 +401,7 @@ in
             };
           };
         });
-        default = [ ];
+        inherit (managedDefault "nix.buildMachines" [ ]) default defaultText;
         description = ''
           This option lists the machines to be used if distributed builds are
           enabled (see {option}`nix.distributedBuilds`).
@@ -409,7 +415,7 @@ in
       envVars = mkOption {
         type = types.attrs;
         internal = true;
-        default = { };
+        inherit (managedDefault "nix.envVars" { }) default defaultText;
         description = "Environment variables used by Nix.";
       };
 
@@ -424,6 +430,7 @@ in
 
       nrBuildUsers = mkOption {
         type = types.int;
+        inherit (managedDefault "nix.nrBuildUsers" 0) default defaultText;
         description = ''
           Number of `nixbld` user accounts created to
           perform secure concurrent builds.  If you receive an error
@@ -451,11 +458,13 @@ in
       # Definition differs substantially from NixOS module
       nixPath = mkOption {
         type = nixPathType;
-        default = lib.optionals cfg.channel.enable [
-          # Include default path <darwin-config>.
-          { darwin-config = "${config.environment.darwinConfig}"; }
-          "/nix/var/nix/profiles/per-user/root/channels"
-        ];
+        inherit (managedDefault "nix.nixPath" (
+          lib.optionals cfg.channel.enable [
+            # Include default path <darwin-config>.
+            { darwin-config = "${config.environment.darwinConfig}"; }
+            "/nix/var/nix/profiles/per-user/root/channels"
+          ]
+        )) default;
 
         defaultText = lib.literalExpression ''
           lib.optionals cfg.channel.enable [
@@ -477,7 +486,7 @@ in
 
       checkConfig = mkOption {
         type = types.bool;
-        default = true;
+        inherit (managedDefault "nix.checkConfig" true) default defaultText;
         description = ''
           If enabled (the default), checks for data type mismatches and that Nix
           can parse the generated nix.conf.
@@ -538,7 +547,7 @@ in
             };
           }
         ));
-        default = { };
+        inherit (managedDefault "nix.registry" { }) default defaultText;
         description = ''
           A system-wide flake registry.
         '';
@@ -546,7 +555,7 @@ in
 
       extraOptions = mkOption {
         type = types.lines;
-        default = "";
+        inherit (managedDefault "nix.extraOptions" "") default defaultText;
         example = ''
           keep-outputs = true
           keep-derivations = true
@@ -715,7 +724,7 @@ in
             };
           };
         };
-        default = { };
+        inherit (managedDefault "nix.settings" { }) default defaultText;
         description = ''
           Configuration for Nix, see
           <https://nixos.org/manual/nix/stable/#sec-conf-file>

--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -160,6 +160,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.nix.enable;
+        message = ''`nix.linux-builder.enable` requires `nix.enable`'';
+      }
+    ];
+
     system.activationScripts.preActivation.text = ''
       mkdir -p ${cfg.workingDirectory}
     '';

--- a/modules/nix/nixpkgs-flake.nix
+++ b/modules/nix/nixpkgs-flake.nix
@@ -37,8 +37,8 @@ in
     setNixPath = mkOption {
       type = types.bool;
 
-      default = cfg.source != null;
-      defaultText = "config.nixpkgs.flake.source != null";
+      default = config.nix.enable && cfg.source != null;
+      defaultText = literalExpression ''config.nix.enable && nixpkgs.flake.source != null'';
 
       description = ''
         Whether to set {env}`NIX_PATH` to include `nixpkgs=flake:nixpkgs` such that `<nixpkgs>`
@@ -57,8 +57,8 @@ in
     setFlakeRegistry = mkOption {
       type = types.bool;
 
-      default = cfg.source != null;
-      defaultText = "config.nixpkgs.flake.source != null";
+      default = config.nix.enable && cfg.source != null;
+      defaultText = literalExpression ''config.nix.enable && config.nixpkgs.flake.source != null'';
 
       description = ''
         Whether to pin nixpkgs in the system-wide flake registry (`/etc/nix/registry.json`) to the
@@ -84,6 +84,18 @@ in
             Setting `nixpkgs.flake.setNixPath` requires that `nixpkgs.flake.setFlakeRegistry` also
             be set, since it is implemented in terms of indirection through the flake registry.
           '';
+        }
+
+        # TODO: Upstream these to NixOS.
+
+        {
+          assertion = cfg.setNixPath -> config.nix.enable;
+          message = ''`nixpkgs.flake.setNixPath` requires `nix.enable`'';
+        }
+
+        {
+          assertion = cfg.setFlakeRegistry -> config.nix.enable;
+          message = ''`nixpkgs.flake.setFlakeRegistry` requires `nix.enable`'';
         }
       ];
     }

--- a/modules/services/activate-system/default.nix
+++ b/modules/services/activate-system/default.nix
@@ -21,7 +21,9 @@
         ln -sfn $(cat ${config.system.profile}/systemConfig) /run/current-system
 
         # Prevent the current configuration from being garbage-collected.
-        ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+        if [[ -d /nix/var/nix/gcroots ]]; then
+          ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+        fi
 
         ${config.system.activationScripts.etcChecks.text}
         ${config.system.activationScripts.etc.text}

--- a/modules/services/cachix-agent.nix
+++ b/modules/services/cachix-agent.nix
@@ -51,6 +51,14 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # TODO: Upstream this to NixOS.
+    assertions = [
+      {
+        assertion = config.nix.enable;
+        message = ''`services.cachix-agent.enable` requires `nix.enable`'';
+      }
+    ];
+
     launchd.daemons.cachix-agent = {
       script = ''
         . ${cfg.credentialsFile}

--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -13,6 +13,11 @@ in
 {
   config.assertions = flatten (
     flip mapAttrsToList config.services.github-runners (name: cfg: map (mkIf cfg.enable) [
+      # TODO: Upstream this to NixOS.
+      {
+        assertion = config.nix.enable;
+        message = ''`services.github-runners.${name}.enable` requires `nix.enable`'';
+      }
       {
         assertion = (cfg.user == null && cfg.group == null) || (cfg.user != null);
         message = "`services.github-runners.${name}`: Either set `user` and `group` to `null` to have nix-darwin manage them or set at least `user` explicitly";

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -22,6 +22,14 @@ in
   };
 
   config = mkIf cfg.enable {
+    # TODO: Upstream this to NixOS.
+    assertions = [
+      {
+        assertion = config.nix.enable;
+        message = ''`services.hercules-ci-agent.enable` requires `nix.enable`'';
+      }
+    ];
+
     launchd.daemons.hercules-ci-agent = {
       script = "exec ${cfg.package}/bin/hercules-ci-agent --config ${cfg.tomlFile}";
 

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -29,6 +29,14 @@ in
   };
 
   config = mkIf cfg.enable {
+    # TODO: Upstream this to NixOS.
+    assertions = [
+      {
+        assertion = config.nix.enable;
+        message = ''`services.lorri.enable` requires `nix.enable`'';
+      }
+    ];
+
     environment.systemPackages = [ pkgs.lorri ];
     launchd.user.agents.lorri = {
       command = with pkgs; "${lorri}/bin/lorri daemon";

--- a/modules/services/nix-gc/default.nix
+++ b/modules/services/nix-gc/default.nix
@@ -62,15 +62,20 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.automatic {
+  config = {
+    assertions = [
+      {
+        assertion = cfg.automatic -> config.nix.enable;
+        message = ''nix.gc.automatic requires nix.enable'';
+      }
+    ];
 
-    launchd.daemons.nix-gc = {
+    launchd.daemons.nix-gc = mkIf cfg.automatic {
       command = "${config.nix.package}/bin/nix-collect-garbage ${cfg.options}";
       environment.NIX_REMOTE = optionalString config.nix.useDaemon "daemon";
       serviceConfig.RunAtLoad = false;
       serviceConfig.StartCalendarInterval = cfg.interval;
       serviceConfig.UserName = cfg.user;
     };
-
   };
 }

--- a/modules/services/nix-optimise/default.nix
+++ b/modules/services/nix-optimise/default.nix
@@ -58,9 +58,15 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.automatic {
+  config = {
+    assertions = [
+      {
+        assertion = cfg.automatic -> config.nix.enable;
+        message = ''nix.optimise.automatic requires nix.enable'';
+      }
+    ];
 
-    launchd.daemons.nix-optimise = {
+    launchd.daemons.nix-optimise = mkIf cfg.automatic {
       environment.NIX_REMOTE = optionalString config.nix.useDaemon "daemon";
       command = "${lib.getExe' config.nix.package "nix-store"} --optimise";
       serviceConfig = {
@@ -69,6 +75,5 @@ in
         UserName = cfg.user;
       };
     };
-
   };
 }

--- a/modules/services/ofborg/default.nix
+++ b/modules/services/ofborg/default.nix
@@ -46,6 +46,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.nix.enable;
+        message = ''`services.ofborg.enable` requires `nix.enable`'';
+      }
+    ];
+
     warnings = mkIf (isDerivation cfg.configFile) [
       "services.ofborg.configFile is a derivation, credentials will be world readable"
     ];

--- a/modules/system/activation-scripts.nix
+++ b/modules/system/activation-scripts.nix
@@ -109,7 +109,9 @@ in
       ln -sfn "$(readlink -f "$systemConfig")" /run/current-system
 
       # Prevent the current configuration from being garbage-collected.
-      ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+      if [[ -d /nix/var/nix/gcroots ]]; then
+        ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+      fi
 
       exit $_status
     '';

--- a/tests/nix-enable.nix
+++ b/tests/nix-enable.nix
@@ -2,7 +2,6 @@
 
 {
   nix.enable = false;
-  nix.package = throw "`nix.package` used when `nix.enable` is turned off";
 
   test = ''
     printf >&2 'checking for unexpected Nix binary in /sw/bin\n'


### PR DESCRIPTION
Backport of https://github.com/LnL7/nix-darwin/pull/1332, with the inapplicable https://github.com/LnL7/nix-darwin/commit/d677e3e844e21789c6f39a90aacadf6dc777ca42 omitted and conflicts resolved. Tested with `nix.enable` on and off.

---

**Note:** This work was funded by Determinate Systems.