### PR TITLE
#1608: aerospace: add option for colemak key-mapping

### DIFF
--- a/modules/services/aerospace/default.nix
+++ b/modules/services/aerospace/default.nix
@@ -199,6 +199,7 @@ in
               type = enum [
                 "qwerty"
                 "dvorak"
+                "colemak"
               ];
               default = "qwerty";
               description = "Keymapping preset.";


### PR DESCRIPTION
Closes #1608 