### PR TITLE
Fix merging of system.defaults.CustomUserPreferences

### DIFF
--- a/modules/system/defaults/CustomPreferences.nix
+++ b/modules/system/defaults/CustomPreferences.nix
@@ -2,10 +2,25 @@
 
 with lib;
 
-{
+let
+  valueType = with lib.types; nullOr (oneOf [
+    bool
+    int
+    float
+    str
+    path
+    (attrsOf valueType)
+    (listOf valueType)
+  ]) // {
+    description = "plist value";
+  };
+  defaultsType = types.submodule {
+    freeformType = valueType;
+  };
+in {
   options = {
     system.defaults.CustomUserPreferences = mkOption {
-      type = types.attrs;
+      type = defaultsType;
       default = { };
       example = {
         "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
@@ -20,7 +35,7 @@ with lib;
     };
 
     system.defaults.CustomSystemPreferences = mkOption {
-      type = types.attrs;
+      type = defaultsType;
       default = { };
       example = {
         "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };

--- a/tests/fixtures/system-defaults-write/activate-user.txt
+++ b/tests/fixtures/system-defaults-write/activate-user.txt
@@ -543,6 +543,14 @@ defaults write NSGlobalDomain 'TISRomanSwitchState' $'<?xml version="1.0" encodi
 <plist version="1.0">
 <integer>1</integer>
 </plist>'
+defaults write com.apple.Safari 'NSUserKeyEquivalents' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Quit Safari</key>
+	<string>@^q</string>
+</dict>
+</plist>'
 defaults write com.apple.Safari 'com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled' $'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -1,6 +1,25 @@
 { config, pkgs, lib, ... }:
 
 {
+  imports = [
+    {
+      system.defaults.CustomUserPreferences = {
+        "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
+        "com.apple.Safari" = {
+          "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
+            true;
+        };
+      };
+    }
+    {
+      system.defaults.CustomUserPreferences = {
+        "com.apple.Safari" = {
+          "NSUserKeyEquivalents"."Quit Safari" = "@^q"; # Option-Cmd-Q
+        };
+      };
+    }
+  ];
+
   system.defaults.NSGlobalDomain.AppleShowAllFiles = true;
   system.defaults.NSGlobalDomain.AppleEnableMouseSwipeNavigateWithScrolls = false;
   system.defaults.NSGlobalDomain.AppleEnableSwipeNavigateWithScrolls = false;
@@ -109,13 +128,6 @@
   system.defaults.WindowManager.EnableTiledWindowMargins = true;
   system.defaults.WindowManager.StandardHideWidgets = true;
   system.defaults.WindowManager.StageManagerHideWidgets = true;
-  system.defaults.CustomUserPreferences = {
-    "NSGlobalDomain" = { "TISRomanSwitchState" = 1; };
-    "com.apple.Safari" = {
-      "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
-        true;
-    };
-  };
   system.defaults.controlcenter.BatteryShowPercentage = true;
   system.defaults.controlcenter.Sound = false;
   system.defaults.controlcenter.Bluetooth = true;


### PR DESCRIPTION
Without this, custom user preferences defined in different modules for the same domain aren't merged.

For example, the following config results in only `UniversalSearchEnabled` defined:

```
{
  imports = [
    {
      system.defaults.CustomUserPreferences = {
        "com.apple.Safari"."NSUserKeyEquivalents"."Quit Safari" = "@~q";
      };
    }
    {
      system.defaults.CustomUserPreferences = {
        "com.apple.Safari"."UniversalSearchEnabled" = false;
      };
    }
  ];
}
```