### PR TITLE
services/openssh: only manage host keys when module is enabled

### DIFF
--- a/modules/services/openssh.nix
+++ b/modules/services/openssh.nix
@@ -122,12 +122,12 @@ in
       fi
     '');
 
-    environment.etc."ssh/sshd_config.d/099-host-keys.conf" = lib.mkIf (cfg.hostKeys != []) {
+    environment.etc."ssh/sshd_config.d/099-host-keys.conf" = lib.mkIf (cfg.enable != null && cfg.hostKeys != []) {
       text = hostKeysConfig;
     };
 
     environment.etc."ssh/sshd_config.d/100-nix-darwin.conf".text = cfg.extraConfig;
 
-    system.activationScripts.openssh.text = lib.mkIf (cfg.hostKeys != []) keygenScript;
+    system.activationScripts.openssh.text = lib.mkIf (cfg.enable != null && cfg.hostKeys != []) keygenScript;
   };
 }


### PR DESCRIPTION
I don't think it makes sense for host keys to be generated/managed when the OpenSSH module is not enabled; because `services.openssh.hostKeys` does not default to `[]` the module currently generates a set of host keys by default for anyone who isn't using the module at all.