### PR TITLE
users: add picture option

### DIFF
--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -1,10 +1,10 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) concatStringsSep concatMapStringsSep elem escapeShellArg
-    escapeShellArgs filter filterAttrs flatten flip mapAttrs' mapAttrsToList
-    mkAfter mkIf mkMerge mkOption mkOrder mkRemovedOptionModule optionals
-    optionalString types;
+  inherit (lib) any concatStringsSep concatMapStringsSep elem escapeShellArg
+    escapeShellArgs filter filterAttrs flatten flip hasSuffix mapAttrs'
+    mapAttrsToList mkAfter mkIf mkMerge mkOption mkOrder mkRemovedOptionModule
+    optionals optionalString types;
 
   cfg = config.users;
 
@@ -140,9 +140,15 @@ in
     ));
 
     warnings = flatten (flip mapAttrsToList cfg.users (name: user:
-      mkIf
-        (user.shell.pname or null == "bash")
-        "Set `users.users.${name}.shell = pkgs.bashInteractive;` instead of `pkgs.bash` as it does not include `readline`."
+      [
+        (mkIf
+          (user.shell.pname or null == "bash")
+          "Set `users.users.${name}.shell = pkgs.bashInteractive;` instead of `pkgs.bash` as it does not include `readline`.")
+        (mkIf
+            (user.picture or null != null
+              && !any (ext: hasSuffix ext user.picture) [ ".jpg" ".jpeg" ])
+          "Set `users.users.${name}.picture` to a JPEG, since other image types do not appear on the login screen.")
+      ]
     ));
 
     users.gids = mkMerge gids;
@@ -312,6 +318,11 @@ in
           dscl . -create ${dsclUser} PrimaryGroupID ${toString v.gid}
           ${optionalString (v.description != null) "dscl . -create ${dsclUser} RealName ${escapeShellArg v.description}"}
           ${optionalString (v.shell != null) "dscl . -create ${dsclUser} UserShell ${escapeShellArg (shellPath v.shell)}"}
+          ${optionalString (v.picture != null) ''
+            dscl . -delete ${dsclUser} Picture
+            dscl . -delete ${dsclUser} JPEGPhoto
+            dscl . -create ${dsclUser} Picture ${escapeShellArg v.picture}
+          ''}
         fi
       '') createdUsers}
 

--- a/modules/users/user.nix
+++ b/modules/users/user.nix
@@ -29,6 +29,19 @@
       '';
     };
 
+    picture = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "./my-profile.jpg";
+      description = ''
+        The profile image used for the user, as a path to a JPEG.
+
+        Non-JPEG images will not appear on the login screen.
+
+        This defaults to `null`, meaning the picture will not be managed.
+      '';
+    };
+
     uid = mkOption {
       type = types.int;
       description = "The user's UID.";

--- a/tests/users-groups.nix
+++ b/tests/users-groups.nix
@@ -17,6 +17,7 @@
   users.users.foo.home = "/Users/foo";
   users.users.foo.createHome = true;
   users.users.foo.shell = pkgs.bashInteractive;
+  users.users.foo.picture = ./.;
 
   users.users."created.user".uid = 42001;
   users.users."created.user".description = null;
@@ -61,6 +62,7 @@
     grep "createhomedir -cu ${lib.escapeShellArg "foo"}" ${config.out}/activate
     grep "dscl . -create ${lib.escapeShellArg "/Users/foo"} UserShell ${lib.escapeShellArg "/run/current-system/sw/bin/bash"}" ${config.out}/activate
     grep "dscl . -create ${lib.escapeShellArg "/Users/foo"} IsHidden 0" ${config.out}/activate
+    grep "dscl . -create ${lib.escapeShellArg "/Users/foo"} Picture /nix/store" ${config.out}/activate
 
     # checking user properties that are null don't get updated in /activate
     (! grep "dscl . -create ${lib.escapeShellArg "/Users/created.user"} RealName" ${config.out}/activate)


### PR DESCRIPTION
Allows for managing users' pictures with nix-darwin. From testing, image types other than JPEG don't work on the login screen. The warning for this shows up while running the users-groups test but I'm not sure how you would prevent that.

I'm new to nix-darwin, so please let me know if I am doing formatting wrong. I did not see a formatter.