### PR TITLE
networking: modify firewall settings only if explicitly set

### DIFF
--- a/modules/networking/applicationFirewall.nix
+++ b/modules/networking/applicationFirewall.nix
@@ -13,6 +13,7 @@ in
 {
   meta.maintainers = [
     (lib.maintainers.prince213 or "prince213")
+    (lib.maintainers.ryanccn or "ryanccn")
   ];
 
   options.networking.applicationFirewall = {
@@ -22,16 +23,34 @@ in
       example = true;
       description = "Whether to enable application firewall.";
     };
-    blockAllIncoming = lib.mkEnableOption "blocking all incoming connections";
-    allowSigned = lib.mkEnableOption "built-in software to receive incoming connections" // {
-      default = true;
+
+    blockAllIncoming = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      example = true;
+      description = "Whether to block all incoming connections.";
     };
-    allowSignedApp =
-      lib.mkEnableOption "downloaded signed software to receive incoming connections"
-      // {
-        default = true;
-      };
-    enableStealthMode = lib.mkEnableOption "stealth mode";
+
+    allowSigned = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      example = true;
+      description = "Whether to allow built-in software to receive incoming connections.";
+    };
+
+    allowSignedApp = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      example = true;
+      description = "Whether to allow downloaded signed software to receive incoming connections.";
+    };
+
+    enableStealthMode = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      example = true;
+      description = "Whether to enable stealth mode.";
+    };
   };
 
   config = {
@@ -39,10 +58,16 @@ in
       echo "configuring application firewall..." >&2
 
       ${lib.optionalString (cfg.enable != null) (socketfilterfw "setglobalstate" cfg.enable)}
-      ${lib.optionalString (cfg.enable == true) (socketfilterfw "setblockall" cfg.blockAllIncoming)}
-      ${socketfilterfw "setallowsigned" cfg.allowSigned}
-      ${socketfilterfw "setallowsignedapp" cfg.allowSignedApp}
-      ${socketfilterfw "setstealthmode" cfg.enableStealthMode}
+      ${lib.optionalString (cfg.blockAllIncoming != null) (
+        socketfilterfw "setblockall" cfg.blockAllIncoming
+      )}
+      ${lib.optionalString (cfg.allowSigned != null) (socketfilterfw "setallowsigned" cfg.allowSigned)}
+      ${lib.optionalString (cfg.allowSignedApp != null) (
+        socketfilterfw "setallowsignedapp" cfg.allowSignedApp
+      )}
+      ${lib.optionalString (cfg.enableStealthMode != null) (
+        socketfilterfw "setstealthmode" cfg.enableStealthMode
+      )}
     '';
   };
 }

--- a/release.nix
+++ b/release.nix
@@ -85,6 +85,7 @@ in {
   tests.homebrew = makeTest ./tests/homebrew.nix;
   tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;
   tests.launchd-setenv = makeTest ./tests/launchd-setenv.nix;
+  tests.networking-firewall = makeTest ./tests/networking-firewall.nix;
   tests.networking-hostname = makeTest ./tests/networking-hostname.nix;
   tests.networking-networkservices = makeTest ./tests/networking-networkservices.nix;
   tests.nix-enable = makeTest ./tests/nix-enable.nix;

--- a/tests/networking-firewall.nix
+++ b/tests/networking-firewall.nix
@@ -1,0 +1,17 @@
+{ config, ... }:
+{
+  networking.applicationFirewall = {
+    enable = true;
+    blockAllIncoming = true;
+    allowSignedApp = false;
+    enableStealthMode = null;
+  };
+
+  test = ''
+    echo "checking socketfilterfw calls in /activate" >&2
+    grep "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on" ${config.out}/activate
+    grep "/usr/libexec/ApplicationFirewall/socketfilterfw --setblockall on" ${config.out}/activate
+    grep "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp off" ${config.out}/activate
+    (! grep "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode" ${config.out}/activate)
+  '';
+}


### PR DESCRIPTION
The current behavior of `networking.applicationFirewall` modifies system firewall settings according to its defaults on activation regardless of whether the user actually uses the module; this PR changes the defaults of the relevant options to `null` and only applies settings when these options are explicitly set by the user.

Ideally, there should be a module enable option that controls whether any of the module options are applied, but currently `networking.applicationFirewall.enable` controls whether the firewall itself is enabled and I am not entirely sure if it is appropriate to make a breaking change to that behavior.