### PR TITLE
homebrew: pass extraEnv to cleanup checks

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -151,7 +151,7 @@ let
         };
         description = ''
           Extra environment variables to set when {command}`nix-darwin` invokes
-          {command}`brew bundle [install]` during system activation.
+          {command}`brew bundle [install]` during system checks and activation.
 
           Useful for setting Homebrew's `HOMEBREW_NO_*` variables (e.g.,
           `HOMEBREW_NO_ENV_HINTS`, `HOMEBREW_NO_ANALYTICS`, `HOMEBREW_NO_UPDATE_REPORT_NEW`)
@@ -1001,6 +1001,7 @@ in
             --user=${escapeShellArg cfg.user} \
             --set-home \
             env HOMEBREW_NO_AUTO_UPDATE=1 \
+            ${concatStringsSep " " (mapAttrsToList (k: v: "${k}=${escapeShellArg v}") cfg.onActivation.extraEnv)} \
             brew bundle cleanup --file='${brewfileFile}' 2>&1) || homebrewCleanupExitCode=$?
         if [ "$homebrewCleanupExitCode" -eq 1 ]; then
           printf >&2 '\e[1;31merror: found Homebrew packages not listed in the Brewfile, aborting activation\e[0m\n'

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -172,11 +172,11 @@ let
         '';
       };
 
-      brewBundleCmd = mkInternalOption { type = types.str; };
+      brewBundleCmd = mkInternalOption { type = types.functionTo types.str; };
     };
 
     config = {
-      brewBundleCmd = concatStringsSep " " (
+      brewBundleCmd = { onlyCheck }: concatStringsSep " " (
         [
           ''PATH="${cfg.prefix}/bin:${lib.makeBinPath [ pkgs.mas ]}:$PATH"''
           "sudo"
@@ -185,13 +185,18 @@ let
           "--set-home"
           "env"
         ]
-        ++ optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+        ++ optional (onlyCheck || !config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
         ++ mapAttrsToList (k: v: "${k}=${escapeShellArg v}") config.extraEnv
         ++ [ "brew bundle --file='${brewfileFile}'" ]
-        ++ optional (!config.upgrade) "--no-upgrade"
-        ++ optional (config.cleanup == "uninstall") "--force-cleanup"
-        ++ optional (config.cleanup == "zap") "--zap --force-cleanup"
-        ++ config.extraFlags
+        ++ (
+          if onlyCheck then
+            [ "cleanup 2>&1" ]
+          else
+            optional (!config.upgrade) "--no-upgrade"
+            ++ optional (config.cleanup == "uninstall") "--force-cleanup"
+            ++ optional (config.cleanup == "zap") "--zap --force-cleanup"
+            ++ config.extraFlags
+        )
       );
     };
   };
@@ -1003,14 +1008,7 @@ in
     system.checks.text = mkIf (cfg.enable && cfg.onActivation.cleanup == "check") ''
       if [ -f "${cfg.prefix}/bin/brew" ]; then
         homebrewCleanupExitCode=0
-        homebrewCleanupResult=$(PATH="${cfg.prefix}/bin:${lib.makeBinPath [ pkgs.mas ]}:$PATH" \
-          sudo \
-            --preserve-env=PATH \
-            --user=${escapeShellArg cfg.user} \
-            --set-home \
-            env HOMEBREW_NO_AUTO_UPDATE=1 \
-            ${concatStringsSep " " (mapAttrsToList (k: v: "${k}=${escapeShellArg v}") cfg.onActivation.extraEnv)} \
-            brew bundle cleanup --file='${brewfileFile}' 2>&1) || homebrewCleanupExitCode=$?
+        homebrewCleanupResult=$(${cfg.onActivation.brewBundleCmd { onlyCheck = true; }}) || homebrewCleanupExitCode=$?
         if [ "$homebrewCleanupExitCode" -eq 1 ]; then
           printf >&2 '\e[1;31merror: found Homebrew packages not listed in the Brewfile, aborting activation\e[0m\n'
           printf >&2 '%s\n' "$homebrewCleanupResult"
@@ -1032,7 +1030,7 @@ in
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
       if [ -f "${cfg.prefix}/bin/brew" ]; then
-        ${cfg.onActivation.brewBundleCmd}
+        ${cfg.onActivation.brewBundleCmd { onlyCheck = false; }}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2
       fi

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -177,7 +177,15 @@ let
 
     config = {
       brewBundleCmd = concatStringsSep " " (
-        optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+        [
+          ''PATH="${cfg.prefix}/bin:${lib.makeBinPath [ pkgs.mas ]}:$PATH"''
+          "sudo"
+          "--preserve-env=PATH"
+          "--user=${escapeShellArg cfg.user}"
+          "--set-home"
+          "env"
+        ]
+        ++ optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
         ++ mapAttrsToList (k: v: "${k}=${escapeShellArg v}") config.extraEnv
         ++ [ "brew bundle --file='${brewfileFile}'" ]
         ++ optional (!config.upgrade) "--no-upgrade"
@@ -1024,13 +1032,7 @@ in
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
       if [ -f "${cfg.prefix}/bin/brew" ]; then
-        PATH="${cfg.prefix}/bin:${lib.makeBinPath [ pkgs.mas ]}:$PATH" \
-        sudo \
-          --preserve-env=PATH \
-          --user=${escapeShellArg cfg.user} \
-          --set-home \
-          env \
-          ${cfg.onActivation.brewBundleCmd}
+        ${cfg.onActivation.brewBundleCmd}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2
       fi

--- a/tests/homebrew-cleanup-check.nix
+++ b/tests/homebrew-cleanup-check.nix
@@ -1,5 +1,9 @@
 { config, ... }:
 
+let
+  brewBundleInstallCmd = config.homebrew.onActivation.brewBundleCmd { onlyCheck = false; };
+in
+
 {
   homebrew.enable = true;
   homebrew.user = "test-homebrew-user";
@@ -7,12 +11,12 @@
 
   test = ''
     echo "checking that cleanup check is present in system checks" >&2
-    grep 'brew bundle cleanup --file=' ${config.out}/activate
+    grep "brew bundle --file='.*-Brewfile' cleanup" ${config.out}/activate
 
-    echo "checking that brew bundle command does not have --cleanup flag" >&2
-    if echo "${config.homebrew.onActivation.brewBundleCmd}" | grep -F -- '--cleanup' > /dev/null; then
-      echo "Expected no --cleanup flag in brewBundleCmd"
-      echo "Actual: ${config.homebrew.onActivation.brewBundleCmd}"
+    echo "checking that brew bundle [install] command does not have --cleanup flag" >&2
+    if echo "${brewBundleInstallCmd}" | grep -F -- '--cleanup' > /dev/null; then
+      echo "Expected no --cleanup flag in brewBundleInstallCmd"
+      echo "Actual: ${brewBundleInstallCmd}"
       exit 1
     fi
   '';


### PR DESCRIPTION
**Context:** This is tangentially related to #1789 as `brew trust` writes its trust record under `$XDG_CONFIG_HOME` if it is set. So for the commands to be consistent one must set the same, consistent `extraEnv`.

**Disclaimer:** All code was written by hand by me but reviewed and verified by an agent (gpt-5.5 on codex).

When `homebrew.onActivation.cleanup == "check"`, nix-darwin runs a separate `brew bundle cleanup` command during `system.checks`, before the normal Homebrew activation command.

That cleanup check should use the same `homebrew.onActivation.extraEnv` values as the main `brew bundle [install]` command. For example, if `$XDG_CONFIG_HOME` is set via `extraEnv`, it should also be visible to `brew bundle cleanup` during the system check phase.

- **Note:** I intentionally kept `homebrew.onActivation.extraFlags` specific to the `bundle [install]` command, rather than passing those flags to the `bundle cleanup` check command, in case one needs to specifically customize the [install] behavior by adding e.g. `--verbose`. But I’m happy to revisit this behavior if you believe `extraFlags` should also apply to the cleanup check command.

### Commits

It would be easier to review the commits one by one through 👉  https://github.com/nix-darwin/nix-darwin/pull/1804/commits

- The 1st commit contains the intended behavior change: pass `homebrew.onActivation.extraEnv` through to the cleanup check.
- The following 2 commits should be trivial refactors. They move the shared PATH/sudo/env setup into `brewBundleCmd`, then reuse that helper for `system.checks`, without intending to change the actual generated commands apart from whitespace and flag ordering.
- **Note:** If the last 2 commits feel too heavy I am okay to drop them. The important behavioral change is the 1st commit that I would like to upstream.
