### PR TITLE
tailscale: add extraSetFlags option for darwin

### DIFF
--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -5,6 +5,14 @@ with lib;
 let
   cfg = config.services.tailscale;
 
+  tailscaledSetScript = pkgs.writeShellScript "tailscaled-set" ''
+    for _ in $(seq 1 60); do
+      ${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags} && exit 0
+      sleep 1
+    done
+    exit 1
+  '';
+
 in
 {
   imports = [
@@ -37,6 +45,13 @@ in
         all non-MagicDNS queries WILL fail.
       '';
     };
+
+    extraSetFlags = mkOption {
+      description = "Extra flags to pass to {command}`tailscale set`.";
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--advertise-exit-node" ];
+    };
   };
 
   config = mkIf cfg.enable {
@@ -57,6 +72,14 @@ in
       command = lib.getExe' cfg.package "tailscaled";
       serviceConfig = {
         Label = "com.tailscale.tailscaled";
+        RunAtLoad = true;
+      };
+    };
+
+    launchd.daemons.tailscaled-set = mkIf (cfg.extraSetFlags != [ ]) {
+      command = "${tailscaledSetScript}";
+      serviceConfig = {
+        Label = "com.tailscale.tailscaled-set";
         RunAtLoad = true;
       };
     };


### PR DESCRIPTION
  Copied from the NixOS module's extraSetFlags:
  https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/networking/tailscale.nix

## Motivation

The NixOS `services.tailscale` module has `extraSetFlags` to pass flags to `tailscale set` (e.g. `--accept-routes`, `--advertise-exit-node`), but the nix-darwin module has no equivalent. On darwin the only way to set these declaratively today is a hand-rolled `system.activationScripts` / `launchd` entry.

Unlike `extraUpFlags` (which runs `tailscale up` and therefore needs an auth key for unattended use), `tailscale set` only changes preferences on the already-running daemon and needs no auth — so it's safe to apply automatically.

## Change

Adds `services.tailscale.extraSetFlags` (matching the NixOS option). It's applied by a small `tailscaled-set` launchd daemon. launchd has no service ordering, so the runner retries `tailscale set` until `tailscaled`'s socket is reachable, then exits. Runs at boot and on each activation; guarded by `mkIf (cfg.extraSetFlags != [])`.

## Example

```nix
services.tailscale = {
  enable = true;
  extraSetFlags = [ "--accept-routes=true" ];
};
```

## Testing

Evaluated a darwin configuration with `extraSetFlags = [ "--accept-routes=true" ]`; the `tailscaled-set` daemon is generated with the expected retry-then-set script. No daemon is created when `extraSetFlags` is empty.