### PR TITLE
Make github-runners state, log, and work dirs use attr name

### DIFF
--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -128,7 +128,7 @@ in
         name = mkOption {
           type = types.nullOr types.str;
           description = ''
-            Name of the runner to configure. If null, defaults to the hostname.
+            Name of the runner to configure. If null, defaults to the attributes name.
 
             Changing this option triggers a new runner registration.
           '';


### PR DESCRIPTION
If you are running multiple runners with the same name (e.g. the hostname) in different repositories it will silently crash one of them because the are sharing the same state directories.

This Patch fixes this issue by using the GitHub runners attribute key instead of the `cfg.name` for seeding the log, state and work directories.

This is a breaking change (somewhat).