### PR TITLE
services/mullvad-vpn: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -83,6 +83,7 @@
   ./services/monitoring/telegraf.nix
   ./services/monitoring/netdata.nix
   ./services/monitoring/prometheus-node-exporter.nix
+  ./services/mullvad-vpn.nix
   ./services/netbird.nix
   ./services/nix-daemon.nix
   ./services/nix-gc

--- a/modules/services/mullvad-vpn.nix
+++ b/modules/services/mullvad-vpn.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.services.mullvad-vpn;
+in
+{
+  options.services.mullvad-vpn = {
+    enable = mkEnableOption "Mullvad VPN daemon";
+    package = mkPackageOption pkgs "mullvad" {
+      example = "pkgs.mullvad-vpn";
+      extraDescription = ''
+        `pkgs.mullvad` only provides the CLI tool, `pkgs.mullvad-vpn` provides both the CLI and the GUI.
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    launchd.daemons.mullvad-vpn = {
+      # derived from
+      # https://github.com/mullvad/mullvadvpn-app/blob/main/dist-assets/pkg-scripts/postinstall#L42
+      command = "${lib.getExe' cfg.package "mullvad-daemon"} -vv";
+      serviceConfig = {
+        Label = "net.mullvad.daemon";
+        RunAtLoad = true;
+        KeepAlive = true;
+        SoftResourceLimits.NumberOfFiles = 1024;
+        StandardErrorPath = /var/log/mullvad-vpn/stderr.log;
+      };
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -111,6 +111,7 @@ in {
   tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
   tests.services-dnscrypt-proxy = makeTest ./tests/services-dnscrypt-proxy.nix;
   tests.services-eternal-terminal = makeTest ./tests/services-eternal-terminal.nix;
+  tests.services-mullvad-vpn = makeTest ./tests/services-mullvad-vpn.nix;
   tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
   tests.services-nix-optimise = makeTest ./tests/services-nix-optimise.nix;
   tests.services-nextdns = makeTest ./tests/services-nextdns.nix;

--- a/tests/services-mullvad-vpn.nix
+++ b/tests/services-mullvad-vpn.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  mullvad-vpn = pkgs.runCommand "mullvad-vpn-0.0.0" { } "mkdir $out";
+in
+{
+  services.mullvad-vpn = {
+    enable = true;
+    package = mullvad-vpn;
+  };
+
+  test = ''
+    echo >&2 "checking mullvad-vpn service in launchd daemons"
+    grep "mullvad" ${config.out}/Library/LaunchDaemons/net.mullvad.daemon.plist
+    grep "${mullvad-vpn}/bin/mullvad-daemon" ${config.out}/Library/LaunchDaemons/net.mullvad.daemon.plist
+  '';
+}


### PR DESCRIPTION
Add service for mullvad-vpn. The launchd service config is derived from [upstream](https://github.com/mullvad/mullvadvpn-app/blob/main/dist-assets/pkg-scripts/postinstall#L42).