### PR TITLE
users: realpath home dirs before comparison

### DIFF
--- a/modules/users/default.nix
+++ b/modules/users/default.nix
@@ -203,7 +203,9 @@ in
               else
                 homeDirectory=$(dscl . -read ${dsclUser} NFSHomeDirectory)
                 homeDirectory=''${homeDirectory#NFSHomeDirectory: }
-                if [[ ${escapeShellArg v.home} != "$homeDirectory" ]]; then
+                configuredHomeDirectory=$(realpath ${escapeShellArg v.home})
+                homeDirectory=$(realpath "$homeDirectory")
+                if [[ "$configuredHomeDirectory" != "$homeDirectory" ]]; then
                   printf >&2 '\e[1;31merror: config contains the wrong home directory for %s, aborting activation\e[0m\n' ${name}
                   printf >&2 'nix-darwin does not support changing the home directory of existing users.\n'
                   printf >&2 '\n'


### PR DESCRIPTION
When we create users with homedir under /var, they end up with
NFSHomeDirectory under /private/var because /var is a symlink. This breaks
consequent activations and requires that user overrides their home dir
attribute with /private/var/... to pass the activation precheck.

`realpath` should normalize the discrepancy.
