### PR TITLE
homebrew: add onActivation.extraEnv option

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -142,6 +142,43 @@ let
           activation.
         '';
       };
+      envHints = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Homebrew to print environment variable hints (e.g.,
+          "Hide these hints with HOMEBREW_NO_ENV_HINTS") during {command}`nix-darwin` system
+          activation.
+
+          Implementation note: when disabled, this option sets the `HOMEBREW_NO_ENV_HINTS`
+          environment variable when {command}`nix-darwin` invokes {command}`brew bundle [install]`
+          during system activation.
+        '';
+      };
+      analytics = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Homebrew to print analytics notices and collect anonymous analytics
+          during {command}`nix-darwin` system activation.
+
+          Implementation note: when disabled, this option sets the `HOMEBREW_NO_ANALYTICS`
+          environment variable when {command}`nix-darwin` invokes {command}`brew bundle [install]`
+          during system activation.
+        '';
+      };
+      updateReportNew = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Homebrew to print lists of new formulae and casks after auto-updating
+          during {command}`nix-darwin` system activation.
+
+          Implementation note: when disabled, this option sets the
+          `HOMEBREW_NO_UPDATE_REPORT_NEW` environment variable when {command}`nix-darwin` invokes
+          {command}`brew bundle [install]` during system activation.
+        '';
+      };
       extraFlags = mkOption {
         type = types.listOf types.str;
         default = [ ];
@@ -158,6 +195,9 @@ let
     config = {
       brewBundleCmd = concatStringsSep " " (
         optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+        ++ optional (!config.envHints) "HOMEBREW_NO_ENV_HINTS=1"
+        ++ optional (!config.analytics) "HOMEBREW_NO_ANALYTICS=1"
+        ++ optional (!config.updateReportNew) "HOMEBREW_NO_UPDATE_REPORT_NEW=1"
         ++ [ "brew bundle --file='${brewfileFile}'" ]
         ++ optional (!config.upgrade) "--no-upgrade"
         ++ optional (config.cleanup == "uninstall") "--cleanup"
@@ -204,6 +244,42 @@ let
           [](#opt-environment.variables).
         '';
       };
+      envHints = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Homebrew to print environment variable hints (e.g.,
+          "Hide these hints with HOMEBREW_NO_ENV_HINTS") when you manually invoke Homebrew commands.
+
+          Implementation note: when disabled, this option sets the
+          `HOMEBREW_NO_ENV_HINTS` environment variable, by adding it to
+          [](#opt-environment.variables).
+        '';
+      };
+      analytics = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Homebrew to print analytics notices and collect anonymous analytics
+          when you manually invoke Homebrew commands.
+
+          Implementation note: when disabled, this option sets the
+          `HOMEBREW_NO_ANALYTICS` environment variable, by adding it to
+          [](#opt-environment.variables).
+        '';
+      };
+      updateReportNew = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable Homebrew to print lists of new formulae and casks after auto-updating
+          when you manually invoke Homebrew commands.
+
+          Implementation note: when disabled, this option sets the
+          `HOMEBREW_NO_UPDATE_REPORT_NEW` environment variable, by adding it to
+          [](#opt-environment.variables).
+        '';
+      };
       # `noLock` was the original option; `lockfiles` replaced it (with inverted semantics).
       # Both are now dead: Homebrew Bundle removed lockfile support in Homebrew 4.4.0
       # (Oct 2024), so the `HOMEBREW_BUNDLE_NO_LOCK` env var and `--no-lock` CLI flag are
@@ -220,6 +296,9 @@ let
       homebrewEnvironmentVariables = {
         HOMEBREW_BUNDLE_FILE = mkIf config.brewfile "${brewfileFile}";
         HOMEBREW_NO_AUTO_UPDATE = mkIf (!config.autoUpdate) "1";
+        HOMEBREW_NO_ENV_HINTS = mkIf (!config.envHints) "1";
+        HOMEBREW_NO_ANALYTICS = mkIf (!config.analytics) "1";
+        HOMEBREW_NO_UPDATE_REPORT_NEW = mkIf (!config.updateReportNew) "1";
       };
     };
   };

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -142,41 +142,24 @@ let
           activation.
         '';
       };
-      envHints = mkOption {
-        type = types.bool;
-        default = true;
+      extraEnv = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        example = {
+          HOMEBREW_NO_ENV_HINTS = "1";
+          HOMEBREW_NO_ANALYTICS = "1";
+        };
         description = ''
-          Whether to enable Homebrew to print environment variable hints (e.g.,
-          "Hide these hints with HOMEBREW_NO_ENV_HINTS") during {command}`nix-darwin` system
-          activation.
-
-          Implementation note: when disabled, this option sets the `HOMEBREW_NO_ENV_HINTS`
-          environment variable when {command}`nix-darwin` invokes {command}`brew bundle [install]`
-          during system activation.
-        '';
-      };
-      analytics = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable Homebrew to print analytics notices and collect anonymous analytics
-          during {command}`nix-darwin` system activation.
-
-          Implementation note: when disabled, this option sets the `HOMEBREW_NO_ANALYTICS`
-          environment variable when {command}`nix-darwin` invokes {command}`brew bundle [install]`
-          during system activation.
-        '';
-      };
-      updateReportNew = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable Homebrew to print lists of new formulae and casks after auto-updating
-          during {command}`nix-darwin` system activation.
-
-          Implementation note: when disabled, this option sets the
-          `HOMEBREW_NO_UPDATE_REPORT_NEW` environment variable when {command}`nix-darwin` invokes
+          Extra environment variables to set when {command}`nix-darwin` invokes
           {command}`brew bundle [install]` during system activation.
+
+          Useful for setting Homebrew's `HOMEBREW_NO_*` variables (e.g.,
+          `HOMEBREW_NO_ENV_HINTS`, `HOMEBREW_NO_ANALYTICS`, `HOMEBREW_NO_UPDATE_REPORT_NEW`)
+          that aren't inherited from the user's shell environment because activation runs
+          under sudo.
+
+          Each entry is prepended to the {command}`brew bundle` invocation in the form
+          `KEY=VALUE`, alongside `HOMEBREW_NO_AUTO_UPDATE=1` when applicable.
         '';
       };
       extraFlags = mkOption {
@@ -195,9 +178,7 @@ let
     config = {
       brewBundleCmd = concatStringsSep " " (
         optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
-        ++ optional (!config.envHints) "HOMEBREW_NO_ENV_HINTS=1"
-        ++ optional (!config.analytics) "HOMEBREW_NO_ANALYTICS=1"
-        ++ optional (!config.updateReportNew) "HOMEBREW_NO_UPDATE_REPORT_NEW=1"
+        ++ mapAttrsToList (k: v: "${k}=${escapeShellArg v}") config.extraEnv
         ++ [ "brew bundle --file='${brewfileFile}'" ]
         ++ optional (!config.upgrade) "--no-upgrade"
         ++ optional (config.cleanup == "uninstall") "--cleanup"
@@ -244,42 +225,6 @@ let
           [](#opt-environment.variables).
         '';
       };
-      envHints = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable Homebrew to print environment variable hints (e.g.,
-          "Hide these hints with HOMEBREW_NO_ENV_HINTS") when you manually invoke Homebrew commands.
-
-          Implementation note: when disabled, this option sets the
-          `HOMEBREW_NO_ENV_HINTS` environment variable, by adding it to
-          [](#opt-environment.variables).
-        '';
-      };
-      analytics = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable Homebrew to print analytics notices and collect anonymous analytics
-          when you manually invoke Homebrew commands.
-
-          Implementation note: when disabled, this option sets the
-          `HOMEBREW_NO_ANALYTICS` environment variable, by adding it to
-          [](#opt-environment.variables).
-        '';
-      };
-      updateReportNew = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable Homebrew to print lists of new formulae and casks after auto-updating
-          when you manually invoke Homebrew commands.
-
-          Implementation note: when disabled, this option sets the
-          `HOMEBREW_NO_UPDATE_REPORT_NEW` environment variable, by adding it to
-          [](#opt-environment.variables).
-        '';
-      };
       # `noLock` was the original option; `lockfiles` replaced it (with inverted semantics).
       # Both are now dead: Homebrew Bundle removed lockfile support in Homebrew 4.4.0
       # (Oct 2024), so the `HOMEBREW_BUNDLE_NO_LOCK` env var and `--no-lock` CLI flag are
@@ -296,9 +241,6 @@ let
       homebrewEnvironmentVariables = {
         HOMEBREW_BUNDLE_FILE = mkIf config.brewfile "${brewfileFile}";
         HOMEBREW_NO_AUTO_UPDATE = mkIf (!config.autoUpdate) "1";
-        HOMEBREW_NO_ENV_HINTS = mkIf (!config.envHints) "1";
-        HOMEBREW_NO_ANALYTICS = mkIf (!config.analytics) "1";
-        HOMEBREW_NO_UPDATE_REPORT_NEW = mkIf (!config.updateReportNew) "1";
       };
     };
   };


### PR DESCRIPTION
## Summary

Adds a generic `homebrew.onActivation.extraEnv` option — an attrset of environment variables prepended to the `brew bundle` invocation during `darwin-rebuild switch`, alongside the existing `HOMEBREW_NO_AUTO_UPDATE=1`.

```nix
homebrew.onActivation.extraEnv = {
  HOMEBREW_NO_ENV_HINTS = "1";
  HOMEBREW_NO_ANALYTICS = "1";
  HOMEBREW_NO_UPDATE_REPORT_NEW = "1";
};
```

## Motivation

During `darwin-rebuild switch`, `brew bundle` produces noisy output (analytics notices, env hints, new formulae reports). Shell environment variables set in `.zshrc` aren't inherited by the activation script (it runs under sudo), and there was no module-level way to suppress them.

## Design

Follows the approach suggested in [#1745 (comment)](https://github.com/nix-darwin/nix-darwin/pull/1745#issuecomment-4239842172): rather than adding one first-class boolean per `HOMEBREW_NO_*` env var, expose a generic `extraEnv` escape hatch that mirrors the existing `extraFlags` / `extraConfig` patterns and matches the `extraEnv` naming used elsewhere in nixpkgs. This covers the long tail of Homebrew env vars without churning on upstream naming changes.

No `global.extraEnv` equivalent — as noted in the same review thread, `environment.variables` already accepts arbitrary attrsets, so a global wrapper would be pure sugar. The activation variant is load-bearing because it needs module help to get past the sudo boundary.

## Implementation

- `homebrew.onActivation.extraEnv` is an `attrsOf str`, defaulting to `{}`.
- Entries are shell-escaped and prepended to `brewBundleCmd` via `mapAttrsToList`.

## Test plan

- Ran `nix-build release.nix -A tests.homebrew` — passes.
- Evaluated `homebrew.onActivation.brewBundleCmd` with `extraEnv = { HOMEBREW_NO_ENV_HINTS = "1"; HOMEBREW_NO_ANALYTICS = "1"; };` and confirmed the rendered command contains the expected `KEY=VALUE` prefixes before `brew bundle`.
- Tested locally by overriding the nix-darwin flake input to this branch and running `darwin-rebuild switch` — Homebrew output is suppressed during activation.

---

<details>
<summary>Original proposal (superseded after review)</summary>

> ## ~~Summary~~
>
> ~~Adds three new boolean options to both `onActivation` and `global` homebrew submodules, following the existing `autoUpdate` pattern:~~
>
> - ~~**`envHints`** — when `false`, sets `HOMEBREW_NO_ENV_HINTS=1` to suppress "Hide these hints..." messages~~
> - ~~**`analytics`** — when `false`, sets `HOMEBREW_NO_ANALYTICS=1` to suppress analytics notices and disable collection~~
> - ~~**`updateReportNew`** — when `false`, sets `HOMEBREW_NO_UPDATE_REPORT_NEW=1` to suppress "New Formulae/Casks" lists after auto-update~~
>
> ~~All default to `true` to preserve existing behavior (non-breaking).~~
>
> ## ~~Implementation~~
>
> ~~Mirrors the existing `autoUpdate` pattern exactly:~~
>
> - ~~**`onActivation`**: env vars prepended to `brewBundleCmd`, same as `HOMEBREW_NO_AUTO_UPDATE`~~
> - ~~**`global`**: env vars added to `homebrewEnvironmentVariables` → `environment.variables`, same as `HOMEBREW_NO_AUTO_UPDATE`~~
>
> ~~Usage:~~
>
> ```nix
> homebrew = {
>   onActivation = { envHints = false; analytics = false; updateReportNew = false; };
>   global = { envHints = false; analytics = false; updateReportNew = false; };
> };
> ```

Replaced with a single `onActivation.extraEnv` attrset per review discussion above.

</details>
