### PR TITLE
fix: error on cleanup rm commands

### DIFF
--- a/modules/system/applications.nix
+++ b/modules/system/applications.nix
@@ -75,10 +75,10 @@
       ${lib.optionalString (config.system.primaryUser != null) ''
         # Clean up for links created at the old location in HOME
         # TODO: Remove this in 25.11.
-        if ourLink ~${config.system.primaryUser}/Applications; then
-          rm ~${config.system.primaryUser}/Applications
-        elif ourLink ~${config.system.primaryUser}/Applications/'Nix Apps'; then
-          rm ~${config.system.primaryUser}/Applications/'Nix Apps'
+        if ourLink ~"${config.system.primaryUser}"/Applications; then
+          rm ~"${config.system.primaryUser}"/Applications
+        elif ourLink ~"${config.system.primaryUser}"/Applications/'Nix Apps'; then
+          rm ~"${config.system.primaryUser}"/Applications/'Nix Apps'
         fi
       ''}
 


### PR DESCRIPTION
# Description

With the addition of the cleanup script, path is triggering and error like this:

```
building the system configuration...
this derivation will be built:
  /nix/store/c6agnrpbbgzhk06g0yr46i96yvxx2lbb-darwin-system-25.11.drv
building '/nix/store/c6agnrpbbgzhk06g0yr46i96yvxx2lbb-darwin-system-25.11.drv'...

In /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11/activate line 2248:
if ourLink ~$username/Applications; then
            ^-------^ SC2154 (warning): username is referenced but not assigned.
            ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if ourLink ~"$username"/Applications; then


In /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11/activate line 2249:
  rm ~$username/Applications
      ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm ~"$username"/Applications


In /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11/activate line 2250:
elif ourLink ~$username/Applications/'Nix Apps'; then
              ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
elif ourLink ~"$username"/Applications/'Nix Apps'; then


In /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11/activate line 2251:
  rm ~$username/Applications/'Nix Apps'
      ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm ~"$username"/Applications/'Nix Apps'

For more information:
  https://www.shellcheck.net/wiki/SC2154 -- username is referenced but not as...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
error: Cannot build '/nix/store/c6agnrpbbgzhk06g0yr46i96yvxx2lbb-darwin-system-25.11.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11
       Last 25 log lines:
       >   rm ~$username/Applications
       >       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
       >
       > Did you mean:
       >   rm ~"$username"/Applications
       >
       >
       > In /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11/activate line 2250:
       > elif ourLink ~$username/Applications/'Nix Apps'; then
       >               ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
       >
       > Did you mean:
       > elif ourLink ~"$username"/Applications/'Nix Apps'; then
       >
       >
       > In /nix/store/m1w34rk4wgkzr4bcw9vivi21vab04sa0-darwin-system-25.11/activate line 2251:
       >   rm ~$username/Applications/'Nix Apps'
       >       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
       >
       > Did you mean:
       >   rm ~"$username"/Applications/'Nix Apps'
       >
       > For more information:
       >   https://www.shellcheck.net/wiki/SC2154 -- username is referenced but not as...
       >   https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
       For full logs, run:
         nix-store -l /nix/store/c6agnrpbbgzhk06g0yr46i96yvxx2lbb-darwin-system-25.11.drv
```

This means that interpolatation of user name is causing prblems on the execution of the `rm` command and if validations.

This fixes interpolaion problems.