### PR TITLE
Convert non-configurable Zsh defaults into configurable options

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -38,10 +38,7 @@ let
 
         path = mkOption {
           type = types.str;
-          default = "\${\ZDOTDIR:-$HOME\}/.zsh_history";
-          # defaultText = literalExpression ''
-          #   "''${ZDOTDIR:-$HOME}/.zsh_history"
-          # '';
+          default = "$HOME/.zsh_history";
           example = literalExpression ''"$HOME/.local/share/zsh/zsh_history"'';
           description = "History file location.";
         };


### PR DESCRIPTION
This converts the following hard-coded options from /etc/zshrc into configurable options, but sets the previously hard-coded values as default. 
```
SAVEHIST=2000
HISTSIZE=2000
HISTFILE=$HOME/.zsh_history

setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK

bindkey -e
```
The exception being that I changed the default `HISTFILE` path to `"${ZDOTDIR:-$HOME}/.zsh_history"
` because that's what Apple sets by default. `${ZDOTDIR:-$HOME}` indicates that it will look for `ZDOTDIR`, then revert to `$HOME`, if it doesn't find it.

The new configurable options are:
`programs.zsh = {`
- `defaultKeymap`
- `history.ignoreDups`
- `history.path`
- `history.save`
- `history.share`
- `history.size`
`};`

Fixes #983.