### PR TITLE
[25.11] github-runner: canonicalizes `workDir` to fix `actions/checkout@v6`

### DIFF
--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -8,7 +8,7 @@ let
   mkSvcName = name: "github-runner-${name}";
   mkStateDir = cfg: "/var/lib/github-runners/${cfg.name}";
   mkLogDir = cfg: "/var/log/github-runners/${cfg.name}";
-  mkWorkDir = cfg: if (cfg.workDir != null) then cfg.workDir else "/var/lib/github-runners/_work/${cfg.name}";
+  mkWorkDir = cfg: if (cfg.workDir != null) then cfg.workDir else "/private/var/lib/github-runners/_work/${cfg.name}";
 in
 {
   config.assertions = flatten (


### PR DESCRIPTION
Backport of https://github.com/nix-darwin/nix-darwin/pull/1655 to 25.11, which is also affected.
cc @Enzime, @lopter
