### PR TITLE
homebrew: skip unchanged bundle activation

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -8,6 +8,12 @@ let
 
   brewfileFile = pkgs.writeText "Brewfile" cfg.brewfile;
 
+  fastPathIdentity = pkgs.writeText "homebrew-activation-identity" (builtins.toJSON {
+    version = 1;
+    inherit (cfg) brewfile prefix user;
+    inherit (cfg.onActivation) cleanup extraEnv;
+  });
+
   # Brewfile creation helper functions -------------------------------------------------------------
 
   mkBrewfileSectionString = heading: entries: optionalString (entries != [ ]) ''
@@ -172,7 +178,23 @@ let
         '';
       };
 
+      fastPath = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to skip {command}`brew bundle` when the generated Brewfile, activation options,
+          and installed Homebrew inventory are unchanged since the last successful activation.
+
+          The inventory includes taps, formulae, casks, and Mac App Store applications. The fast
+          path requires [](#opt-homebrew.onActivation.autoUpdate) and
+          [](#opt-homebrew.onActivation.upgrade) to be disabled. It does not support arbitrary
+          Brewfile directives, extra flags, Visual Studio Code extensions, Go packages, Cargo
+          packages, or formula options that reconcile link, conflict, or service state.
+        '';
+      };
+
       brewBundleCmd = mkInternalOption { type = types.functionTo types.str; };
+      inventoryCmd = mkInternalOption { type = types.str; };
     };
 
     config = {
@@ -197,6 +219,33 @@ let
             ++ optional (config.cleanup == "zap") "--zap --force-cleanup"
             ++ config.extraFlags
         )
+      );
+
+      inventoryCmd = concatStringsSep " " (
+        [
+          ''PATH="${cfg.prefix}/bin:${lib.makeBinPath [ pkgs.mas ]}:$PATH"''
+          "sudo"
+          "--preserve-env=PATH"
+          "--user=${escapeShellArg cfg.user}"
+          "--set-home"
+          "env"
+        ]
+        ++ mapAttrsToList (k: v: "${k}=${escapeShellArg v}") config.extraEnv
+        ++ [
+          "/bin/sh"
+          "-c"
+          (escapeShellArg ''
+            set -e
+            printf '%s\n' '[taps]'
+            brew tap | LC_ALL=C sort
+            printf '%s\n' '[formulae]'
+            brew list --formula -1 | LC_ALL=C sort
+            printf '%s\n' '[casks]'
+            brew list --cask -1 | LC_ALL=C sort
+            printf '%s\n' '[mas]'
+            mas list | LC_ALL=C sort
+          '')
+        ]
       );
     };
   };
@@ -958,6 +1007,49 @@ in
       (mkIf (hasSuffix "/bin" cfg.prefix) "`homebrew.prefix` should be the Homebrew prefix directory (e.g., `/opt/homebrew`), not the bin directory. The value should match what `brew --prefix` returns. Did you mean to remove the trailing `/bin`?")
     ];
 
+    assertions = [
+      {
+        assertion = !cfg.onActivation.fastPath || !cfg.onActivation.autoUpdate;
+        message = "`homebrew.onActivation.fastPath` requires `homebrew.onActivation.autoUpdate = false`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath || !cfg.onActivation.upgrade;
+        message = "`homebrew.onActivation.fastPath` requires `homebrew.onActivation.upgrade = false`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath || cfg.onActivation.extraFlags == [ ];
+        message = "`homebrew.onActivation.fastPath` does not support `homebrew.onActivation.extraFlags`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath || cfg.vscode == [ ];
+        message = "`homebrew.onActivation.fastPath` does not support `homebrew.vscode`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath || cfg.goPackages == [ ];
+        message = "`homebrew.onActivation.fastPath` does not support `homebrew.goPackages`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath || cfg.cargoPackages == [ ];
+        message = "`homebrew.onActivation.fastPath` does not support `homebrew.cargoPackages`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath || cfg.extraConfig == "";
+        message = "`homebrew.onActivation.fastPath` does not support `homebrew.extraConfig`.";
+      }
+      {
+        assertion = !cfg.onActivation.fastPath
+          || !any
+          (brew:
+            brew.conflicts_with != null
+              || brew.link != null
+              || brew.restart_service != null
+              || brew.start_service != null
+          )
+          cfg.brews;
+        message = "`homebrew.onActivation.fastPath` does not support formula state options (`conflicts_with`, `link`, `restart_service`, or `start_service`).";
+      }
+    ];
+
     system.requiresPrimaryUser = mkIf (cfg.enable && options.homebrew.user.highestPrio == (mkOptionDefault {}).priority) [
       "homebrew.enable"
     ];
@@ -1030,7 +1122,32 @@ in
       # Homebrew Bundle
       echo >&2 "Homebrew bundle..."
       if [ -f "${cfg.prefix}/bin/brew" ]; then
-        ${cfg.onActivation.brewBundleCmd { onlyCheck = false; }}
+        ${if cfg.onActivation.fastPath then ''
+          homebrewStateDir=/var/db/nix-darwin/homebrew
+          homebrewState="$homebrewStateDir/activation-state"
+          mkdir -p "$homebrewStateDir"
+          homebrewStateNext=$(mktemp "$homebrewStateDir/.activation-state.XXXXXX")
+          trap 'rm -f "$homebrewStateNext"' EXIT
+
+          writeHomebrewState() {
+            printf '%s\n' ${escapeShellArg fastPathIdentity} > "$homebrewStateNext"
+            homebrewInventory=$(${cfg.onActivation.inventoryCmd})
+            printf '%s\n' "$homebrewInventory" >> "$homebrewStateNext"
+          }
+
+          writeHomebrewState
+
+          if cmp -s "$homebrewState" "$homebrewStateNext"; then
+            echo >&2 "Homebrew inventory unchanged, skipping bundle."
+          else
+            ${cfg.onActivation.brewBundleCmd { onlyCheck = false; }}
+            writeHomebrewState
+            mv -f "$homebrewStateNext" "$homebrewState"
+          fi
+
+          rm -f "$homebrewStateNext"
+          trap - EXIT
+        '' else cfg.onActivation.brewBundleCmd { onlyCheck = false; }}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2
       fi

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -236,14 +236,21 @@ let
           "-c"
           (escapeShellArg ''
             set -e
+            inventoryDir=$(mktemp -d)
+            trap 'rm -rf "$inventoryDir"' EXIT
+            brew tap > "$inventoryDir/taps"
+            brew list --formula -1 > "$inventoryDir/formulae"
+            brew list --cask -1 > "$inventoryDir/casks"
+            mas list > "$inventoryDir/mas"
+
             printf '%s\n' '[taps]'
-            brew tap | LC_ALL=C sort
+            LC_ALL=C sort "$inventoryDir/taps"
             printf '%s\n' '[formulae]'
-            brew list --formula -1 | LC_ALL=C sort
+            LC_ALL=C sort "$inventoryDir/formulae"
             printf '%s\n' '[casks]'
-            brew list --cask -1 | LC_ALL=C sort
+            LC_ALL=C sort "$inventoryDir/casks"
             printf '%s\n' '[mas]'
-            mas list | LC_ALL=C sort
+            LC_ALL=C sort "$inventoryDir/mas"
           '')
         ]
       );

--- a/release.nix
+++ b/release.nix
@@ -84,6 +84,7 @@ in {
   tests.environment-terminfo = makeTest ./tests/environment-terminfo.nix;
   tests.homebrew = makeTest ./tests/homebrew.nix;
   tests.homebrew-cleanup-check = makeTest ./tests/homebrew-cleanup-check.nix;
+  tests.homebrew-fast-path = makeTest ./tests/homebrew-fast-path.nix;
   tests.homebrew-shell-integration = makeTest ./tests/homebrew-shell-integration.nix;
   tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;
   tests.launchd-setenv = makeTest ./tests/launchd-setenv.nix;

--- a/tests/homebrew-fast-path.nix
+++ b/tests/homebrew-fast-path.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+let
+  fastPathRejects = homebrew:
+    let
+      evaluated = import ../. {
+        inherit pkgs;
+        nixpkgs = config.nixpkgs.source;
+        system = pkgs.stdenv.hostPlatform.system;
+        configuration = {
+          system.stateVersion = 6;
+          system.primaryUser = "test-homebrew-user";
+          homebrew = lib.recursiveUpdate
+            {
+              enable = true;
+              onActivation.fastPath = true;
+            }
+            homebrew;
+        };
+      };
+    in
+      !(builtins.tryEval evaluated.config.system.build.toplevel.drvPath).success;
+in
+
+{
+  homebrew = {
+    enable = true;
+    user = "test-homebrew-user";
+    taps = [ "homebrew/cask" ];
+    brews = [ "imagemagick" ];
+    casks = [ "firefox" ];
+    masApps.Xcode = 497799835;
+    onActivation.fastPath = true;
+  };
+
+  test = assert fastPathRejects { onActivation.upgrade = true; };
+    assert fastPathRejects { extraConfig = ''brew "unsupported"''; };
+    assert fastPathRejects { vscode = [ "golang.go" ]; };
+    assert fastPathRejects { brews = [{ name = "mysql"; link = true; }]; };
+    ''
+      activate=${config.out}/activate
+      bash -n "$activate"
+
+      echo "checking fast path inventory" >&2
+      grep -F "brew tap | LC_ALL=C sort" "$activate"
+      grep -F "brew list --formula -1 | LC_ALL=C sort" "$activate"
+      grep -F "brew list --cask -1 | LC_ALL=C sort" "$activate"
+      grep -F "mas list | LC_ALL=C sort" "$activate"
+
+      echo "checking fast path cache" >&2
+      grep -F "homebrewStateDir=/var/db/nix-darwin/homebrew" "$activate"
+      grep -F 'homebrewState="$homebrewStateDir/activation-state"' "$activate"
+      grep -F 'cmp -s "$homebrewState" "$homebrewStateNext"' "$activate"
+      grep -F 'mv -f "$homebrewStateNext" "$homebrewState"' "$activate"
+
+      echo "checking reconciliation remains unchanged" >&2
+      grep -F "brew bundle --file='" "$activate" | grep -F -- "--no-upgrade"
+    '';
+}

--- a/tests/homebrew-fast-path.nix
+++ b/tests/homebrew-fast-path.nix
@@ -41,11 +41,12 @@ in
       activate=${config.out}/activate
       bash -n "$activate"
 
-      echo "checking fast path inventory" >&2
-      grep -F "brew tap | LC_ALL=C sort" "$activate"
-      grep -F "brew list --formula -1 | LC_ALL=C sort" "$activate"
-      grep -F "brew list --cask -1 | LC_ALL=C sort" "$activate"
-      grep -F "mas list | LC_ALL=C sort" "$activate"
+    echo "checking fast path inventory" >&2
+    grep -F 'brew tap > "$inventoryDir/taps"' "$activate"
+    grep -F 'brew list --formula -1 > "$inventoryDir/formulae"' "$activate"
+    grep -F 'brew list --cask -1 > "$inventoryDir/casks"' "$activate"
+    grep -F 'mas list > "$inventoryDir/mas"' "$activate"
+    grep -F 'LC_ALL=C sort "$inventoryDir/formulae"' "$activate"
 
       echo "checking fast path cache" >&2
       grep -F "homebrewStateDir=/var/db/nix-darwin/homebrew" "$activate"

--- a/tests/homebrew.nix
+++ b/tests/homebrew.nix
@@ -131,5 +131,8 @@ in
 
     echo "checking that cleanup check is absent by default" >&2
     (! grep 'brew bundle cleanup --file=' ${config.out}/activate)
+
+    echo "checking that the fast path is absent by default" >&2
+    (! grep 'homebrewState=' ${config.out}/activate)
   '';
 }


### PR DESCRIPTION
Closes #1829.

## Summary

Add opt-in `homebrew.onActivation.fastPath` support. After a successful reconciliation, nix-darwin records:

* an identity covering the generated Brewfile and relevant activation configuration
* sorted inventories for taps, formulae, casks, and Mac App Store applications

A later activation skips `brew bundle` only when both are unchanged. Any configuration or inventory change runs the existing `brew bundle` command unchanged, then refreshes the state atomically.

The option rejects modes and directives whose behavior cannot be represented by these inventories, including upgrades, auto-update, arbitrary flags and Brewfile config, unsupported package categories, and formula link, conflict, or service state options.

## Tests

* `nix build .#checks.aarch64-darwin.homebrew-fast-path --no-link --print-build-logs`
* `nix build .#checks.aarch64-darwin.homebrew .#checks.aarch64-darwin.homebrew-cleanup-check .#checks.aarch64-darwin.homebrew-shell-integration --no-link --print-build-logs`

(sent by an AI agent via Codex)
