### PR TITLE
Address nixpkgs generator.toPlist evaluation warning

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -9,7 +9,7 @@ let
 
   toEnvironmentText = name: value: {
     name = "${value.serviceConfig.Label}.plist";
-    value.text = generators.toPlist { } value.serviceConfig;
+    value.text = generators.toPlist { escape = true; } value.serviceConfig;
   };
 
   launchdConfig = import ./launchd.nix;

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -6,7 +6,7 @@ let
   cfg = config.system.defaults;
 
   writeDefault = domain: key: value:
-    "defaults write ${domain} '${key}' $'${strings.escape [ "'" ] (generators.toPlist { } value)}'";
+    "defaults write ${domain} '${key}' $'${strings.escape [ "'" ] (generators.toPlist { escape = true; } value)}'";
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
   userDefaultsToList = domain: attrs: let


### PR DESCRIPTION
Resolves warning in nixpkgs:
```
Using `lib.generators.toPlist` without `escape = true` is deprecated
```