### PR TITLE
security/chmodbpf: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -10,6 +10,7 @@
   ./security/pki
   ./security/sandbox
   ./security/sudo.nix
+  ./security/chmodbpf.nix
   ./system
   ./system/base.nix
   ./system/primary-user.nix

--- a/modules/security/chmodbpf.nix
+++ b/modules/security/chmodbpf.nix
@@ -1,0 +1,77 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.security.chmodbpf;
+in {
+  meta.maintainers = [ lib.maintainers.feyorsh or "feyorsh" ];
+
+  options.security.chmodbpf = {
+    enable = mkEnableOption "ChmodBPF";
+    maxDevices = mkOption {
+      type = types.ints.unsigned;
+      default = 256;
+      description = ''
+        Number of BPF devices that will be created.
+
+        This is bound by debug.bpf_maxdevices.
+      '';
+    };
+    group = mkOption {
+      type = types.str;
+      default = "access_bpf";
+      description = ''
+        The group's name.
+      '';
+    };
+    members = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        The group's members.
+      '';
+    };
+    writable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether the BPF access group can send raw packets (in addition to capturing them).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = optionalAttrs (cfg.group == "access_bpf") {
+      groups.access_bpf = {
+        gid = 555;
+        members = cfg.members;
+        description = "User group with permissions for /dev/bpf*";
+      };
+      knownGroups = [ cfg.group ];
+    };
+
+    launchd.daemons.chmodbpf.serviceConfig = {
+      Program = (pkgs.writeShellScript "ChmodBPF"
+        ''
+          FORCE_CREATE_BPF_MAX=${toString cfg.maxDevices}
+
+          SYSCTL_MAX=$( sysctl -n debug.bpf_maxdevices )
+          if [ "$FORCE_CREATE_BPF_MAX" -gt "$SYSCTL_MAX" ] ; then
+	          FORCE_CREATE_BPF_MAX=$SYSCTL_MAX
+          fi
+
+          syslog -s -l notice "ChmodBPF: Forcing creation and setting permissions for /dev/bpf0-$(( FORCE_CREATE_BPF_MAX - 1))"
+
+          CUR_DEV=0
+          while [ "$CUR_DEV" -lt "$FORCE_CREATE_BPF_MAX" ] ; do
+	          # Try to do the minimum necessary to trigger the next device.
+	          read -r -n 0 < /dev/bpf$CUR_DEV > /dev/null 2>&1
+	          CUR_DEV=$(( CUR_DEV + 1 ))
+          done
+
+          ${lib.getExe' pkgs.coreutils "chgrp"} ${cfg.group} /dev/bpf*
+          ${lib.getExe' pkgs.coreutils "chmod"} g+r${lib.optionalString cfg.writable "w"} /dev/bpf*
+        '').outPath;
+      RunAtLoad = true;
+    };
+  };
+}


### PR DESCRIPTION
Tools that make use of BPF like Wireshark or tcpdump normally require running as `sudo` in order to capture network traffic due to the permissions of `/dev/bpf*` (a quirk unique to macOS due to how its devfs is implemented).
To be able to capture traffic without `sudo`, Wireshark packages a "ChmodBPF" launch daemon which changes the permissions of `/dev/bpf*` on boot, giving users in the `access_bpf` group read/write access.

This nix-darwin module duplicates the ChmodBPF functionality from upstream [Wireshark](https://gitlab.com/wireshark/wireshark/-/blob/master/packaging/macosx/ChmodBPF/root/Library/Application%20Support/Wireshark/ChmodBPF/ChmodBPF).
For what it's worth, I've been using this without issue for several months.

(This is my first contribution to nix-darwin, so please scrutinize my code and let me know if there are ways I can make it more idiomatic.)
