### PR TITLE
modules/examples/lnl: drop qes

### DIFF
--- a/modules/examples/lnl.nix
+++ b/modules/examples/lnl.nix
@@ -50,8 +50,6 @@
       pkgs.jq
       pkgs.ripgrep
       pkgs.shellcheck
-
-      pkgs.qes
     ];
 
   services.yabai.enable = true;


### PR DESCRIPTION
See:
- https://github.com/NixOS/nixpkgs/issues/371202
- https://github.com/NixOS/nixpkgs/pull/473109
- https://github.com/astratagem/dotfield/issues/1
- https://github.com/asmvik/skhd/issues/44

Looks like it was merged into skhd pre-2020 and was only in nixpkgs in a cached state. Based on that last link the cached version may not even work on newer versions of macOS?

Regardless, this is causing tests to fail.