### PR TITLE
flakeModules: add darwinModules option

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -3,9 +3,20 @@
   ...
 }:
 {
-  options.flake.darwinConfigurations = lib.mkOption {
-    type = lib.types.lazyAttrsOf lib.types.raw;
-    default = { };
-    description = "Darwin system configurations";
+  options.flake = {
+    darwinConfigurations = lib.mkOption {
+      type = lib.types.lazyAttrsOf lib.types.raw;
+      default = { };
+      description = "Darwin system configurations";
+    };
+    darwinModules = lib.mkOption {
+      type = lib.types.lazyAttrsOf lib.types.raw;
+      default = { };
+      description = ''
+        Darwin Modules
+
+        You may use this for reusable pieces of configuration, service modules, etc.
+      '';
+    };
   };
 }


### PR DESCRIPTION
Mirrors structure of darwinConfigurations
Description based on similar option for Home-Manager, see [<home-manager/flake-module.nix>](https://github.com/nix-community/home-manager/blob/00ed86e58bb6979a7921859fd1615d19382eac5c/flake-module.nix#L39-L41)