### PR TITLE
flake: make lib an option of darwinSystem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       evalConfig = import ./eval-config.nix;
 
       darwinSystem = args@{ modules, ... }: self.lib.evalConfig (
-        { inherit (nixpkgs) lib; }
+        { lib = args.lib or nixpkgs.lib; }
         // nixpkgs.lib.optionalAttrs (args ? pkgs) { inherit (args.pkgs) lib; }
         // builtins.removeAttrs args [ "system" "pkgs" "inputs" ]
         // {


### PR DESCRIPTION
With `nixosSystem` you do this, so you can add your own custom functions to lib.
```
let lib = (_: super: { custom = import ./lib.nix { lib = super; }; });
in nixosConfigurations.host1 = lib.nixosSystem { ... }
```

This allows you to pass `lib` to `darwinSystem` so you can use the custom functions in `nix-darwin`.