### PR TITLE
etc: support Lix 2.95.1

### DIFF
--- a/doc/known-files/a6dee4985bf207d3bec6a3cee28aefb33e60f5d0a91d8c20bbd71b9dadb2e601
+++ b/doc/known-files/a6dee4985bf207d3bec6a3cee28aefb33e60f5d0a91d8c20bbd71b9dadb2e601
@@ -1,0 +1,3 @@
+# Written by https://install.lix.systems/.
+# The contents below are based on options specified at installation time.
+

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -891,6 +891,8 @@ in
         3bd68ef979a42070a44f8d82c205cfd8e8cca425d91253ec2c10a88179bb34aa
         # Nix 2.33.3
         71f7fdc9f6c9e55ca0f2e6f85137037d660b3224a34d59305e8530ca292bc734
+        # Lix 2.95.1
+        a6dee4985bf207d3bec6a3cee28aefb33e60f5d0a91d8c20bbd71b9dadb2e601
       )
       if [[ -e /etc/nix/nix.custom.conf ]]; then
         nixCustomConfSha256Output=$(shasum -a 256 /etc/nix/nix.custom.conf)


### PR DESCRIPTION
Relates to #1729

#1730 solves the first error, while this PR solves the second error. 

After installing lix 2.95.1 and manually renaming /etc/nix/nix.conf to skip the first error, running flakes with nix-darwin errors out:

```
error: custom settings in `/etc/nix/nix.custom.conf`, aborting activation
You will need to migrate these to nix-darwin `nix.*` settings if you
wish to keep them. Check the manual for the appropriate settings and
add them to your system configuration, then run:

  $ sudo mv /etc/nix/nix.custom.conf{,.before-nix-darwin}

and activate your system again.
```

I have added the sha256 for the `nix.custom.conf` file created by lix in the change.

Content is:
```
# Written by https://install.lix.systems/.
# The contents below are based on options specified at installation time.


```
