### PR TITLE
defaults: Add `desktopservices`

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -23,6 +23,7 @@
   ./system/defaults/GlobalPreferences.nix
   ./system/defaults/CustomPreferences.nix
   ./system/defaults/clock.nix
+  ./system/defaults/desktopservices.nix
   ./system/defaults/dock.nix
   ./system/defaults/finder.nix
   ./system/defaults/hitoolbox.nix

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -30,6 +30,7 @@ let
   LaunchServices = userDefaultsToList "com.apple.LaunchServices" cfg.LaunchServices;
   NSGlobalDomain = userDefaultsToList "-g" cfg.NSGlobalDomain;
   menuExtraClock = userDefaultsToList "com.apple.menuextra.clock" cfg.menuExtraClock;
+  desktopservices = userDefaultsToList "com.apple.desktopservices" cfg.desktopservices;
   dock = userDefaultsToList "com.apple.dock" dockFiltered;
   finder = userDefaultsToList "com.apple.finder" cfg.finder;
   hitoolbox = userDefaultsToList "com.apple.HIToolbox" cfg.hitoolbox;
@@ -73,6 +74,7 @@ in
         "LaunchServices"
         "NSGlobalDomain"
         "menuExtraClock"
+        "desktopservices"
         "dock"
         "finder"
         "hitoolbox"
@@ -108,6 +110,7 @@ in
         LaunchServices
         NSGlobalDomain
         menuExtraClock
+        desktopservices
         dock
         finder
         hitoolbox
@@ -134,6 +137,7 @@ in
         ${concatStringsSep "\n" GlobalPreferences}
         ${concatStringsSep "\n" LaunchServices}
         ${concatStringsSep "\n" menuExtraClock}
+        ${concatStringsSep "\n" desktopservices}
         ${concatStringsSep "\n" dock}
         ${concatStringsSep "\n" finder}
         ${concatStringsSep "\n" hitoolbox}

--- a/modules/system/defaults/desktopservices.nix
+++ b/modules/system/defaults/desktopservices.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+
+with lib;
+{
+  options = {
+
+    system.defaults.desktopservices.DSDontWriteNetworkStores = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Disable creation of metadata files (.DS_Store/AppleDouble files) on network volumes.
+        Default is to create (false).
+      '';
+    };
+
+    system.defaults.desktopservices.DSDontWriteUSBStores = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Disable creation of metadata files (.DS_Store/AppleDouble files) on USB volumes.
+        Default is to create (false).
+      '';
+    };
+  };
+}

--- a/tests/fixtures/system-defaults-write/user.txt
+++ b/tests/fixtures/system-defaults-write/user.txt
@@ -230,6 +230,16 @@ launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user
 <plist version="1.0">
 <true/>
 </plist>'
+launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user -- defaults write com.apple.desktopservices DSDontWriteNetworkStores '<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<true/>
+</plist>'
+launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user -- defaults write com.apple.desktopservices DSDontWriteUSBStores '<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<true/>
+</plist>'
 launchctl asuser "$(id -u -- test-defaults-user)" sudo --user=test-defaults-user -- defaults write com.apple.dock appswitcher-all-displays '<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/system-defaults-write.nix
+++ b/tests/system-defaults-write.nix
@@ -68,6 +68,8 @@
   system.defaults.menuExtraClock.Show24Hour = false;
   system.defaults.menuExtraClock.ShowDayOfWeek = true;
   system.defaults.menuExtraClock.ShowDate = 2;
+  system.defaults.desktopservices.DSDontWriteNetworkStores = true;
+  system.defaults.desktopservices.DSDontWriteUSBStores = true;
   system.defaults.dock.expose-group-apps = true;
   system.defaults.dock.appswitcher-all-displays = false;
   system.defaults.dock.autohide-delay = 0.24;


### PR DESCRIPTION
Extracted from https://github.com/nix-darwin/nix-darwin/pull/253 by https://github.com/einsweniger

I only needed the desktop services defaults.  The original PR has bundled other features that are out of scope.