### PR TITLE
github-runner: add support for node24

### DIFF
--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -262,8 +262,8 @@ in
         };
 
         nodeRuntimes = mkOption {
-          type = with types; nonEmptyListOf (enum [ "node20" ]);
-          default = [ "node20" ];
+          type = with types; nonEmptyListOf (enum [ "node20" "node24" ]);
+          default = [ "node20" "node24" ];
           description = ''
             List of Node.js runtimes the runner should support.
           '';


### PR DESCRIPTION
GitHub is releasing new [major versions of its actions](https://github.com/actions/checkout/releases/tag/v5.0.0), requiring node 24 as the minimum node runtime.
This PR adds `node24` to the list of supported node runtimes.
We should wait until https://github.com/NixOS/nixpkgs/pull/434377 is merged and released in nixpkgs-unstable.