### PR TITLE
Fix ShellCheck escaped character issue in `nixPath` check

### DIFF
--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -173,7 +173,7 @@ let
       printf >&2 'Make sure that %s exists,\n' \
         ${escapeDoubleQuote (
           if config.environment.darwinConfig == null then
-            "the \\`<darwin-config>\\` entry in `nix.nixPath`"
+            "the \\`<darwin-config>\\` entry in \\`nix.nixPath\\`"
           else
             "\\`${config.environment.darwinConfig}\\`"
         )}


### PR DESCRIPTION
When building a system with `system.checks.verifyNixPath = true;`, I get this ShellCheck error:

```
In /nix/store/i1fvq9x8kkqqpkblks41qgg83mk034q6-darwin-system-25.05.75b99da/activate line 187:
    "the \`<darwin-config>\` entry in `nix.nixPath`"
                                      ^-----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
    "the \`<darwin-config>\` entry in $(nix.nixPath)"

For more information:
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```

This PR ensures that backticks are properly escaped.