### PR TITLE
modules/nix: drop assertion for auto-optimise-store

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -812,13 +812,6 @@ in
         { assertion = elem "nixbld" config.users.knownGroups -> elem "nixbld" createdGroups; message = "refusing to delete group nixbld in users.knownGroups, this would break nix"; }
         { assertion = elem "_nixbld1" config.users.knownUsers -> elem "_nixbld1" createdUsers; message = "refusing to delete user _nixbld1 in users.knownUsers, this would break nix"; }
         { assertion = config.users.groups ? "nixbld" -> config.users.groups.nixbld.members != []; message = "refusing to remove all members from nixbld group, this would break nix"; }
-
-        {
-          # Should be fixed in Lix by https://gerrit.lix.systems/c/lix/+/2100
-          # Lix 2.92.0 will set `VERSION_SUFFIX` to `""`; `lib.versionAtLeast "" "pre20241107"` will return `true`.
-          assertion = cfg.settings.auto-optimise-store -> (cfg.package.pname == "lix" && (isNixAtLeast "2.92.0" && versionAtLeast (strings.removePrefix "-" cfg.package.VERSION_SUFFIX) "pre20241107"));
-          message = "`nix.settings.auto-optimise-store` is known to corrupt the Nix Store, please use `nix.optimise.automatic` instead.";
-        }
       ];
 
     # Not in NixOS module


### PR DESCRIPTION
This assertion is not (anymore?) in the [NixOS module](https://github.com/NixOS/nixpkgs/blob/f240e332610927da7e2b378ee51b2849e3317cc5/nixos/modules/config/nix.nix).

Also, the lix patch was ported to the official Nix implementation (see https://github.com/NixOS/nix/pull/14676).
Hence, I believe that we should drop this assertion.
