### PR TITLE
treewide: specify full path to home directories in `/var/lib`

### DIFF
--- a/modules/services/buildkite-agents.nix
+++ b/modules/services/buildkite-agents.nix
@@ -46,7 +46,7 @@ let
       };
 
       dataDir = mkOption {
-        default = "/var/lib/buildkite-agent-${name}";
+        default = "/private/var/lib/buildkite-agent-${name}";
         description = "The workdir for the agent";
         type = types.str;
       };

--- a/modules/services/dnscrypt-proxy.nix
+++ b/modules/services/dnscrypt-proxy.nix
@@ -46,7 +46,7 @@ in
     users.users._dnscrypt-proxy = {
       uid = config.ids.uids._dnscrypt-proxy;
       gid = config.ids.gids._dnscrypt-proxy;
-      home = "/var/lib/dnscrypt-proxy";
+      home = "/private/var/lib/dnscrypt-proxy";
       createHome = true;
       shell = "/usr/bin/false";
       description = "System user for dnscrypt-proxy";

--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -188,7 +188,7 @@ in
       createHome = false;
       description = "GitHub Runner service user";
       gid = config.users.groups."_github-runner".gid;
-      home = "/var/lib/github-runners";
+      home = "/private/var/lib/github-runners";
       shell = "/bin/bash";
       uid = mkDefault 533;
     };

--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -529,7 +529,7 @@ in
       { name = "gitlab-runner";
         uid = mkDefault 532;
         # gid = mkDefault config.users.groups.gitlab-runner.gid;
-        home = mkDefault "/var/lib/gitlab-runner";
+        home = mkDefault "/private/var/lib/gitlab-runner";
         shell = "/bin/bash";
         description = "Gitlab agent user";
       };

--- a/modules/services/hercules-ci-agent/settings.nix
+++ b/modules/services/hercules-ci-agent/settings.nix
@@ -25,7 +25,7 @@ let
       };
       baseDirectory = mkOption {
         type = types.path;
-        default = "/var/lib/hercules-ci-agent";
+        default = "/private/var/lib/hercules-ci-agent";
         description = ''
           State directory (secrets, work directory, etc) for agent
         '';

--- a/modules/services/monitoring/prometheus-node-exporter.nix
+++ b/modules/services/monitoring/prometheus-node-exporter.nix
@@ -81,7 +81,7 @@ in {
     users.users._prometheus-node-exporter = {
       uid = config.ids.uids._prometheus-node-exporter;
       gid = config.ids.gids._prometheus-node-exporter;
-      home = "/var/lib/prometheus-node-exporter";
+      home = "/private/var/lib/prometheus-node-exporter";
       createHome = true;
       shell = "/usr/bin/false";
       description = "System user for the Prometheus Node exporter";

--- a/modules/services/ofborg/default.nix
+++ b/modules/services/ofborg/default.nix
@@ -84,7 +84,7 @@ in
 
     users.users.ofborg.uid = mkDefault 531;
     users.users.ofborg.gid = mkDefault config.users.groups.ofborg.gid;
-    users.users.ofborg.home = mkDefault "/var/lib/ofborg";
+    users.users.ofborg.home = mkDefault "/private/var/lib/ofborg";
     users.users.ofborg.shell = "/bin/bash";
     users.users.ofborg.description = "OfBorg service user";
 

--- a/tests/services-ofborg.nix
+++ b/tests/services-ofborg.nix
@@ -24,7 +24,7 @@ in
     grep "chown .* '/var/log/ofborg.log'" ${config.out}/activate
 
     echo >&2 "checking config.json permissions in /activate"
-    grep "chmod 600 '/var/lib/ofborg/config.json'" ${config.out}/activate
-    grep "chown .* '/var/lib/ofborg/config.json'" ${config.out}/activate
+    grep "chmod 600 '/private/var/lib/ofborg/config.json'" ${config.out}/activate
+    grep "chown .* '/private/var/lib/ofborg/config.json'" ${config.out}/activate
   '';
 }


### PR DESCRIPTION
It seems macOS will resolve the home directory paths on system upgrades (it happened on the 15.7 upgrade for me), which will break system activation unless the user then manually changes the path in their configuration or sets it back for each user. So set it as the default to be compatible with updates.

In both cases manual intervention will be required sooner or later, either with this commit to adjust the home directories of existing users to their full paths (on systems that are not yet upgraded), or without it, to change the configuration to reference the full paths manually after upgrading.

So it's kind of a breaking change, in that activation will fail with an error for existing users, but it will fail if they upgrade their system anyway. The only case in which there will be no failure for existing installations, is both if the system is upgraded, and only after the upgrade this commit is applied. But since `/var` is a symlink to `/private/var`, the data remains in exactly the same place, so no manual data migration is required.

Closes #1256
