### PR TITLE
flake: only include simple in checks 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
       description = "nix flake init -t nix-darwin";
     };
 
-    checks = forDarwinSystems (system: jobs.${system}.tests // jobs.${system}.examples);
+    checks = forDarwinSystems (system: jobs.${system}.tests // { inherit (jobs.${system}.examples) simple;});
 
     packages = forAllSystems (system: {
       inherit (jobs.${system}.docs) manualHTML manpages optionsJSON;


### PR DESCRIPTION
The packages in the examples aren't stubbed out.

I guess a proper fix could be an overlay that stubs out everything but that's another PR.