### PR TITLE
[24.11] homebrew: remove --no-lock flag

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -137,7 +137,7 @@ let
     config = {
       brewBundleCmd = concatStringsSep " " (
         optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
-        ++ [ "brew bundle --file='${brewfileFile}' --no-lock" ]
+        ++ [ "brew bundle --file='${brewfileFile}'" ]
         ++ optional (!config.upgrade) "--no-upgrade"
         ++ optional (config.cleanup == "uninstall") "--cleanup"
         ++ optional (config.cleanup == "zap") "--cleanup --zap"


### PR DESCRIPTION
backport of #1362

(cherry picked from commit 991bb2f6d46fc2ff7990913c173afdb0318314cb)

closes #1363