### PR TITLE
programs/cloudflare-warp: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -108,6 +108,7 @@
   ./programs/_1password-gui.nix
   ./programs/arqbackup.nix
   ./programs/bash
+  ./programs/cloudflare-warp.nix
   ./programs/direnv.nix
   ./programs/fish.nix
   ./programs/gnupg.nix

--- a/modules/programs/cloudflare-warp.nix
+++ b/modules/programs/cloudflare-warp.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.cloudflare-warp;
+in
+{
+  options = {
+    programs.cloudflare-warp = {
+      enable = lib.mkEnableOption "the Cloudflare WARP application";
+      package = lib.mkPackageOption pkgs "Cloudflare WARP" {
+        default = [ "cloudflare-warp" ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    launchd.daemons.cloudflare-warp = {
+      serviceConfig = {
+        Label = "com.cloudflare.1dot1dot1dot1.macos.warp.daemon";
+        ProgramArguments = [
+          "${cfg.package}/Applications/Cloudflare WARP.app/Contents/Resources/CloudflareWARP"
+        ];
+        UserName = "root";
+        RunAtLoad = true;
+        KeepAlive = true;
+        SoftResourceLimits = {
+          NumberOfFiles = 32768;
+        };
+      };
+    };
+  };
+
+  meta.maintainers = [
+    lib.maintainers.anish
+  ];
+}


### PR DESCRIPTION
I recently added Darwin support to `cloudflare-warp` in nixpkgs (see https://github.com/NixOS/nixpkgs/pull/481432 and https://github.com/NixOS/nixpkgs/pull/481599). Cloudflare WARP also requires a launchd daemon to be running for the GUI to communicate with, which this module sets up via `launchd.daemons`.

I tested this and it worked for me. However, if you have a previous Cloudflare WARP installation and get "Failed to save to disk" when running `warp-cli registration new`, you may need to clear stale keychain entries:

```bash
sudo security delete-generic-password -s "WARP" /Library/Keychains/System.keychain
sudo launchctl unload /Library/LaunchDaemons/com.cloudflare.1dot1dot1dot1.macos.warp.daemon.plist
sudo launchctl load /Library/LaunchDaemons/com.cloudflare.1dot1dot1dot1.macos.warp.daemon.plist
warp-cli registration new
```
