### PR TITLE
dnsmasq: add servers option for upstream DNS configuration

### DIFF
--- a/tests/services-dnsmasq.nix
+++ b/tests/services-dnsmasq.nix
@@ -12,12 +12,20 @@ in
   services.dnsmasq.addresses = {
     localhost = "127.0.0.1";
   };
+  services.dnsmasq.servers = [
+    "8.8.8.8"
+    "/example.com/192.168.1.1"
+  ];
 
   test = ''
     echo >&2 "checking dnsmasq service in /Library/LaunchDaemons"
     grep "org.nixos.dnsmasq" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
     grep "${dnsmasq}/bin/dnsmasq" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
     grep -F -- "--address=/localhost/127.0.0.1" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
+
+    echo >&2 "checking server options"
+    grep -F -- "--server=8.8.8.8" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
+    grep -F -- "--server=/example.com/192.168.1.1" ${config.out}/Library/LaunchDaemons/org.nixos.dnsmasq.plist
 
     echo >&2 "checking resolver config"
     grep -F "port 53" ${config.out}/etc/resolver/localhost


### PR DESCRIPTION
Adds a new `services.dnsmasq.servers` option to configure upstream DNS servers. This allows users to specify which DNS servers dnsmasq should forward queries to, supporting domain-specific routing and custom ports. When empty (default), dnsmasq uses servers from /etc/resolv.conf.

This option is very useful when you want to e.g. combine dnsmasq with dnscrypt-proxy.