### PR TITLE
Preserve terminfo environment variables for %staff, not %admin

### DIFF
--- a/modules/config/terminfo.nix
+++ b/modules/config/terminfo.nix
@@ -78,9 +78,9 @@
       let
         extraConfig = ''
 
-          # Keep terminfo database for root and %admin.
-          Defaults:root,%admin env_keep+=TERMINFO_DIRS
-          Defaults:root,%admin env_keep+=TERMINFO
+          # Keep terminfo database for root and %staff.
+          Defaults:root,%staff env_keep+=TERMINFO_DIRS
+          Defaults:root,%staff env_keep+=TERMINFO
         '';
       in
       lib.mkIf config.security.sudo.keepTerminfo {


### PR DESCRIPTION
Interactive users on macOS are in the staff group. They are the ones who might care about text user interfaces. As long as they are allowed to use sudo at all, they should have TERMINFO_DIRS and TERMINFO propagated to the sudo environment, whether they are administrators or not.