### PR TITLE
programs/devenv: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -108,6 +108,7 @@
   ./programs/_1password-gui.nix
   ./programs/arqbackup.nix
   ./programs/bash
+  ./programs/devenv.nix
   ./programs/direnv.nix
   ./programs/fish.nix
   ./programs/gnupg.nix

--- a/modules/programs/devenv.nix
+++ b/modules/programs/devenv.nix
@@ -1,0 +1,53 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.devenv;
+
+  hook = shell: "${lib.getExe cfg.package} hook ${shell}";
+in
+{
+  meta.maintainers = [
+    lib.maintainers.domenkozar or "domenkozar"
+    lib.maintainers.sandydoo or "sandydoo"
+    lib.maintainers.anish or "anish"
+  ];
+
+  options.programs.devenv = {
+    enable = lib.mkEnableOption "devenv, fast, declarative, reproducible and composable developer environments";
+
+    package = lib.mkPackageOption pkgs "devenv" { };
+
+    enableBashIntegration = lib.mkEnableOption "auto-activation of devenv environments in Bash" // {
+      default = true;
+    };
+
+    enableFishIntegration = lib.mkEnableOption "auto-activation of devenv environments in Fish" // {
+      default = true;
+    };
+
+    enableZshIntegration = lib.mkEnableOption "auto-activation of devenv environments in Zsh" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(${hook "bash"})"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      ${hook "fish"} | source
+    '';
+
+    programs.zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
+      eval "$(${hook "zsh"})"
+    '';
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -94,6 +94,7 @@ in {
   tests.nix-enable = makeTest ./tests/nix-enable.nix;
   tests.nixpkgs-overlays = makeTest ./tests/nixpkgs-overlays.nix;
   tests.nixpkgs-config-allow-unfree = makeTest ./tests/nixpkgs-config-allow-unfree.nix;
+  tests.programs-devenv = makeTest ./tests/programs-devenv.nix;
   tests.programs-gnupg = makeTest ./tests/programs-gnupg.nix;
   tests.programs-mas = makeTest ./tests/programs-mas.nix;
   tests.programs-mas-no-cleanup = makeTest ./tests/programs-mas-no-cleanup.nix;

--- a/tests/programs-devenv.nix
+++ b/tests/programs-devenv.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  devenv =
+    pkgs.runCommand "devenv-0.0.0" { } ''
+      mkdir -p $out/bin
+      cat > $out/bin/devenv <<'EOF'
+      #!/usr/bin/env bash
+      exit 0
+      EOF
+      chmod +x $out/bin/devenv
+    ''
+    // {
+      meta.mainProgram = "devenv";
+    };
+in
+{
+  programs.bash.enable = true;
+  programs.zsh.enable = true;
+  programs.fish.enable = true;
+
+  programs.devenv = {
+    enable = true;
+    package = devenv;
+  };
+
+  test = ''
+    echo >&2 "checking devenv bash integration in /etc/bashrc"
+    grep 'devenv hook bash' ${config.out}/etc/bashrc
+
+    echo >&2 "checking devenv zsh integration in /etc/zshrc"
+    grep 'devenv hook zsh' ${config.out}/etc/zshrc
+
+    echo >&2 "checking devenv fish integration in /etc/fish/config.fish"
+    grep 'devenv hook fish' ${config.out}/etc/fish/config.fish
+  '';
+}


### PR DESCRIPTION
Adds a `programs.devenv` module that installs devenv and sources its shell hook into bash/zsh/fish `interactiveShellInit` so trusted projects auto-activate on `cd`.

This is the nix-darwin counterpart to the same module in home-manager (nix-community/home-manager#9379) and the pending one in NixOS (nixos/nixpkgs#543412), addressing https://github.com/cachix/devenv/issues/3019

@domenkozar @sandydoo adding you as maintainers to this one as well
