### PR TITLE
feat(bash): add an option to integrate shell aliases

### DIFF
--- a/modules/programs/bash/default.nix
+++ b/modules/programs/bash/default.nix
@@ -4,6 +4,12 @@ with lib;
 
 let
   cfg = config.programs.bash;
+
+  bashAliases = builtins.concatStringsSep "\n" (
+    lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}") (
+      lib.filterAttrs (k: v: v != null) cfg.shellAliases
+    )
+  );
 in
 
 {
@@ -17,6 +23,15 @@ in
       type = types.bool;
       default = true;
       description = "Whether to configure bash as an interactive shell.";
+    };
+
+    programs.bash.shellAliases = lib.mkOption {
+      default = { };
+      description = ''
+        Set of aliases for bash shell, which overrides {option}`environment.shellAliases`.
+        See {option}`environment.shellAliases` for an option format description.
+      '';
+      type = with lib.types; attrsOf (nullOr (either str path));
     };
 
     programs.bash.interactiveShellInit = mkOption {
@@ -74,6 +89,8 @@ in
       shopt -s checkwinsize
 
       ${config.system.build.setAliases.text}
+
+      ${bashAliases}
 
       ${config.environment.interactiveShellInit}
       ${cfg.interactiveShellInit}


### PR DESCRIPTION
This adds a new option in `programs.bash`: `shellAliases`. It copies the logic directly from upstream NixOS code with no change.

This should bring the functionalities to macOS systems with no downsides.

Reference:
- helper: https://github.com/NixOS/nixpkgs/blob/8884a11555a31d5c0fef1b0d277c135687ea5a96/nixos/modules/programs/bash/bash.nix#L17-L21
- option: https://github.com/NixOS/nixpkgs/blob/8884a11555a31d5c0fef1b0d277c135687ea5a96/nixos/modules/programs/bash/bash.nix#L44-L51
- `/etc/bashrc`: https://github.com/NixOS/nixpkgs/blob/8884a11555a31d5c0fef1b0d277c135687ea5a96/nixos/modules/programs/bash/bash.nix#L149

I guessed the best location in the `/etc/bashrc` to include this, since the `nix-darwin` one varies slightly from the `nixos` one.

cc https://github.com/nix-darwin/nix-darwin/issues/1695 
cc https://github.com/nobe4/dotfiles/pull/51
cc https://nobe4.fr/posts/nix-darwin-shell-override/