### PR TITLE
darwin-rebuild: add flake options to zsh completions

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.zsh-completions
+++ b/pkgs/nix-tools/darwin-rebuild.zsh-completions
@@ -21,6 +21,17 @@ _arguments \
   '(--keep-going -k)'{--keep-going,-k}"[keep going until all builds are finished]"\
   '(--keep-failed -K)'{--keep-failed,-K}'[keep failed builds (usually in /tmp)]'\
   '--fallback[If binary download fails, fall back on building from source]'\
+  '--flake[Build from the given flake URI]:flake uri:'\
+  '--no-flake[Disable implicit flake detection]'\
+  '(-L --print-build-logs)'{-L,--print-build-logs}'[Print build logs during the build]'\
+  '--refresh[Refresh flake inputs]'\
+  '--impure[Allow impure evaluation for flakes]'\
+  '--recreate-lock-file[Recreate flake.lock from scratch]'\
+  '*--update-input[Update a specific flake input]:input name:'\
+  '*--override-input[Override a flake input]:input name: :flake url: '\
+  '--offline[Do not access the network]'\
+  '--dry-run[Show what would be done without making changes]'\
+  '-Q[Only print the resulting store path]'\
   '--show-trace[Print stack trace of evaluation errors]'\
   '*--option[set Nix configuration option]:options:_nix_options:value:_nix_options_value'\
   '*--arg[argument to pass to the Nix function]:Name:_nix_complete_function_arg:Value: '\


### PR DESCRIPTION
I noticed `darwin-rebuild` was missing completions for flakes (it has been annoying me for a while), so I added the most common ones. 

I left out some of the more niche debugging/CI flags to keep the list from getting too cluttered, but I’m happy to add them if you think it’s better to be exhaustive!

**Left out for now:**
```zsh
  '--no-update-lock-file[Do not update flake.lock]'\
  '--no-write-lock-file[Do not write flake.lock]'\
  '--no-registries[Do not use flake registries]'\
  '--commit-lock-file[Commit flake.lock updates]'\
  '--substituters[Override substituters list]:substituters:'\
```