### PR TITLE
Add BatteryShowEnergyMode to controlcenter module

### DIFF
--- a/modules/system/defaults/controlcenter.nix
+++ b/modules/system/defaults/controlcenter.nix
@@ -99,7 +99,6 @@
 
         system.defaults.controlcenter.BatteryShowEnergyMode = lib.mkOption {
         type = lib.types.nullOr lib.types.bool;
-        apply = v: if v == null then null else if v then 1 else 0;
         default = null;
         description = ''
             Apple menu > System Settings > Control Center > Battery > Show Energy Mode

--- a/modules/system/defaults/controlcenter.nix
+++ b/modules/system/defaults/controlcenter.nix
@@ -96,5 +96,18 @@
             24 = Hide icon in menu bar
         '';
     };
+
+        system.defaults.controlcenter.BatteryShowEnergyMode = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        apply = v: if v == true then 1 else null;
+        default = null;
+        description = ''
+            Apple menu > System Settings > Control Center > Battery > Show Energy Mode
+
+            Show the Energy Mode toggle in menu bar. Default is null.
+
+            1 = Display icon in the menu bar
+        '';
+    };
   };
 }

--- a/modules/system/defaults/controlcenter.nix
+++ b/modules/system/defaults/controlcenter.nix
@@ -99,14 +99,15 @@
 
         system.defaults.controlcenter.BatteryShowEnergyMode = lib.mkOption {
         type = lib.types.nullOr lib.types.bool;
-        apply = v: if v == true then 1 else null;
+        apply = v: if v == null then null else if v then 1 else 0;
         default = null;
         description = ''
             Apple menu > System Settings > Control Center > Battery > Show Energy Mode
 
             Show the Energy Mode toggle in menu bar. Default is null.
 
-            1 = Display icon in the menu bar
+            true = Display icon in the menu bar
+            false = Show energy mode when active
         '';
     };
   };

--- a/tests/fixtures/system-defaults-write/user.txt
+++ b/tests/fixtures/system-defaults-write/user.txt
@@ -636,6 +636,11 @@ launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user
 <plist version="1.0">
 <integer>18</integer>
 </plist>'
+launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user -- defaults write ~test-defaults-user/Library/Preferences/ByHost/com.apple.controlcenter 'BatteryShowEnergyMode' $'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<integer>1</integer>
+</plist>'
 launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user -- defaults write ~test-defaults-user/Library/Preferences/ByHost/com.apple.controlcenter 'BatteryShowPercentage' $'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -140,6 +140,7 @@
   system.defaults.controlcenter.Display = false;
   system.defaults.controlcenter.FocusModes = false;
   system.defaults.controlcenter.NowPlaying = true;
+  system.defaults.controlcenter.BatteryShowEnergyMode = true;
   test = lib.strings.concatMapStringsSep "\n"
     (x: ''
       echo >&2 "checking ${x} defaults write in /activate"


### PR DESCRIPTION
Adds option for showing Energy Mode in menu bar, mapping true to 1 and null/false to null, based on plist tests.