### PR TITLE
fix: use new param --sidebar-depth

### DIFF
--- a/doc/manual/default.nix
+++ b/doc/manual/default.nix
@@ -94,8 +94,7 @@ in rec {
         --stylesheet highlightjs/mono-blue.css \
         --script ./highlightjs/highlight.pack.js \
         --script ./highlightjs/loader.js \
-        --toc-depth 1 \
-        --chunk-toc-depth 1 \
+        --sidebar-depth 1 \
         ./manual.md \
         $dst/index.html
 


### PR DESCRIPTION
I was faced with this error while trying to rebuild my system:

```console
error: Cannot build '/nix/store/122l99yz179ijwnzdlf8svrdksmbyjwm-darwin-manual-html.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/qknyi2ky78q9f4dx4whnyb7dbsr6qxm1-darwin-manual-html
       Last 12 log lines:
       > usage: nixos-render-docs manual html [-h] --manpage-urls MANPAGE_URLS
       >                                      --revision REVISION
       >                                      [--generator GENERATOR]
       >                                      [--stylesheet STYLESHEET]
       >                                      [--script SCRIPT] [--media-dir MEDIA_DIR]
       >                                      [--redirects REDIRECTS]
       >                                      [--sidebar-depth SIDEBAR_DEPTH]
       >                                      [--nav NAV] [--toc-depth [TOC_DEPTH]]
       >                                      [--chunk-toc-depth [CHUNK_TOC_DEPTH]]
       >                                      [--section-toc-depth [SECTION_TOC_DEPTH]]
       >                                      infile outfile
       > nixos-render-docs manual html: error: --toc-depth has been removed, use --sidebar-depth instead
       For full logs, run:
         nix log /nix/store/122l99yz179ijwnzdlf8svrdksmbyjwm-darwin-manual-html.drv
```

Relevant inputs:

```json
    "nix-darwin": {
      "inputs": {
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1781761792,
        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
        "owner": "nix-darwin",
        "repo": "nix-darwin",
        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
        "type": "github"
      },
      "original": {
        "owner": "nix-darwin",
        "repo": "nix-darwin",
        "type": "github"
      }
    },
    "nixpkgs": {
      "locked": {
        "lastModified": 1783247743,
        "narHash": "sha256-9b2xGt5CAd6WriPJOZs/EYXq9fGVCeoisYo1P3nhL2Y=",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "c4013e501c048ae7c4a8940c92837636042bf6c3",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "ref": "nixpkgs-unstable",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
```

Looks like the argument was renamed and combined. This fix was sufficient to overcome the error and allow building the system again.