### PR TITLE
Add system.keyboard.builtinKeyboardOnly option

### DIFF
--- a/modules/system/keyboard.nix
+++ b/modules/system/keyboard.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -44,10 +49,23 @@ in
       description = "Whether to swap the left Control key and Fn (Globe) key.";
     };
 
+    system.keyboard.builtinKeyboardOnly = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to apply keyboard mappings only to the built-in MacBook keyboard,
+        leaving external keyboards unaffected.
+
+        Uses `hidutil --matching` to target only the Apple Internal Keyboard.
+        This is verified to work on Apple Silicon Macs. Older Intel MacBooks may
+        use a different product string.
+      '';
+    };
+
     system.keyboard.userKeyMapping = mkOption {
       internal = true;
       type = types.listOf (types.attrsOf types.int);
-      default = [];
+      default = [ ];
       description = ''
         List of keyboard mappings to apply, for more information see
         <https://developer.apple.com/library/content/technotes/tn2450/_index.html>.
@@ -57,13 +75,23 @@ in
 
   config = {
 
-    warnings = mkIf (!cfg.enableKeyMapping && cfg.userKeyMapping != [])
-      [ "system.keyboard.enableKeyMapping is not enabled, keyboard mappings will not be configured." ];
+    warnings = mkIf (!cfg.enableKeyMapping && cfg.userKeyMapping != [ ]) [
+      "system.keyboard.enableKeyMapping is not enabled, keyboard mappings will not be configured."
+    ];
 
     system.keyboard.userKeyMapping = [
-      (mkIf cfg.remapCapsLockToControl { HIDKeyboardModifierMappingSrc = 30064771129; HIDKeyboardModifierMappingDst = 30064771296; })
-      (mkIf cfg.remapCapsLockToEscape { HIDKeyboardModifierMappingSrc = 30064771129; HIDKeyboardModifierMappingDst = 30064771113; })
-      (mkIf cfg.nonUS.remapTilde { HIDKeyboardModifierMappingSrc = 30064771172; HIDKeyboardModifierMappingDst = 30064771125; })
+      (mkIf cfg.remapCapsLockToControl {
+        HIDKeyboardModifierMappingSrc = 30064771129;
+        HIDKeyboardModifierMappingDst = 30064771296;
+      })
+      (mkIf cfg.remapCapsLockToEscape {
+        HIDKeyboardModifierMappingSrc = 30064771129;
+        HIDKeyboardModifierMappingDst = 30064771113;
+      })
+      (mkIf cfg.nonUS.remapTilde {
+        HIDKeyboardModifierMappingSrc = 30064771172;
+        HIDKeyboardModifierMappingDst = 30064771125;
+      })
       (mkIf cfg.swapLeftCommandAndLeftAlt {
         HIDKeyboardModifierMappingSrc = 30064771299;
         HIDKeyboardModifierMappingDst = 30064771298;
@@ -82,11 +110,15 @@ in
       })
     ];
 
-    system.activationScripts.keyboard.text = optionalString cfg.enableKeyMapping ''
-      # Configuring keyboard
-      echo "configuring keyboard..." >&2
-      hidutil property --set '{"UserKeyMapping":${builtins.toJSON cfg.userKeyMapping}}' > /dev/null
-    '';
+    system.activationScripts.keyboard.text =
+      let
+        matchingArg = optionalString cfg.builtinKeyboardOnly ''--matching '{"Product":"Apple Internal Keyboard / Trackpad","PrimaryUsagePage":1,"PrimaryUsage":6}' '';
+      in
+      optionalString cfg.enableKeyMapping ''
+        # Configuring keyboard
+        echo "configuring keyboard..." >&2
+        hidutil property ${matchingArg}--set '{"UserKeyMapping":${builtins.toJSON cfg.userKeyMapping}}' > /dev/null
+      '';
 
   };
 }


### PR DESCRIPTION
> [!WARNING]
> This doesn't seem to keep mappings through the restarts. I think the approach for mapping has to be more complex (see #210).

This partially addresses #1566. In my mind, this remapping the builtin keyboard would be the most common use-case as external keyboards typically have software of their own.