### PR TITLE
linux-builder: Allow custom host & port

### DIFF
--- a/modules/nix/linux-builder.nix
+++ b/modules/nix/linux-builder.nix
@@ -80,6 +80,30 @@ in
       '';
     };
 
+    host = mkOption {
+      type = types.str;
+      default = "localhost";
+      defaultText = literalExpression ''"localhost"'';
+      description = ''
+        The host used for communicating with the build machine via SSH.
+
+        This is localhost for the default linux-builder, but might be
+        an IP address for alternative implementations.
+      '';
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 31022;
+      description = ''
+        The port used for communicating with the build machine via SSH.
+
+        A high port is used for the default linux-builder, but alternative
+        implementations may use i.e. 22 together with
+        {option}`nix.linux-builder.host`.
+      '';
+    };
+
     protocol = mkOption {
       type = types.str;
       default = "ssh-ng";
@@ -212,9 +236,9 @@ in
       environment.etc."ssh/ssh_config.d/100-linux-builder.conf".text = ''
         Host linux-builder
           User builder
-          Hostname localhost
+          Hostname ${cfg.host}
           HostKeyAlias linux-builder
-          Port 31022
+          Port ${toString cfg.port}
           IdentityFile /etc/nix/builder_ed25519
       '';
 


### PR DESCRIPTION
I think it's useful to allow customization here.

Ran into this while playing around with an alternative implementation of a linux-builder at https://github.com/phaer/nixos-vm-on-macos. The underlying hypervisor doesn't seem to provide an interface for port forwarding, but does provide full virtio-net ips, so need to be able to customize host and port here but could otherwise reuse the module. 