### PR TITLE
flake-module: add darwinModules option for flake-parts integration

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,11 +1,46 @@
 {
   lib,
+  flake-parts-lib,
+  moduleLocation,
   ...
 }:
+let
+  inherit (lib)
+    mapAttrs
+    mkOption
+    types
+    ;
+in
 {
-  options.flake.darwinConfigurations = lib.mkOption {
-    type = lib.types.lazyAttrsOf lib.types.raw;
-    default = { };
-    description = "Darwin system configurations";
+  options = {
+    flake = flake-parts-lib.mkSubmoduleOptions {
+      darwinConfigurations = mkOption {
+        type = types.lazyAttrsOf types.raw;
+        default = { };
+        description = ''
+          Instantiated nix-darwin configurations.
+
+          `darwinConfigurations` is for specific machines. If you want to expose
+          reusable configurations, add them to `darwinModules` in the form of modules, so
+          that you can reference them in this or another flake's `darwinConfigurations`.
+        '';
+      };
+      darwinModules = mkOption {
+        type = types.lazyAttrsOf types.deferredModule;
+        default = { };
+        apply = mapAttrs (
+          k: v: {
+            _class = "darwin";
+            _file = "${toString moduleLocation}#darwinModules.${k}";
+            imports = [ v ];
+          }
+        );
+        description = ''
+          nix-darwin modules.
+
+          You may use this for reusable pieces of configuration, service modules, etc.
+        '';
+      };
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,10 @@
       darwin-uninstaller = prev.callPackage ./pkgs/darwin-uninstaller { };
     };
 
-    flakeModules.default = ./flake-module.nix;
+    flakeModules = rec {
+      nix-darwin = ./flake-module.nix;
+      default = nix-darwin;
+    };
 
     darwinModules.hydra = ./modules/examples/hydra.nix;
     darwinModules.lnl = ./modules/examples/lnl.nix;


### PR DESCRIPTION
This PR enhances the flake-parts module to add support for `darwinModules`, following the same pattern as [home-manager's implementation](https://github.com/nix-community/home-manager/blob/master/flake-module.nix). This allows users to expose reusable nix-darwin modules through their flakes when using flake-parts.

This builds off of the previous PR #1670 