### PR TITLE
Load LaunchAgents as the user

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -206,6 +206,11 @@ in
           name
         ]
       ) (attrNames cfg.user.envVariables)
+      ++ lib.map (name: lib.showOption [
+        "launchd"
+        "agents"
+        name
+      ]) (attrNames cfg.agents)
       ++ lib.map ({ managedBy, ... }: managedBy) (attrValues cfg.user.agents);
 
     environment.launchAgents = mapAttrs' toEnvironmentText cfg.agents;


### PR DESCRIPTION
Fixes one part of https://github.com/nix-darwin/nix-darwin/issues/1255, specifically this error:

```
Warning: Expecting a LaunchDaemons path since the command was ran as root. Got LaunchAgents instead.
`launchctl bootout` is a recommended alternative.
Unload failed: 5: Input/output error
Try running `launchctl bootout` as root for richer errors.
```

LaunchAgents should run as the user, but calling `launchctl load` as root tries to load the Agents to the root user which might have unintended consequences. The way to load LaunchAgents located in ~/Library also works here.

I changed `launchd.launchAgents` to load the same way `launchd.userLaunchAgents` is loaded. As a result, setting `launchd.launchAgents` now requires `system.primaryUser`.