### PR TITLE
Fix typo in Nix module

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -835,7 +835,7 @@ in
 
     system.requiresPrimaryUser = mkIf (
       config.system.stateVersion < 2
-      && options.nix.nixPath.highestPrio == (mkDefault {}).priotity
+      && options.nix.nixPath.highestPrio == (mkDefault {}).priority
     ) [
       "nix.nixPath"
     ];


### PR DESCRIPTION
This typo was introduced in [this commit](https://github.com/nix-darwin/nix-darwin/commit/bed70a84af8e4bc28e4050cded929505a030195a). I discovered this when I kept getting `error: attribute 'nix' missing` and traced it back a bit.