### PR TITLE
dnsmasq: make the daemon wait for the nix store to be mounted

### DIFF
--- a/modules/services/dnsmasq.nix
+++ b/modules/services/dnsmasq.nix
@@ -69,13 +69,15 @@ in
     environment.systemPackages = [ cfg.package ];
 
     launchd.daemons.dnsmasq = {
-      serviceConfig.ProgramArguments = [
-        "${cfg.package}/bin/dnsmasq"
-        "--listen-address=${cfg.bind}"
-        "--port=${toString cfg.port}"
-        "--keep-in-foreground"
-      ] ++ (mapA (domain: addr: "--address=/${domain}/${addr}") cfg.addresses)
-        ++ (map (server: "--server=${server}") cfg.servers);
+      command = let
+        args = [
+          "--listen-address=${cfg.bind}"
+          "--port=${toString cfg.port}"
+          "--keep-in-foreground"
+        ] ++ (mapA (domain: addr: "--address=/${domain}/${addr}") cfg.addresses)
+          ++ (map (server: "--server=${server}") cfg.servers);
+      in
+        "${cfg.package}/bin/dnsmasq ${concatStringsSep " " args}";
 
       serviceConfig.KeepAlive = true;
       serviceConfig.RunAtLoad = true;


### PR DESCRIPTION
Uses the wait4path mac os util to make the daemon wait for /nix/store to appear.

This resolves the issue I have of the daemon failing to starting because the nix store is not yet mounted.