### PR TITLE
fix: zsh-fast-syntax-highlighting path

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -215,7 +215,7 @@ in
       }
 
       ${optionalString cfg.enableFastSyntaxHighlighting
-        "source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh"
+        "source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh/plugins/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
       }
 
       ${optionalString cfg.enableFzfCompletion "source ${fzfCompletion}"}


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/101007