### PR TITLE
defaults: use upstream plist value type

### DIFF
--- a/modules/system/defaults/CustomPreferences.nix
+++ b/modules/system/defaults/CustomPreferences.nix
@@ -1,25 +1,12 @@
-{ config, lib, ... }:
-
-with lib;
+{ lib, pkgs, ... }:
 
 let
-  valueType = with lib.types; nullOr (oneOf [
-    bool
-    int
-    float
-    str
-    path
-    (attrsOf valueType)
-    (listOf valueType)
-  ]) // {
-    description = "plist value";
-  };
-  defaultsType = types.submodule {
-    freeformType = valueType;
+  defaultsType = lib.types.submodule {
+    freeformType = (pkgs.formats.plist { }).type;
   };
 in {
   options = {
-    system.defaults.CustomUserPreferences = mkOption {
+    system.defaults.CustomUserPreferences = lib.mkOption {
       type = defaultsType;
       default = { };
       example = {
@@ -34,7 +21,7 @@ in {
       '';
     };
 
-    system.defaults.CustomSystemPreferences = mkOption {
+    system.defaults.CustomSystemPreferences = lib.mkOption {
       type = defaultsType;
       default = { };
       example = {


### PR DESCRIPTION
We shouldn't vendor the value type as it can change upstream like in https://github.com/NixOS/nixpkgs/pull/518660

This PR isn't actually necessary for using `mkPlistData` from that PR as it creates an attrset containing strings which is still compatible with the old type