### PR TITLE
nixpkgs.config: Add allowUnfreePackages option

### DIFF
--- a/modules/nix/nixpkgs.nix
+++ b/modules/nix/nixpkgs.nix
@@ -17,10 +17,13 @@ let
   mergeConfig =
     lhs_: rhs_:
     let
-      lhs = optCall lhs_ { inherit pkgs; };
-      rhs = optCall rhs_ { inherit pkgs; };
+      lhs = optCall lhs_ { inherit lib pkgs; };
+      rhs = optCall rhs_ { inherit lib pkgs; };
     in
     lib.recursiveUpdate lhs rhs
+    // lib.optionalAttrs (lhs ? allowUnfreePackages) {
+      allowUnfreePackages = lhs.allowUnfreePackages ++ (lib.attrByPath [ "allowUnfreePackages" ] [ ] rhs);
+    }
     // lib.optionalAttrs (lhs ? packageOverrides) {
       packageOverrides =
         pkgs:

--- a/release.nix
+++ b/release.nix
@@ -93,6 +93,7 @@ in {
   tests.networking-networkservices-no-dhcp-client-id = makeTest ./tests/networking-networkservices-no-dhcp-client-id.nix;
   tests.nix-enable = makeTest ./tests/nix-enable.nix;
   tests.nixpkgs-overlays = makeTest ./tests/nixpkgs-overlays.nix;
+  tests.nixpkgs-config-allow-unfree = makeTest ./tests/nixpkgs-config-allow-unfree.nix;
   tests.programs-gnupg = makeTest ./tests/programs-gnupg.nix;
   tests.programs-ssh = makeTest ./tests/programs-ssh.nix;
   tests.programs-tmux = makeTest ./tests/programs-tmux.nix;

--- a/tests/nixpkgs-config-allow-unfree.nix
+++ b/tests/nixpkgs-config-allow-unfree.nix
@@ -1,0 +1,45 @@
+# Check that nixpkgs.config.allowUnfreePackages is merged correctly
+# run with: nix-build release.nix -A tests.nixpkgs-config-allow-unfree
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  # Module 1: Define some unfree packages
+  nixpkgs.config.allowUnfreePackages = [
+    "vscode"
+    "slack"
+  ];
+
+  # Module 2: Define more unfree packages (simulating multiple modules)
+  # In a real scenario, this would be in a separate file
+  imports = [
+    (
+      { config, ... }:
+      {
+        nixpkgs.config.allowUnfreePackages = [
+          "zoom"
+          "discord"
+        ];
+      }
+    )
+  ];
+
+  test = ''
+    echo checking allowUnfreePackages merging >&2
+
+    # Verify that all packages from both modules are present
+    expected_packages=("discord" "slack" "vscode" "zoom")
+    actual_packages=(${builtins.toString (builtins.sort builtins.lessThan config.nixpkgs.config.allowUnfreePackages)})
+
+    for pkg in "''${expected_packages[@]}"; do
+      if [[ ! " ''${actual_packages[@]} " =~ " $pkg " ]]; then
+        echo "ERROR: Expected package '$pkg' not found in allowUnfreePackages" >&2
+        exit 1
+      fi
+    done
+  '';
+}


### PR DESCRIPTION
Make sure it merges correctly and verify with a test.

This was added in nixpkgs some time ago and is quite a nice addition as it merges additively (in contrast to allowUnfreePredicate) thus allowing to localize allowUnfreePackage specifications to all the locations in your local config where unfree packages are added.

A test is also provided which can be executed with

```sh
nix-build release.nix -A tests.nixpkgs-config-allow-unfree
```

Please let me know if there is anything else you need to get this merged.