### PR TITLE
config/terminfo: remove termite

### DIFF
--- a/modules/config/terminfo.nix
+++ b/modules/config/terminfo.nix
@@ -48,7 +48,6 @@
           rxvt-unicode-unwrapped
           rxvt-unicode-unwrapped-emoji
           st
-          termite
           tmux
           wezterm
         ] ++ lib.optional (pkgs ? ghostty-bin) ghostty-bin


### PR DESCRIPTION
Terminfo was removed from nixpkgs because it was deprecated upstream.

Link: https://github.com/NixOS/nixpkgs/pull/522784