### PR TITLE
aerospace: Add support for config-version and persistent-workspaces

### DIFF
--- a/modules/services/aerospace/default.nix
+++ b/modules/services/aerospace/default.nix
@@ -52,6 +52,17 @@ in
               default = false;
               description = "Do not start AeroSpace at login. (Managed by launchd instead)";
             };
+            config-version = lib.mkOption {
+              type = int;
+              default = 1;
+              description = "Config version for compatibility and deprecations";
+            };
+            persistent-workspaces = lib.mkOption {
+              type = listOf str;
+              default = [ ];
+              description = "List of workspaces that should stay alive even when empty. Only available when config-version >= 2.";
+              example = [ "1" "2" "A" "B" ];
+            };
             after-login-command = lib.mkOption {
               type = listOf str;
               default = [ ];
@@ -242,6 +253,10 @@ in
         {
           assertion = cfg.settings.after-login-command == [ ];
           message = "AeroSpace will not run these commands as it does not start itself.";
+        }
+        {
+          assertion = (cfg.settings.persistent-workspaces == [ ]) || (cfg.settings.config-version >= 2);
+          message = "persistent-workspaces requires config-version >= 2";
         }
       ];
       environment.systemPackages = [ cfg.package ];


### PR DESCRIPTION
## Summary

Adds support for AeroSpace's `config-version` and `persistent-workspaces` configuration options to the nix-darwin aerospace module.

Fixes #1714

## Changes

1. **Added config-version option**
   - Type: `int`
   - Default: `1`
   - Description: Configuration version for compatibility and deprecations

2. **Added persistent-workspaces option**
   - Type: `listOf str`
   - Default: `[]`
   - Description: List of workspaces that stay alive even when empty
   - Example: `[ "1" "2" "A" "B" ]`

3. **Added validation**
   - Assertion ensures `persistent-workspaces` can only be used when `config-version >= 2`
   - Error message: "persistent-workspaces requires config-version >= 2"

## Documentation Reference

These options are documented in the [AeroSpace guide](https://nikitabobko.github.io/AeroSpace/guide#default-config):
- `config-version` enables newer features and ensures compatibility
- `persistent-workspaces` is only available since config-version 2

## Testing

Tested with a local nix-darwin configuration:
- Build succeeds with `config-version = 2` and `persistent-workspaces` set
- Generated TOML correctly includes both options
- Build fails with validation error when `persistent-workspaces` is used with `config-version = 1`
- Build succeeds when `persistent-workspaces` is empty (regardless of config-version)

## Example Usage

```nix
services.aerospace = {
  enable = true;
  settings = {
    config-version = 2;
    persistent-workspaces = [ "Q" "W" "F" "A" "R" "S" "Z" "M" ];
    # ... other settings
  };
};
```

Generates TOML output:
```toml
config-version = 2
persistent-workspaces = ["Q", "W", "F", "A", "R", "S", "Z", "M"]
```