### PR TITLE
programs/zsh: add separate saveSize option for SAVEHIST

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -65,6 +65,13 @@ in
       description = "Change history size.";
     };
 
+    programs.zsh.saveSize = mkOption {
+      type = types.int;
+      default = cfg.histSize;
+      defaultText = literalExpression "config.${opt.histSize}";
+      description = "Change the number of history entries to save.";
+    };
+
     programs.zsh.histFile = mkOption {
       type = types.str;
       default = "$HOME/.zsh_history";
@@ -203,7 +210,7 @@ in
 
       # Setup command line history.
       # Don't export these, otherwise other shells (bash) will try to use same HISTFILE.
-      SAVEHIST=${builtins.toString cfg.histSize}
+      SAVEHIST=${builtins.toString cfg.saveSize}
       HISTSIZE=${builtins.toString cfg.histSize}
       HISTFILE=${cfg.histFile}
 

--- a/tests/programs-zsh.nix
+++ b/tests/programs-zsh.nix
@@ -14,6 +14,8 @@
    programs.zsh.interactiveShellInit = "source /etc/zshrc.d/*.conf";
    programs.zsh.loginShellInit = "source /etc/zprofile.d/*.conf";
    programs.zsh.promptInit = "autoload -U promptinit && promptinit && prompt off";
+   programs.zsh.histSize = 4000;
+   programs.zsh.saveSize = 3000;
 
    programs.zsh.variables.FOO = "42";
 
@@ -32,6 +34,9 @@
      grep 'source /etc/zshrc.d/\*.conf' ${config.out}/etc/zshrc
      echo >&2 "checking prompt off in /etc/zshrc"
      grep 'prompt off' ${config.out}/etc/zshrc
+     echo >&2 "checking zsh history sizes in /etc/zshrc"
+     grep 'SAVEHIST=3000' ${config.out}/etc/zshrc
+     grep 'HISTSIZE=4000' ${config.out}/etc/zshrc
      echo >&2 "checking compinit in /etc/zshrc"
      grep 'autoload -U compinit && compinit' ${config.out}/etc/zshrc
      echo >&2 "checking bashcompinit in /etc/zshrc"


### PR DESCRIPTION
Add `programs.zsh.saveSize` to allow configuring `SAVEHIST` independently from `HISTSIZE`.

The new option defaults to `programs.zsh.histSize`, preserving the existing behavior for configurations that only set `histSize`.

An example of when this could be useful from `man zhall`

```
HISTSIZE <S>
			The  maximum number of events stored in the internal history list.  If you use the HIST_EXPIRE_DUPS_FIRST option, setting this value larger than the SAVEHIST
			size will give you the difference as a cushion for saving duplicated history events.

			If this is made local, it is not implicitly set to 0, but may be explicitly set locally.
```
