### PR TITLE
modules/system/launchd: tolerate unreachable user GUI domain on activation

### DIFF
--- a/modules/system/launchd.nix
+++ b/modules/system/launchd.nix
@@ -45,7 +45,11 @@ let
         sudo --user=${user} -- rm ~${user}/Library/LaunchAgents/${target}
       fi
       sudo --user=${user} -- cp -f '${cfg.build.launchd}/user/Library/LaunchAgents/${target}' ~${user}/Library/LaunchAgents/${target}
-      launchctl asuser "$(id -u -- ${user})" sudo --user=${user} -- launchctl load -w ~${user}/Library/LaunchAgents/${target}
+      if launchctl asuser "$(id -u -- ${user})" launchctl print "gui/$(id -u -- ${user})" &> /dev/null; then
+        launchctl asuser "$(id -u -- ${user})" sudo --user=${user} -- launchctl load -w ~${user}/Library/LaunchAgents/${target}
+      else
+        echo "warning: ${user}'s GUI domain unreachable from this session; user service $(basename ${target} .plist) will be picked up on next login" >&2
+      fi
     fi
   '';
 


### PR DESCRIPTION
Closes #1758.

When `darwin-rebuild switch` runs from a context that can't reach the primary user's launchd GUI domain — typically an SSH session as a non-primary deploy user, sudo'd up to root — `launchctl asuser ... launchctl load -w` fails and `set -e` kills the rest of the activation. None of the steps after the `userLaunchd` block run (`networking`, `nvram`, `homebrew`, the final `/run/current-system` symlink), and the system is left inconsistent.

This probes whether the user's GUI domain is reachable before attempting the load. If it isn't, the load is skipped with a warning — the plist has already been `cp -f`'d into place, so the new agent gets picked up on the user's next login. Real load failures (malformed plist, permissions, etc.) still propagate as before, since only the unreachable-domain case is gated.

Tested on macOS 26.3: reproduced the original abort, confirmed the patch lets activation finish cleanly with the warning, and confirmed local `darwin-rebuild switch` as the primary user still takes the original codepath.
