### PR TITLE
fix test

### DIFF
--- a/tests/services-aerospace.nix
+++ b/tests/services-aerospace.nix
@@ -60,35 +60,35 @@ in
       ${config.out}/user/Library/LaunchAgents/org.nixos.aerospace.plist`
 
     echo >&2 "checking config in $conf"
-    grep "after-startup-command = \\['layout tiles'\\]" $conf
+    grep 'after-startup-command = \["layout tiles"\]' $conf
 
     grep 'bottom = 8' $conf
     grep 'left = 8' $conf
     grep 'right = 8' $conf
     grep 'top = 8' $conf
 
-    grep "alt-h = 'focus left'" $conf
-    grep "alt-j = 'focus down'" $conf
-    grep "alt-k = 'focus up'" $conf
-    grep "alt-l = 'focus right'" $conf
+    grep 'alt-h = "focus left"' $conf
+    grep 'alt-j = "focus down"' $conf
+    grep 'alt-k = "focus up"' $conf
+    grep 'alt-l = "focus right"' $conf
 
     grep 'check-further-callbacks = false' $conf
-    grep "run = 'move-node-to-workspace m'" $conf
-    grep "app-id = 'Another.Cool.App'" $conf
+    grep 'run = "move-node-to-workspace m"' $conf
+    grep 'app-id = "Another.Cool.App"' $conf
     grep 'during-aerospace-startup = false' $conf
 
-    grep "run = 'layout floating'" $conf
-    grep "app-name-regex-substring = 'finder|calendar'" $conf
+    grep 'run = "layout floating"' $conf
+    grep 'app-name-regex-substring = "finder|calendar"' $conf
     (! grep 'window-title-regex-substring' $conf)
     
-    grep "workspace = '1'" $conf
-    grep "run = 'layout h_accordion'" $conf
+    grep 'workspace = "1"' $conf
+    grep 'run = "layout h_accordion"' $conf
 
     grep '1 = 1' $conf
-    grep "2 = 'main'" $conf
-    grep "3 = 'secondary'" $conf
-    grep "4 = 'built-in'" $conf
-    grep "5 = '^built-in retina display\$'" $conf
-    grep "6 = \\['secondary', 'dell'\\]" $conf
+    grep '2 = "main"' $conf
+    grep '3 = "secondary"' $conf
+    grep '4 = "built-in"' $conf
+    grep '5 = "^built-in retina display$"' $conf
+    grep '6 = \["secondary", "dell"\]' $conf
   '';
 }


### PR DESCRIPTION
In the latest nixpkgs-unstable, the quote of toml changes from single quote to double quotes, this makes tests failed

Reference: https://github.com/NixOS/nixpkgs/pull/516560