### PR TITLE
services/xquartz: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -101,6 +101,7 @@
   ./services/tailscale.nix
   ./services/trezord.nix
   ./services/wg-quick.nix
+  ./services/xquartz.nix
   ./services/yabai
   ./services/nextdns
   ./services/jankyborders

--- a/modules/services/xquartz.nix
+++ b/modules/services/xquartz.nix
@@ -1,0 +1,62 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.services.xquartz;
+  xauth = pkgs.xorg.xauth;
+in {
+  meta.maintainers = [ lib.maintainers.feyorsh or "feyorsh" ];
+
+  options.services.xquartz = {
+    enable = mkEnableOption "XQuartz";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.xquartz;
+      description = "The XQuartz package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = let
+      daemon = "org.nixos.xquartz.privileged_startx.plist";
+      agent = "org.nixos.xquartz.startx.plist";
+      plistLocation = name: builtins.head (builtins.match ".*cp ([^[:space:]]+-${name}) .*" (builtins.readFile "${cfg.package}/bin/xquartz-install"));
+    in {
+      systemPackages = [ cfg.package ];
+
+      launchDaemons.${daemon}.source =
+        (pkgs.substitute {
+          src = plistLocation daemon;
+          substitutions = [
+            "--replace-fail"
+            "@PRIVILEGED_STARTX@"
+            "${cfg.package}/libexec/privileged_startx"
+
+            "--replace-fail"
+            "@PRIVILEGED_STARTX_D@"
+            "${cfg.package}/etc/X11/xinit/privileged_startx.d"
+          ];
+        }).outPath;
+
+      launchAgents.${agent}.source =
+        (pkgs.substitute {
+          src = plistLocation agent;
+          substitutions = [
+            "--replace-fail"
+            "@LAUNCHD_STARTX@"
+            "${cfg.package}/libexec/launchd_startx"
+
+            "--replace-fail"
+            "@STARTX@"
+            "${cfg.package}/bin/startx"
+
+            "--replace-fail"
+            "@XQUARTZ@"
+            "${cfg.package}/bin/Xquartz"
+          ];
+        }).outPath;
+        etc."ssh/ssh_config.d/70-xquartz.conf".text = ''
+          XAuthLocation ${xauth}/bin/xauth
+        '';
+    };
+  };
+}


### PR DESCRIPTION
This is a simple module to manage the XQuartz launch daemon/agent with nix-darwin instead of manually running `xquartz-install` (or using Homebrew).

I've been using this module in my personal config for several months without issue, including with X forwarding over SSH.
You can test to make sure it works with a program like `xeyes` or `oneko`.