### PR TITLE
nix: set builders to @/etc/nix/machines when distributedBuilds is enabled

### DIFF
--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -962,6 +962,7 @@ in
         # );
       }
 
+      (mkIf cfg.distributedBuilds { builders = "@/etc/nix/machines"; })
       (mkIf (!cfg.distributedBuilds) { builders = null; })
 
       (mkIf (isNixAtLeast "2.3pre") { sandbox-fallback = false; })


### PR DESCRIPTION
When `nix.distributedBuilds` is `true` and `nix.buildMachines` is configured, nix-darwin writes the machine specifications to `/etc/nix/machines` but never adds `builders = @/etc/nix/machines` to the generated `nix.conf`. This means the nix daemon does not read the machines file and distributed builds silently fail.

This fix mirrors the NixOS module's behavior for setting the builders when `distributedBuilds` is `true`.