### PR TITLE
Add flake-parts module

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,0 +1,11 @@
+{
+  lib,
+  ...
+}:
+{
+  options.flake.darwinConfigurations = lib.mkOption {
+    type = lib.types.lazyAttrsOf lib.types.raw;
+    default = { };
+    description = "Darwin system configurations";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
       darwin-uninstaller = prev.callPackage ./pkgs/darwin-uninstaller { };
     };
 
+    flakeModules.default = ./flake-module.nix;
+
     darwinModules.hydra = ./modules/examples/hydra.nix;
     darwinModules.lnl = ./modules/examples/lnl.nix;
     darwinModules.simple = ./modules/examples/simple.nix;


### PR DESCRIPTION
Everything was fine using flake-parts and nix-darwin while it was just one machine, but when I tried to add a second machine I'd get the following error:

```
error: The option `flake.darwinConfigurations' is defined multiple times while it's expected to be unique.
...
```

This avoids that issue, and I can't be the only one hitting this so would be good to just have it defined upstream.