### PR TITLE
github-runner: remove node20 runtime from defaults

### DIFF
--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -263,7 +263,7 @@ in
 
         nodeRuntimes = mkOption {
           type = with types; nonEmptyListOf (enum [ "node20" "node24" ]);
-          default = [ "node20" "node24" ];
+          default = [ "node24" ];
           description = ''
             List of Node.js runtimes the runner should support.
           '';

--- a/tests/services-github-runners.nix
+++ b/tests/services-github-runners.nix
@@ -4,7 +4,6 @@
     enable = true;
     url = "https://github.com/nixos/nixpkgs";
     tokenFile = "/secret/path/to/a/github/token";
-    nodeRuntimes = [ "node24" ];
   };
 
   test = ''


### PR DESCRIPTION
It's marked as insecure starting with 26.05, and now github-runner package defaults to supporting only node24
See https://github.com/NixOS/nixpkgs/pull/524856

Reincarnation of https://github.com/nix-darwin/nix-darwin/pull/1788
cc @Samasaur1 