### PR TITLE
fix(modules): fixed typos in various modules

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -88,7 +88,7 @@ in
       description = ''
         Shell script code called during global environment initialisation
         after all variables and profileVariables have been set.
-        This code is asumed to be shell-independent, which means you should
+        This code is assumed to be shell-independent, which means you should
         stick to pure sh without sh word split.
       '';
     };

--- a/modules/services/jankyborders/default.nix
+++ b/modules/services/jankyborders/default.nix
@@ -22,7 +22,7 @@ in {
   ];
 
   options.services.jankyborders = {
-    enable = mkEnableOption "Enable the jankyborders service.";
+    enable = mkEnableOption "the jankyborders service.";
 
     package = mkPackageOption pkgs "jankyborders" {};
 

--- a/modules/services/khd/default.nix
+++ b/modules/services/khd/default.nix
@@ -33,7 +33,7 @@ in
     services.khd.i3Keybindings = mkOption {
       type = types.bool;
       default = false;
-      description = "Wether to configure i3 style keybindings for kwm.";
+      description = "Whether to configure i3 style keybindings for kwm.";
     };
   };
 

--- a/modules/services/spacebar/default.nix
+++ b/modules/services/spacebar/default.nix
@@ -22,7 +22,7 @@ in
     services.spacebar.enable = mkOption {
       type = bool;
       default = false;
-      description = "Whether to enable the spacebar spacebar.";
+      description = "Whether to enable the spacebar.";
     };
 
     services.spacebar.package = mkOption {

--- a/modules/services/wg-quick.nix
+++ b/modules/services/wg-quick.nix
@@ -83,7 +83,7 @@ let
       preDown = mkOption {
         type = with types; coercedTo (listOf str) (concatStringsSep "\n") lines;
         default = "";
-        description = "List of commadns to run before interface shutdown.";
+        description = "List of commands to run before interface shutdown.";
       };
 
       preUp = mkOption {


### PR DESCRIPTION
Changes only textual and do not affect any functionality.

PR fixes typos in several modules:

- environment/default.nix: corrected "asumed" -> "assumed"
- services/jankyborders/default.nix: adjusted enable option description
- services/khd/default.nix: corrected "Wether" -> "Whether"
- services/spacebar/default.nix: removed duplicate word "spacebar"
- services/wg-quick.nix: corrected "commadns" -> "commands"