### PR TITLE
services.plugin-playground: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -104,6 +104,7 @@
   ./services/yabai
   ./services/nextdns
   ./services/jankyborders
+  ./services/plugin-playground
   ./programs/_1password.nix
   ./programs/_1password-gui.nix
   ./programs/arqbackup.nix

--- a/modules/services/plugin-playground/default.nix
+++ b/modules/services/plugin-playground/default.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.plugin-playground;
+
+  boolToStr = b: if b then "true" else "false";
+in {
+  options.services.plugin-playground = {
+    enable = mkEnableOption "Plugin Playground runtime tweak system";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.plugin-playground;
+      defaultText = literalExpression "pkgs.plugin-playground";
+      description = "The Plugin Playground package to use.";
+    };
+
+    disablePAC = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Disables arm64e PAC signing for spawned processes. Required if compiling without native arm64e ABI.";
+    };
+
+    useLegacyAmmonia = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Uses the legacy tweak path (/private/var/ammonia/core/tweaks/) instead of the default.";
+    };
+
+    pauseInjection = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Globally pauses tweak injection for all processes.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    system.activationScripts.pluginPlayground.text = ''
+      echo "Configuring Plugin Playground..."
+      mkdir -p /opt/pluginplayground/tweaks
+      mkdir -p /var/log/pluginplayground
+      chmod 777 /opt/pluginplayground/tweaks
+      chmod 777 /var/log/pluginplayground
+
+      if [ ! -f /opt/pluginplayground/current.options ]; then
+        touch /opt/pluginplayground/current.options
+        chmod 666 /opt/pluginplayground/current.options
+      fi
+
+      defaults write /opt/pluginplayground/current.options disablePAC -bool ${boolToStr cfg.disablePAC}
+      defaults write /opt/pluginplayground/current.options useLegacyAmmonia -bool ${boolToStr cfg.useLegacyAmmonia}
+      defaults write /opt/pluginplayground/current.options pauseInjection -bool ${boolToStr cfg.pauseInjection}
+      chmod 666 /opt/pluginplayground/current.options
+    '';
+
+    launchd.daemons.plugin-playground-grant = {
+      serviceConfig = {
+        Label = "com.pluginplayground.grant";
+        ProgramArguments = [ "${cfg.package}/bin/grant" ];
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/pluginplayground/grant.log";
+        StandardErrorPath = "/var/log/pluginplayground/grant.err";
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.aspauldingcode or "aspauldingcode" ];
+}


### PR DESCRIPTION
This PR introduces a new service module for [Plugin Playground](https://github.com/CoreBedtime/playground), a general-purpose runtime tweak system for macOS.

### What changed
- Added `services.plugin-playground` to manage the tweak injection environment.
- Configures default system preferences (`/opt/pluginplayground/current.options`) natively using macOS `defaults`.
- Registers the `grant` utility via a `launchd` daemon to manage process injection.

### Why it changed
To allow declarative Nix configuration of Plugin Playground on macOS (Apple Silicon).

### How it was tested
- Verified module options natively via a local `darwin-rebuild switch`.
- Ran `nix-build release.nix -A tests` locally without errors.

### Dependency
Depends on Nixpkgs PR https://github.com/NixOS/nixpkgs/pull/534452 to provide the underlying `plugin-playground` derivation.