### PR TITLE
modules/networking/wifi: New Module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -51,6 +51,7 @@
   ./time
   ./networking
   ./networking/applicationFirewall.nix
+  ./networking/wifi.nix
   ./nix
   ./nix/linux-builder.nix
   ./nix/nix-darwin.nix

--- a/modules/networking/wifi.nix
+++ b/modules/networking/wifi.nix
@@ -1,0 +1,81 @@
+{ config, lib, ... }:
+let
+  cfg = config.networking.wifi;
+in
+{
+  meta.maintainers = [ lib.maintainers._347Online or "347Online" ];
+
+  options = {
+    networking.wifi = {
+      AskToJoinNetworks = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "Off"
+            "Notify"
+            "Ask"
+          ]
+        );
+        default = null;
+        example = "Notify";
+        description = ''
+          Sets the behavior for when no known Wi-Fi network is available:
+
+              Off
+                  Known networks will be joined automatically.
+                  If no known networks are available, you will have to manually select a network.
+
+              Notify (macOS default)
+                  Known networks will be joined automatically.
+                  If no known networks are available, you will be notified of available networks.
+
+              Ask (macOS Tahoe and later)
+                  Known networks will be joined automatically.
+                  If no known networks are available, you will be asked before joining a new network.
+
+          This is equivalent to the setting in 'System Settings > Wi-Fi'
+        '';
+        apply =
+          value:
+          if value == "Off" then
+            "DoNothing"
+          else if value == "Ask" then
+            "Prompt"
+          else
+            value;
+      };
+      AskToJoinHotspots = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "Never"
+            "AskToJoin"
+            "Automatic"
+          ]
+        );
+        default = null;
+        example = "AskToJoin";
+        description = ''
+          Sets the behavior for when nearby personal hotspots are detected and no Wi-Fi network is available:
+
+              Never
+                  Do nothing
+
+              AskToJoin (macOS default)
+                  Show a notification prompting the user to join personal hotspot if it is available
+
+              Automatic (macOS Tahoe and later)
+                  Connect to personal hotspot automatically
+
+          This is equivalent to the setting in 'System Settings > Wi-Fi'
+        '';
+      };
+    };
+  };
+
+  config = {
+    system.defaults.CustomSystemPreferences."/Library/Preferences/SystemConfiguration/com.apple.airport.preferences" =
+      {
+        AutoHotspotMode = cfg.AskToJoinHotspots;
+        JoinModeFallback = [ cfg.AskToJoinNetworks ];
+      };
+  };
+}


### PR DESCRIPTION
Configures Wi-Fi settings (fixes #1716)

Options for behavior when networks or hotspots are detected

- [x] Document macOS version after which the defined settings are available, as discussed here: https://github.com/nix-darwin/nix-darwin/issues/1716#issuecomment-3969426376