### PR TITLE
feat(zsh): add an option to integrate shell aliases and zsh options

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -9,6 +9,12 @@ let
   zshVariables =
     mapAttrsToList (n: v: ''${n}="${v}"'') cfg.variables;
 
+  zshAliases = builtins.concatStringsSep "\n" (
+    lib.mapAttrsToList (k: v: "alias -- ${k}=${lib.escapeShellArg v}") (
+      lib.filterAttrs (k: v: v != null) cfg.shellAliases
+    )
+  );
+
   fzfCompletion = ./fzf-completion.zsh;
   fzfGit = ./fzf-git.zsh;
   fzfHistory = ./fzf-history.zsh;
@@ -33,6 +39,15 @@ in
         characters.
       '';
       apply = mapAttrs (n: v: if isList v then concatStringsSep ":" v else v);
+    };
+
+    programs.zsh.shellAliases = lib.mkOption {
+      default = { };
+      description = ''
+        Set of aliases for zsh shell, which overrides {option}`environment.shellAliases`.
+        See {option}`environment.shellAliases` for an option format description.
+      '';
+      type = with lib.types; attrsOf (nullOr (either str path));
     };
 
     programs.zsh.shellInit = mkOption {
@@ -71,6 +86,22 @@ in
       description = "Change history file.";
     };
 
+    programs.zsh.setOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "HIST_IGNORE_DUPS"
+        "SHARE_HISTORY"
+        "HIST_FCNTL_LOCK"
+      ];
+      example = [
+        "EXTENDED_HISTORY"
+        "RM_STAR_WAIT"
+      ];
+      description = ''
+        Configure zsh options. See
+        {manpage}`zshoptions(1)`.
+      '';
+    };
     programs.zsh.enableCompletion = mkOption {
       type = types.bool;
       default = true;
@@ -207,7 +238,10 @@ in
       HISTSIZE=${builtins.toString cfg.histSize}
       HISTFILE=${cfg.histFile}
 
-      setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
+      ${lib.optionalString (cfg.setOptions != [ ]) ''
+        # Set zsh options.
+        setopt ${builtins.concatStringsSep " " cfg.setOptions}
+      ''}
 
       bindkey -e
 
@@ -234,6 +268,9 @@ in
       ${optionalString cfg.enableFzfCompletion "source ${fzfCompletion}"}
       ${optionalString cfg.enableFzfGit "source ${fzfGit}"}
       ${optionalString cfg.enableFzfHistory "source ${fzfHistory}"}
+
+      # Setup aliases.
+      ${zshAliases}
 
       # Read system-wide modifications.
       if test -f /etc/zshrc.local; then


### PR DESCRIPTION
This adds a new option in `programs.zsh`: `shellAliases`. It copies the logic directly from upstream NixOS code with no change.

This should bring the functionalities to macOS systems with no downsides.

Reference:
- helper: https://github.com/NixOS/nixpkgs/blob/38f36dd24fe8bc36f0b0aefd103c4a730538a6fc/nixos/modules/programs/zsh/zsh.nix#L18-L22
- option:
    - https://github.com/NixOS/nixpkgs/blob/38f36dd24fe8bc36f0b0aefd103c4a730538a6fc/nixos/modules/programs/zsh/zsh.nix#L61-L68
    - https://github.com/NixOS/nixpkgs/blob/38f36dd24fe8bc36f0b0aefd103c4a730538a6fc/nixos/modules/programs/zsh/zsh.nix#L124-L139
- `/etc/zshrc`:
    - https://github.com/NixOS/nixpkgs/blob/38f36dd24fe8bc36f0b0aefd103c4a730538a6fc/nixos/modules/programs/zsh/zsh.nix#L247-L250
    - https://github.com/NixOS/nixpkgs/blob/38f36dd24fe8bc36f0b0aefd103c4a730538a6fc/nixos/modules/programs/zsh/zsh.nix#L284-L285

I guessed the best location in the `/etc/zshrc` to include this, since the `nix-darwin` one varies slightly from the `nixos` one.

Note that the default values correspond to what the `setopt` was fixed, so no change are expected.

cc https://github.com/nix-darwin/nix-darwin/issues/1695
cc https://github.com/nobe4/dotfiles/pull/51
cc https://nobe4.fr/posts/nix-darwin-shell-override/