### PR TITLE
systems.newsyslog: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -42,6 +42,7 @@
   ./system/etc.nix
   ./system/keyboard.nix
   ./system/launchd.nix
+  ./system/newsyslog.nix
   ./system/nvram.nix
   ./system/patches.nix
   ./system/shells.nix

--- a/modules/system/newsyslog.nix
+++ b/modules/system/newsyslog.nix
@@ -1,0 +1,260 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.system.newsyslog;
+in
+{
+  options = {
+    system.newsyslog = {
+      enable = lib.mkEnableOption "newsyslog configuration management";
+
+      files = mkOption {
+        type = types.attrsOf (
+          types.listOf (
+            types.submodule {
+              options = {
+                logfilename = mkOption {
+                  type = types.str;
+                  description = ''
+                    Path to the log file to rotate, or the literal string `<default>`.
+
+                    The `<default>` entry applies when newsyslog is invoked with an explicit
+                    log file argument that does not match another entry.
+                  '';
+                  example = "/var/log/myapp.log";
+                };
+
+                owner = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Owner of the log file.
+
+                    If `null`, the owner portion of `owner:group` is left blank.
+                    See `newsyslog.conf(5)` for default ownership behavior (`root:admin`).
+                  '';
+                  example = "myuser";
+                };
+
+                group = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Group of the log file.
+
+                    If `null`, the group portion of `owner:group` is left blank.
+                    See `newsyslog.conf(5)` for default ownership behavior (`root:admin`).
+                  '';
+                  example = "wheel";
+                };
+
+                mode = mkOption {
+                  type = types.str;
+                  default = "644";
+                  description = ''
+                    File mode (permissions) for the rotated log file.
+                  '';
+                  example = "600";
+                };
+
+                count = mkOption {
+                  type = types.ints.unsigned;
+                  default = 5;
+                  description = ''
+                    Number of rotated log files to keep.
+                  '';
+                };
+
+                size = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Maximum size (in KB) before rotation (e.g., "100", "1024", "4096").
+
+                    If `null`, size-based rotation is disabled.
+                  '';
+                  example = "2048";
+                };
+
+                when = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Time-based rotation schedule.
+
+                    The value may be an interval in hours, a specific time, or both.
+                    If both are specified, both conditions must be satisfied.
+
+                    Examples:
+                    - Interval only: 24
+                    - Daily: @T00 (daily at midnight)
+                    - Interval and time: 24@T00
+                    - Weekly: $W0D00 (weekly on Sunday at midnight)
+                    - Monthly: $M1D00 (monthly on the 1st at midnight)
+
+                    If `null`, time-based rotation is disabled.
+                  '';
+                  example = "@T00";
+                };
+
+                flags = mkOption {
+                  type = types.listOf (
+                    types.enum [
+                      "B"
+                      "C"
+                      "D"
+                      "G"
+                      "J"
+                      "N"
+                      "U"
+                      "Z"
+                      "-"
+                    ]
+                  );
+                  default = [ ];
+                  description = ''
+                    List of flags for newsyslog.
+                    - "B" - Binary file, don't add status message
+                    - "C" - Create log file if missing when newsyslog runs with `-C`/`-CC`
+                    - "D" - Mark rotated files with the UF_NODUMP flag
+                    - "G" - Indicates that logfilename is a shell pattern
+                    - "J" - Compress rotated logs with bzip2
+                    - "N" - Do not signal a daemon after rotating this log
+                    - "U" - pidFile points to a process group ID (negative value)
+                    - "Z" - Compress rotated logs with gzip
+                    - "-" - Placeholder when specifying pidFile/signal without other flags
+                  '';
+                  example = [
+                    "Z"
+                    "C"
+                  ];
+                };
+
+                pidFile = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Path to PID file.
+
+                    If specified, the process will be signaled after rotation.
+                    This path must be absolute (start with `/`).
+                  '';
+                  example = "/var/run/myapp.pid";
+                };
+
+                signal = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    Signal to send to the process (default is SIGHUP if pidFile is specified).
+                    Can be signal name (HUP, USR1, etc.) or number.
+                  '';
+                  example = "USR1";
+                };
+              };
+            }
+          )
+        );
+        default = { };
+        description = ''
+          Attribute set of newsyslog configuration files to create in /etc/newsyslog.d/.
+
+          Each attribute name becomes the filename (with .conf extension automatically added).
+          Each attribute value is a list of log rotation entries.
+        '';
+        example = lib.literalExpression ''
+          {
+            myapp = [
+              {
+                logfilename = "/var/log/myapp.log";
+                owner = "myuser";
+                group = "wheel";
+                mode = "644";
+                count = 7;
+                size = "10M";
+                flags = [ "Z" "C" ];
+                pidFile = "/var/run/myapp.pid";
+                signal = "USR1";
+              }
+            ];
+            system = [
+              {
+                logfilename = "/var/log/system.log";
+                mode = "644";
+                count = 5;
+                when = "@T00";
+                flags = [ "Z" ];
+              }
+            ];
+          }
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = lib.flatten (
+      lib.mapAttrsToList (
+        fileName: entries:
+        lib.flatten (
+          lib.imap0 (index: entry: [
+            {
+              assertion = entry.signal == null || entry.pidFile != null;
+              message = "system.newsyslog.files.${fileName}[${toString index}].signal requires pidFile to be set.";
+            }
+            {
+              assertion = entry.pidFile == null || builtins.match "/.*" entry.pidFile != null;
+              message = "system.newsyslog.files.${fileName}[${toString index}].pidFile must be an absolute path starting with '/'.";
+            }
+          ]) entries
+        )
+      ) cfg.files
+    );
+
+    environment.etc =
+      let
+        orStar = value: if value == null then "*" else value;
+
+        formatOwnerGroup =
+          entry:
+          "${lib.optionalString (entry.owner != null) entry.owner}:${
+            lib.optionalString (entry.group != null) entry.group
+          }";
+
+        formatFlags =
+          entry:
+          lib.optional (entry.flags != [ ]) (lib.concatStrings entry.flags)
+          ++ lib.optional (entry.flags == [ ] && (entry.pidFile != null || entry.signal != null)) "-";
+
+        formatEntry =
+          entry:
+          lib.concatStringsSep "\t" (
+            [
+              entry.logfilename
+            ]
+            ++ lib.optional (entry.owner != null || entry.group != null) (formatOwnerGroup entry)
+            ++ [
+              entry.mode
+              (toString entry.count)
+              (orStar entry.size)
+              (orStar entry.when)
+            ]
+            ++ formatFlags entry
+            ++ lib.optionals (entry.pidFile != null) [ entry.pidFile ]
+            ++ lib.optionals (entry.signal != null) [ entry.signal ]
+          );
+
+        generateFileContent = entries: ''
+          # Generated by nix-darwin
+          # logfilename [owner:group] mode count size when flags [/pid_file] [sig_num]
+          ${lib.concatMapStringsSep "\n" formatEntry entries}
+        '';
+      in
+      lib.mapAttrs' (name: entries: {
+        name = "newsyslog.d/${name}.conf";
+        value.text = generateFileContent entries;
+      }) cfg.files;
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -132,6 +132,7 @@ in {
   tests.system-packages = makeTest ./tests/system-packages.nix;
   tests.system-path = makeTest ./tests/system-path.nix;
   tests.system-shells = makeTest ./tests/system-shells.nix;
+  tests.system-newsyslog = makeTest ./tests/system-newsyslog.nix;
   tests.users-groups = makeTest ./tests/users-groups.nix;
   tests.users-packages = makeTest ./tests/users-packages.nix;
   tests.fonts = makeTest ./tests/fonts.nix;

--- a/tests/system-newsyslog.nix
+++ b/tests/system-newsyslog.nix
@@ -1,0 +1,157 @@
+{
+  config,
+  ...
+}:
+
+{
+  system.newsyslog = {
+    enable = true;
+
+    files = {
+      myapp = [
+        {
+          logfilename = "/var/log/myapp.log";
+          owner = "myuser";
+          group = "wheel";
+          mode = "644";
+          count = 7;
+          size = "4096";
+          flags = [
+            "Z"
+            "C"
+          ];
+          pidFile = "/var/run/myapp.pid";
+          signal = "USR1";
+        }
+        {
+          logfilename = "/var/log/myapp-debug.log";
+          owner = "myuser";
+          mode = "600";
+          count = 3;
+          size = "2048";
+          flags = [ "Z" ];
+        }
+      ];
+
+      system = [
+        {
+          logfilename = "/var/log/system.log";
+          mode = "644";
+          count = 5;
+          when = "@T00";
+          flags = [ "Z" ];
+        }
+        {
+          logfilename = "/var/log/mail.log";
+          group = "mail";
+          mode = "640";
+          count = 10;
+          size = "1024";
+          flags = [
+            "B"
+            "Z"
+          ];
+          pidFile = "/var/run/syslogd.pid";
+        }
+      ];
+
+      minimal = [
+        {
+          logfilename = "/tmp/test.log";
+          mode = "644";
+          count = 2;
+          size = "100K";
+        }
+      ];
+
+      both-size-when = [
+        {
+          logfilename = "/var/log/both.log";
+          mode = "644";
+          count = 3;
+          size = "2048";
+          when = "@T12";
+          flags = [ "Z" ];
+        }
+      ];
+
+      empty-flags = [
+        {
+          logfilename = "/var/log/empty-flags.log";
+          mode = "644";
+          count = 1;
+          size = "1024";
+        }
+      ];
+
+      pidfile-empty-flags = [
+        {
+          logfilename = "/var/log/pidfile-empty-flags.log";
+          mode = "644";
+          count = 1;
+          size = "1024";
+          pidFile = "/var/run/pidfile-empty-flags.pid";
+        }
+      ];
+    };
+  };
+
+  test = ''
+    set -e
+
+    check_pattern() {
+      local pattern="$1"
+      local file="$2"
+      echo "--> Checking for pattern: '$pattern'"
+      echo "    in file:              '$file'"
+
+      if grep --color=never -E "$pattern" "$file"; then
+        echo "    +++ PASS: Pattern found."
+        echo
+      else
+        echo "    --- FAIL: Pattern NOT found."
+        exit 1
+      fi
+    }
+
+    echo "checking newsyslog.d configuration files exist"
+    test -f ${config.out}/etc/newsyslog.d/myapp.conf
+    test -f ${config.out}/etc/newsyslog.d/system.conf
+    test -f ${config.out}/etc/newsyslog.d/minimal.conf
+    test -f ${config.out}/etc/newsyslog.d/both-size-when.conf
+    test -f ${config.out}/etc/newsyslog.d/empty-flags.conf
+    test -f ${config.out}/etc/newsyslog.d/pidfile-empty-flags.conf
+
+    echo
+    echo "checking file content patterns"
+    check_pattern "myuser:wheel.*644.*7.*4096.*\*.*ZC.*USR1"   ${config.out}/etc/newsyslog.d/myapp.conf
+    check_pattern "myuser:.*600.*3.*2048.*\*.*Z"               ${config.out}/etc/newsyslog.d/myapp.conf
+    check_pattern "system.log.*644.*5.*\*.*@T00.*Z"          ${config.out}/etc/newsyslog.d/system.conf
+    check_pattern ":mail.*640.*10.*1024.*\*.*BZ"               ${config.out}/etc/newsyslog.d/system.conf
+    check_pattern "test.log.*644.*2.*100K.*\*"               ${config.out}/etc/newsyslog.d/minimal.conf
+    check_pattern "both.log.*644.*3.*2048.*@T12.*Z"            ${config.out}/etc/newsyslog.d/both-size-when.conf
+    check_pattern "empty-flags.log.*644.*1.*1024.*\*"          ${config.out}/etc/newsyslog.d/empty-flags.conf
+    check_pattern "pidfile-empty-flags.log.*644.*1.*1024.*\*.*-.*pidfile-empty-flags.pid" ${config.out}/etc/newsyslog.d/pidfile-empty-flags.conf
+
+    # Verify no colons in minimal.conf (no owner/group)
+    echo "--> Verifying no colons in minimal.conf"
+    if grep -v "^#" ${config.out}/etc/newsyslog.d/minimal.conf | grep -q ":"; then
+      echo "    --- FAIL: minimal.conf should not contain colons"
+      exit 1
+    else
+        echo "    +++ PASS: No colons found."
+    fi
+
+    # Verify group-only format
+    echo "--> Verifying group-only format in system.conf"
+    if ! grep -q ":mail" ${config.out}/etc/newsyslog.d/system.conf; then
+      echo "    --- FAIL: Did not find group-only format ':mail'"
+      exit 1
+    else
+      echo "    +++ PASS: Found group-only format."
+    fi
+
+    echo
+    echo "All tests passed successfully."
+  '';
+}


### PR DESCRIPTION
Have been meaning to create something like this for a while. Just implements a basic way to generate `newsyslog.d` files to help with log rotation on macos. I plan on continuing with integration with launchd services that have logging setup so you can easily enable logging and rotating logs for launchd agents on your system. 

Tested a little bit real quick with my own config by creating an entry for `nh-clean` and `sudo newsyslog -f /etc/newsyslog.d/nh-clean.conf` to invoke the cleanup. 

Closes https://github.com/nix-darwin/nix-darwin/pull/1843