### PR TITLE
remove duplicates from brewfile

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -12,7 +12,7 @@ let
 
   mkBrewfileSectionString = heading: entries: optionalString (entries != [ ]) ''
     # ${heading}
-    ${concatMapStringsSep "\n" (v: v.brewfileLine or v) entries}
+    ${concatStringsSep "\n" (unique (map (v: v.brewfileLine or v) entries))}
 
   '';
 


### PR DESCRIPTION
For example, if you add the same cask multiple times from different locations, you'll end up with a brewfile that tries to install that cask multiple times. This removes those duplicates.