### PR TITLE
nix-daemon: use PathState to wait for nix store

### DIFF
--- a/tests/services-nix-daemon.nix
+++ b/tests/services-nix-daemon.nix
@@ -14,10 +14,9 @@ in
   test = ''
     echo checking nix-daemon service in /Library/LaunchDaemons >&2
     grep "<string>org.nixos.nix-daemon</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
-    grep "<string>/bin/wait4path" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
-    grep "&amp;&amp;" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
-    grep "exec ${nix}/bin/nix-daemon</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    grep "${nix}/bin/nix-daemon</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
     grep "<key>KeepAlive</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    grep "<key>PathState</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist
     (! grep "<key>Sockets</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nix-daemon.plist)
 
     echo checking NIX_SSL_CERT_FILE in nix-daemon service >&2


### PR DESCRIPTION
This allows to avoid wait4path and sh from execution path; simplifying
permissions setup for the daemon (which needs Full Disk Access to manage
all files under /nix/store.)

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
