### PR TITLE
programs/tailscale-gui: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -115,6 +115,7 @@
   ./programs/info
   ./programs/nix-index
   ./programs/ssh.nix
+  ./programs/tailscale-gui.nix
   ./programs/tmux.nix
   ./programs/vim.nix
   ./programs/zsh

--- a/modules/programs/tailscale-gui.nix
+++ b/modules/programs/tailscale-gui.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.tailscale-gui;
+in
+{
+  options = {
+    programs.tailscale-gui = {
+      enable = lib.mkEnableOption "the Tailscale GUI application";
+      package = lib.mkPackageOption pkgs "Tailscale GUI" {
+        default = [ "tailscale-gui" ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    system.activationScripts.applications.text = lib.mkAfter ''
+      install -o root -g wheel -m0555 -d "/Applications/Tailscale.app"
+      rsyncFlags=(
+        --checksum
+        --copy-unsafe-links
+        --archive
+        --delete
+        --chmod=-w
+        --no-group
+        --no-owner
+      )
+      ${lib.getExe pkgs.rsync} "''${rsyncFlags[@]}" \
+        ${cfg.package}/Applications/Tailscale.app/ /Applications/Tailscale.app
+    '';
+  };
+
+  meta.maintainers = [
+    lib.maintainers.anish
+  ];
+}


### PR DESCRIPTION
Adds a module for the Tailscale GUI application, following the same pattern as `programs._1password-gui`.

The Tailscale GUI for macOS requires running from `/Applications` to function correctly (it uses system extensions for VPN functionality). I think this is the same situation as 1Password GUI (NixOS/nixpkgs#254944). I copied the approach in `programs/_1password-gui`, copying the app to `/Applications` using `rsync`.

I tested by adding this to my config, and things seem to be working as expected:

```nix
programs.tailscale-gui.enable = true;
```

nixpkgs PR adding tailscale-gui package: https://github.com/NixOS/nixpkgs/pull/483910