### PR TITLE
gitlab-runner: launchdType, self-deploy, and direct config.toml on darwin

### DIFF
--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -105,8 +105,8 @@ let
             "del(.[] | nulls)"
             "del(.session_server[] | nulls)"
          ])} ${configPath} \
-        > config.toml.new
-      mv config.toml.new ${configPath}
+        > ${configPath}.new
+      mv ${configPath}.new ${configPath}
 
       # make config file readable by service
       chown -R --reference=$HOME $(dirname ${configPath})

--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -4,13 +4,104 @@ with lib;
 let
   cfg = config.services.gitlab-runner;
   hasDocker = config.virtualisation.docker.enable;
-  hashedServices = mapAttrs'
-    (name: service: nameValuePair
-      "${name}_${config.networking.hostName}_${
-        substring 0 12
-        (hashString "md5" (unsafeDiscardStringContext (toJSON service)))}"
-      service)
-    cfg.services;
+  # config.toml is generated directly with tomlq (a real TOML serializer), a pure
+  # function of these options and the one value not known at build time: each
+  # runner's token, taken from its registrationConfigFile at runtime and so kept
+  # out of the store. gitlab-runner run reads and runs whatever [[runners]] the
+  # file defines (https://docs.gitlab.com/runner/commands/), so a modern
+  # authentication token (glrt-) needs no registration step: it authenticates on
+  # its own and the runner fills in its id and system_id from the server on
+  # startup. A deprecated registration token, which register still accepts, is
+  # exchanged for a runner token by a one-time register in the configure script
+  # below; a runner's server-side attributes (tags, run_untagged, access_level,
+  # maximum_timeout) are stored there, the only place they take for either token
+  # type (https://docs.gitlab.com/runner/register/).
+
+  # An attribute set as a config.toml fragment: drop null-valued attributes (TOML
+  # has no null, so an unset optional must not appear) and render the rest as a
+  # JSON object literal, which is also a jq expression. tomlq (-n, null input)
+  # serializes that to TOML, nested [runners.docker] table and arrays included, so
+  # nothing is hand-assembled.
+  tomlObject = attrs: toJSON (filterAttrs (_: v: v != null) attrs);
+
+  globalObject = tomlObject {
+    concurrent = cfg.concurrent;
+    check_interval = cfg.checkInterval;
+    sentry_dsn = cfg.sentryDSN;
+    listen_address = cfg.prometheusListenAddress;
+    session_server = filterAttrs (_: v: v != null) {
+      session_timeout = cfg.sessionServer.sessionTimeout;
+      listen_address = cfg.sessionServer.listenAddress;
+      advertise_address = cfg.sessionServer.advertiseAddress;
+    };
+  };
+
+  # A runner's [[runners]] entry as a jq object, minus the name, url, and token
+  # the configure script splices in at runtime (the name because it is hashed for
+  # a legacy runner and plain for an authentication-token one).
+  runnerObject = service: tomlObject {
+    executor = service.executor;
+    limit = service.limit;
+    request_concurrency = service.requestConcurrency;
+    debug_trace_disabled = service.debugTraceDisabled;
+    environment = mapAttrsToList (n: v: "${n}=${v}") service.environmentVariables;
+    builds_dir = service.buildsDir;
+    clone_url = service.cloneUrl;
+    pre_clone_script = service.preCloneScript;
+    pre_build_script = service.preBuildScript;
+    post_build_script = service.postBuildScript;
+    docker =
+      if hasPrefix "docker" service.executor
+      then (
+        assert assertMsg (service.dockerImage != null)
+          "services.gitlab-runner.services.${service.executor} needs dockerImage for the docker executor";
+        {
+          image = service.dockerImage;
+          disable_cache = service.dockerDisableCache;
+          privileged = service.dockerPrivileged;
+          volumes = service.dockerVolumes;
+          extra_hosts = service.dockerExtraHosts;
+          allowed_images = service.dockerAllowedImages;
+          allowed_services = service.dockerAllowedServices;
+        }
+      )
+      else null;
+  };
+
+  # A legacy runner's identity on GitLab is exactly what register stores
+  # server-side; a change to any of it is a different runner that must be
+  # re-registered, and nothing else (an environment, a limit, a volume) is. The
+  # runner is named over just these fields so that a server-side change moves the
+  # name (forcing a re-register and sweeping the old one) while a local change
+  # leaves it, and so reloads config.toml without re-registering.
+  runnerIdentity = service: {
+    inherit (service)
+      registrationConfigFile registrationFlags
+      tagList runUntagged protected maximumTimeout;
+  };
+  legacyName = name: service:
+    "${name}_${config.networking.hostName}_${
+      substring 0 12
+      (hashString "md5" (unsafeDiscardStringContext
+        (toJSON (runnerIdentity service))))}";
+
+  # The attributes register stores server-side when it exchanges a deprecated
+  # registration token. An authentication token has these set at creation, so
+  # register ignores them there; they are never config.toml fields.
+  registrationServerFlags = service:
+    optional (service.tagList != [ ]) "--tag-list ${escapeShellArg (concatStringsSep "," service.tagList)}"
+    ++ optional service.runUntagged "--run-untagged"
+    ++ optional service.protected "--access-level ref_protected"
+    ++ optional (service.maximumTimeout > 0) "--maximum-timeout ${toString service.maximumTimeout}"
+    ++ service.registrationFlags;
+  # Whether any runner uses the deprecated registration flow. Gates the register
+  # tooling and the unregister sweep so an authentication-only instance carries
+  # neither.
+  hasLegacyRunner = any (service: service.registrationType == "registration") (attrValues cfg.services);
+  # The runner names this configuration registers on GitLab (the deprecated
+  # registration flow only). The unregister sweep keeps GitLab to exactly these.
+  legacyNames = mapAttrsToList (name: service: legacyName name service)
+    (filterAttrs (_: service: service.registrationType == "registration") cfg.services);
   configPath = "$HOME/.gitlab-runner/config.toml";
   configureScript = pkgs.writeShellScriptBin "gitlab-runner-configure" (
     if (cfg.configFile != null) then ''
@@ -20,103 +111,75 @@ let
       chown -R --reference=$HOME $(dirname ${configPath})
     '' else ''
       set -e
-      export CONFIG_FILE=${configPath}
-
-      mkdir -p $(dirname ${configPath})
-
-      # remove no longer existing services
-      gitlab-runner verify --delete
-
-      # current and desired state
-      NEEDED_SERVICES=$(echo ${concatStringsSep " " (attrNames hashedServices)} | tr " " "\n")
-      REGISTERED_SERVICES=$(gitlab-runner list 2>&1 | grep 'Executor' | awk '{ print $1 }')
-
-      # difference between current and desired state
-      NEW_SERVICES=$(grep -vxF -f <(echo "$REGISTERED_SERVICES") <(echo "$NEEDED_SERVICES") || true)
-      OLD_SERVICES=$(grep -vxF -f <(echo "$NEEDED_SERVICES") <(echo "$REGISTERED_SERVICES") || true)
-
-      # register new services
-      ${concatStringsSep "\n" (mapAttrsToList (name: service: ''
-        if echo "$NEW_SERVICES" | grep -xq ${name}; then
-          bash -c ${escapeShellArg (concatStringsSep " \\\n " ([
-            "set -a && source ${service.registrationConfigFile} &&"
-            "gitlab-runner register"
-            "--non-interactive"
-            "--name ${name}"
-            "--executor ${service.executor}"
-            "--limit ${toString service.limit}"
-            "--request-concurrency ${toString service.requestConcurrency}"
-            "--maximum-timeout ${toString service.maximumTimeout}"
-          ] ++ service.registrationFlags
-            ++ optional (service.buildsDir != null)
-            "--builds-dir ${service.buildsDir}"
-            ++ optional (service.cloneUrl != null)
-            "--clone-url ${service.cloneUrl}"
-            ++ optional (service.preCloneScript != null)
-            "--pre-clone-script ${service.preCloneScript}"
-            ++ optional (service.preBuildScript != null)
-            "--pre-build-script ${service.preBuildScript}"
-            ++ optional (service.postBuildScript != null)
-            "--post-build-script ${service.postBuildScript}"
-            ++ optional (service.tagList != [ ])
-            "--tag-list ${concatStringsSep "," service.tagList}"
-            ++ optional service.runUntagged
-            "--run-untagged"
-            ++ optional service.protected
-            "--access-level ref_protected"
-            ++ optional service.debugTraceDisabled
-            "--debug-trace-disabled"
-            ++ map (e: "--env ${escapeShellArg e}") (mapAttrsToList (name: value: "${name}=${value}") service.environmentVariables)
-            ++ optionals (hasPrefix "docker" service.executor) (
-              assert (
-                assertMsg (service.dockerImage != null)
-                  "dockerImage option is required for ${service.executor} executor (${name})");
-              [ "--docker-image ${service.dockerImage}" ]
-              ++ optional service.dockerDisableCache
-              "--docker-disable-cache"
-              ++ optional service.dockerPrivileged
-              "--docker-privileged"
-              ++ map (v: "--docker-volumes ${escapeShellArg v}") service.dockerVolumes
-              ++ map (v: "--docker-extra-hosts ${escapeShellArg v}") service.dockerExtraHosts
-              ++ map (v: "--docker-allowed-images ${escapeShellArg v}") service.dockerAllowedImages
-              ++ map (v: "--docker-allowed-services ${escapeShellArg v}") service.dockerAllowedServices
-            )
-          ))} && sleep 1 || exit 1
-        fi
-      '') hashedServices)}
-
-      # unregister old services
-      for NAME in $(echo "$OLD_SERVICES")
-      do
-        [ ! -z "$NAME" ] && gitlab-runner unregister \
-          --name "$NAME" && sleep 1
+      mkdir -p "$(dirname ${configPath})"
+      ${optionalString hasLegacyRunner ''
+      # Unregister dropped legacy runners, the base module's OLD_SERVICES: a
+      # runner in config.toml named by our "<name>_<host>_<hash>" convention that
+      # this rebuild no longer registers (a removed service, or a server-side
+      # change that moved the hash). Registered names are read with tomlq rather
+      # than parsed out of `gitlab-runner list`, and scoped to our naming so an
+      # operator-owned authentication runner (plain name) is never touched.
+      tomlq -r '.runners[]?.name' "${configPath}" 2>/dev/null | while read -r registered_name; do
+        case "$registered_name" in
+          *_${config.networking.hostName}_????????????)
+            printf '%s\n' ${escapeShellArg (concatStringsSep "\n" legacyNames)} | grep -qxF -- "$registered_name" \
+              || gitlab-runner unregister --config "${configPath}" --name "$registered_name" || true ;;
+        esac
       done
-
-      # update global options
-      tomlq -t \
-         ${escapeShellArg (concatStringsSep " | " [
-            ".check_interval = ${toJSON cfg.checkInterval}"
-            ".concurrent = ${toJSON cfg.concurrent}"
-            ".sentry_dsn = ${toJSON cfg.sentryDSN}"
-            ".listen_address = ${toJSON cfg.prometheusListenAddress}"
-            ".session_server.listen_address = ${toJSON cfg.sessionServer.listenAddress}"
-            ".session_server.advertise_address = ${toJSON cfg.sessionServer.advertiseAddress}"
-            ".session_server.session_timeout = ${toJSON cfg.sessionServer.sessionTimeout}"
-            "del(.[] | nulls)"
-            "del(.session_server[] | nulls)"
-         ])} ${configPath} \
-        > ${configPath}.new
-      mv ${configPath}.new ${configPath}
+      ''}
+      # Generate config.toml with tomlq. url and token are the only runtime
+      # values, sourced from each runner's registrationConfigFile. Whether a
+      # runner uses an authentication token or a deprecated registration token is
+      # declared per runner (registrationType), so this branch is resolved at
+      # build time and runners of either kind share one config.toml.
+      {
+        tomlq -n -t ${escapeShellArg globalObject}
+      ${concatStringsSep "\n" (mapAttrsToList (name: service: ''
+        (
+          . ${service.registrationConfigFile}
+        ${if service.registrationType == "registration" then ''
+          # Deprecated registration token: register exchanges it for a runner
+          # token (reused from config.toml on later rebuilds, so only a
+          # server-side change, which moves the hashed name, re-registers) and
+          # stores the server-side attributes. https://docs.gitlab.com/runner/register/
+          runner_name=${escapeShellArg (legacyName name service)}
+          runner_token="$(tomlq -r ${escapeShellArg "[.runners[]? | select(.name == ${toJSON (legacyName name service)}) | .token][0] // empty"} "${configPath}" 2>/dev/null || true)"
+          if [ -z "$runner_token" ]; then
+            scratch="$(mktemp -d)"
+            gitlab-runner register --config "$scratch/config.toml" --non-interactive \
+              --url "$CI_SERVER_URL" --registration-token "$REGISTRATION_TOKEN" \
+              --name "$runner_name" --executor ${escapeShellArg service.executor} \
+              ${concatStringsSep " " (registrationServerFlags service)}
+            runner_token="$(tomlq -r '.runners[0].token' "$scratch/config.toml")"
+            rm -rf "$scratch"
+          fi
+        '' else ''
+          # Authentication token: written to config.toml as-is, no register; the
+          # runner self-binds on run.
+          runner_name=${escapeShellArg name}
+          runner_token="$REGISTRATION_TOKEN"
+        ''}
+          tomlq -n -t --arg name "$runner_name" --arg url "$CI_SERVER_URL" --arg token "$runner_token" \
+            ${escapeShellArg "{runners: [${runnerObject service} + {name: $name, url: $url, token: $token}]}"}
+        )'') cfg.services)}
+      } > "${configPath}.new"
+      mv "${configPath}.new" "${configPath}"
 
       # make config file readable by service
-      chown -R --reference=$HOME $(dirname ${configPath})
+      chown -R --reference="$HOME" "$(dirname ${configPath})"
     '');
-  # Exec the current-system gitlab-runner (the nix-daemon launchd pattern),
-  # not the pinned store path, so a runner restarted in place comes back on
-  # the deployed version with no plist reload. A normal reload lands the new
-  # binary anyway, so this is transparent unless a caller turns
-  # restartIfChanged off and cycles the runner itself.
-  runnerExec = "/run/current-system/sw/bin/gitlab-runner";
+  # seamlessRestart makes a runner able to deploy the host it runs on. Its plist
+  # is made immutable (below, it embeds the /run/current-system profile, not
+  # store paths), so activation never reloads it (the plist never differs across
+  # closures) and the switch it runs never tears it down mid-job; it picks up
+  # each new deployment on its own graceful restart, running the current-system
+  # gitlab-runner rather than a pinned /nix/store path so that restart lands the
+  # deployed version.
+  selfDeploy = cfg.seamlessRestart;
+  runnerExec =
+    if selfDeploy
+    then "/run/current-system/sw/bin/gitlab-runner"
+    else "${cfg.package}/bin/gitlab-runner";
   startScript = pkgs.writeShellScriptBin "gitlab-runner-start" (
     if cfg.gracefulTermination then ''
       export CONFIG_FILE=${configPath}
@@ -140,7 +203,10 @@ let
   # the logged-in session user respectively.
   serviceEnvironment = { #config.networking.proxy.envVars // {
     NIX_REMOTE = "daemon";
-    NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+    NIX_SSL_CERT_FILE =
+      if selfDeploy
+      then "/run/current-system/sw/etc/ssl/certs/ca-bundle.crt"
+      else "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   };
   servicePath = with pkgs; [
     bash
@@ -160,6 +226,14 @@ let
   serviceScript = ''
     ${configureScript}/bin/gitlab-runner-configure && exec ${startScript}/bin/gitlab-runner-start
   '';
+  # In selfDeploy mode the plist must embed no /nix/store paths, so activation
+  # never rewrites it and it needs no reload. Everything it names resolves
+  # through the current-system profile instead: this service script is installed
+  # into the system profile and run by its profile path, PATH is the profile bin
+  # dir, and the CA bundle is the profile's. A fork or nixpkgs change then moves
+  # only the symlink targets and the plist bytes stay identical, so one bootstrap
+  # ever installs it and every later change lands on the next SIGQUIT cycle.
+  serviceRunnerService = pkgs.writeShellScriptBin "gitlab-runner-service" serviceScript;
   serviceConfigCommon = {
     ProcessType = "Interactive";
     ThrottleInterval = 30;
@@ -209,6 +283,26 @@ in
         the login keychain and the iOS Simulator. Jobs only run while
         that user's session exists, so pair it with automatic login on
         a dedicated CI host.
+      '';
+    };
+    seamlessRestart = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether the runner can deploy the nix-darwin configuration of the
+        host it runs on, for example a CI job that runs `darwin-rebuild
+        switch` on this machine.
+
+        When `true` the runner's launchd plist embeds no `/nix/store` paths:
+        it runs the `gitlab-runner` on the `/run/current-system` profile and
+        resolves its config and CA bundle through that profile. The plist is
+        therefore immutable across closures, so activation never reloads the
+        runner (the switch it runs cannot tear it down mid-job) and the runner
+        picks up each new deployment on its own graceful restart, which the
+        deploy triggers with `launchctl kill SIGQUIT`. Pair it with
+        {option}`services.gitlab-runner.gracefulTermination` so that restart
+        drains the running job rather than aborting it.
       '';
     };
     configFile = mkOption {
@@ -442,6 +536,28 @@ in
               `REGISTRATION_TOKEN=<registration secret>`
             '';
           };
+          registrationType = mkOption {
+            type = types.enum [ "authentication" "registration" ];
+            default = "authentication";
+            description = ''
+              The kind of token {option}`registrationConfigFile` provides.
+
+              `"authentication"` (the default) treats it as a runner
+              authentication token (the `glrt-` prefix), created for the runner
+              in the GitLab UI or API. config.toml is written with the token
+              directly and the runner authenticates on its own; no
+              `gitlab-runner register` runs. From GitLab 18.0 this is the only
+              supported token type.
+
+              `"registration"` treats it as a deprecated registration token,
+              which `gitlab-runner register` exchanges for a runner token,
+              setting the runner's server-side attributes ({option}`tagList`,
+              {option}`runUntagged`, {option}`protected`,
+              {option}`maximumTimeout`) at creation.
+
+              Runners of either type can share one instance.
+            '';
+          };
           registrationFlags = mkOption {
             type = types.listOf types.str;
             default = [ ];
@@ -626,7 +742,8 @@ in
   config = mkIf cfg.enable (mkMerge [ {
 
     warnings = optional (cfg.configFile != null) "services.gitlab-runner.`configFile` is deprecated, please use services.gitlab-runner.`services`.";
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ]
+      ++ optionals selfDeploy (servicePath ++ [ serviceRunnerService pkgs.cacert ]);
   }
 
   (mkIf (cfg.launchdType == "daemon") {
@@ -653,10 +770,13 @@ in
     launchd.daemons.gitlab-runner = {
       environment = serviceEnvironment // {
         HOME = "${config.users.users.gitlab-runner.home}";
-      };
-      path = servicePath;
-      script = serviceScript;
-      serviceConfig = serviceConfigCommon // {
+      } // optionalAttrs selfDeploy { PATH = "/run/current-system/sw/bin"; };
+      path = if selfDeploy then [ ] else servicePath;
+      command = if selfDeploy then "/run/current-system/sw/bin/gitlab-runner-service" else "";
+      script = if selfDeploy then "" else serviceScript;
+      serviceConfig = serviceConfigCommon // optionalAttrs selfDeploy {
+        KeepAlive = true;
+      } // {
         GroupName = "gitlab-runner";
         UserName  = "gitlab-runner";
         WorkingDirectory = config.users.users.gitlab-runner.home;
@@ -666,17 +786,19 @@ in
 
   (mkIf (cfg.launchdType == "agent") {
     launchd.user.agents.gitlab-runner = {
-      environment = serviceEnvironment;
-      path = servicePath;
-      script = serviceScript;
+      environment = serviceEnvironment // optionalAttrs selfDeploy { PATH = "/run/current-system/sw/bin"; };
+      path = if selfDeploy then [ ] else servicePath;
+      command = if selfDeploy then "/run/current-system/sw/bin/gitlab-runner-service" else "";
+      script = if selfDeploy then "" else serviceScript;
       managedBy = "services.gitlab-runner.launchdType";
       serviceConfig = serviceConfigCommon // {
-        # GitLab's documented LaunchAgent sets SessionCreate so code
-        # signing can reach the login keychain, and restarts the runner
-        # only on unsuccessful exit:
+        # GitLab's documented LaunchAgent sets SessionCreate so code signing can
+        # reach the login keychain. It normally restarts the runner only on an
+        # unsuccessful exit; a selfDeploy runner exits cleanly on its graceful
+        # drain and must relaunch, so it keeps KeepAlive on.
         # https://docs.gitlab.com/runner/install/osx/
         SessionCreate = true;
-        KeepAlive.SuccessfulExit = false;
+        KeepAlive = if selfDeploy then true else { SuccessfulExit = false; };
       };
     };
   })

--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -115,10 +115,71 @@ let
     export CONFIG_FILE=${configPath}
     exec gitlab-runner run --working-directory $HOME
   '';
+  # The service definition shared by both launchd placements; HOME (and
+  # with it config.toml) comes from the daemon's dedicated user or from
+  # the logged-in session user respectively.
+  serviceEnvironment = { #config.networking.proxy.envVars // {
+    NIX_REMOTE = "daemon";
+    NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  };
+  servicePath = with pkgs; [
+    bash
+    gawk
+    jq
+    moreutils
+    yq
+    # util-linux
+    cfg.package
+    coreutils
+    gnugrep
+    gnused
+  ] ++ cfg.extraPackages;
+  serviceScript = ''
+    ${configureScript}/bin/gitlab-runner-configure && ${startScript}/bin/gitlab-runner-start
+  '';
+  serviceConfigCommon = {
+    ProcessType = "Interactive";
+    ThrottleInterval = 30;
+
+    # StandardOutPath = "/var/lib/gitlab-runner/out.log";
+    # StandardErrorPath = "/var/lib/gitlab-runner/err.log";
+    # The combination of KeepAlive.NetworkState and WatchPaths
+    # will ensure that buildkite-agent is started on boot, but
+    # after networking is available (so the hostname is
+    # correct).
+    RunAtLoad = true;
+    # KeepAlive.NetworkState = true;
+    WatchPaths = [
+      "/etc/resolv.conf"
+      "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
+    ];
+  };
 in
 {
   options.services.gitlab-runner = {
     enable = mkEnableOption "Gitlab Runner";
+    launchdType = mkOption {
+      type = types.enum [ "daemon" "agent" ];
+      default = "daemon";
+      example = "agent";
+      description = ''
+        The launchd service class the runner is placed in.
+
+        `"daemon"` runs the runner as a system LaunchDaemon under the
+        dedicated `gitlab-runner` user, with no access to any GUI
+        session. This fits session-independent workloads, for example
+        nix or Android builds.
+
+        `"agent"` runs the runner as a LaunchAgent in the logged-in
+        session of {option}`system.primaryUser`, which GitLab documents
+        as the only supported mode on macOS
+        (<https://docs.gitlab.com/runner/install/osx/>).
+        Session-dependent workloads require it: code signing against
+        the login keychain and the iOS Simulator. Jobs only run while
+        that user's session exists, so pair it with automatic login on
+        a dedicated CI host.
+      '';
+    };
     configFile = mkOption {
       type = types.nullOr types.path;
       default = null;
@@ -523,8 +584,13 @@ in
       });
     };
   };
-  config = mkIf cfg.enable {
+  config = mkIf cfg.enable (mkMerge [ {
 
+    warnings = optional (cfg.configFile != null) "services.gitlab-runner.`configFile` is deprecated, please use services.gitlab-runner.`services`.";
+    environment.systemPackages = [ cfg.package ];
+  }
+
+  (mkIf (cfg.launchdType == "daemon") {
     users.users.gitlab-runner =
       { name = "gitlab-runner";
         uid = mkDefault 532;
@@ -545,56 +611,36 @@ in
     #  chown ${toString user.uid}:${toString user.gid} '${user.home}'
     #'';
 
-
-    warnings = optional (cfg.configFile != null) "services.gitlab-runner.`configFile` is deprecated, please use services.gitlab-runner.`services`.";
-    environment.systemPackages = [ cfg.package ];
-
     launchd.daemons.gitlab-runner = {
-      environment = { #config.networking.proxy.envVars // {
+      environment = serviceEnvironment // {
         HOME = "${config.users.users.gitlab-runner.home}";
-        NIX_REMOTE = "daemon";
-        NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       };
-      path = with pkgs; [
-        bash
-        gawk
-        jq
-        moreutils
-        yq
-        # util-linux
-        cfg.package
-        coreutils
-        gnugrep
-        gnused
-      ] ++ cfg.extraPackages;
-
-        script = ''
-            ${configureScript}/bin/gitlab-runner-configure && ${startScript}/bin/gitlab-runner-start
-        '';
-
-        serviceConfig = {
-            ProcessType = "Interactive";
-            ThrottleInterval = 30;
-
-          # StandardOutPath = "/var/lib/gitlab-runner/out.log";
-          # StandardErrorPath = "/var/lib/gitlab-runner/err.log";
-          # The combination of KeepAlive.NetworkState and WatchPaths
-          # will ensure that buildkite-agent is started on boot, but
-          # after networking is available (so the hostname is
-          # correct).
-          RunAtLoad = true;
-        #   KeepAlive.NetworkState = true;
-          WatchPaths = [
-            "/etc/resolv.conf"
-            "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
-          ];
-
-          GroupName = "gitlab-runner";
-          UserName  = "gitlab-runner";
-          WorkingDirectory = config.users.users.gitlab-runner.home;
-        };
-
+      path = servicePath;
+      script = serviceScript;
+      serviceConfig = serviceConfigCommon // {
+        GroupName = "gitlab-runner";
+        UserName  = "gitlab-runner";
+        WorkingDirectory = config.users.users.gitlab-runner.home;
+      };
     };
+  })
+
+  (mkIf (cfg.launchdType == "agent") {
+    launchd.user.agents.gitlab-runner = {
+      environment = serviceEnvironment;
+      path = servicePath;
+      script = serviceScript;
+      managedBy = "services.gitlab-runner.launchdType";
+      serviceConfig = serviceConfigCommon // {
+        # GitLab's documented LaunchAgent sets SessionCreate so code
+        # signing can reach the login keychain, and restarts the runner
+        # only on unsuccessful exit:
+        # https://docs.gitlab.com/runner/install/osx/
+        SessionCreate = true;
+        KeepAlive.SuccessfulExit = false;
+      };
+    };
+  })
     # systemd.services.gitlab-runner = {
     #   description = "Gitlab Runner";
     #   documentation = [ "https://docs.gitlab.com/runner/" ];
@@ -636,7 +682,7 @@ in
     # virtualisation.docker.enable = mkIf (
     #   any (s: s.executor == "docker") (attrValues cfg.services)
     # ) (mkDefault true);
-  };
+  ]);
   imports = [
     (mkRenamedOptionModule [ "services" "gitlab-runner" "packages" ] [ "services" "gitlab-runner" "extraPackages" ] )
     (mkRemovedOptionModule [ "services" "gitlab-runner" "configOptions" ] "Use services.gitlab-runner.services option instead" )

--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -111,10 +111,30 @@ let
       # make config file readable by service
       chown -R --reference=$HOME $(dirname ${configPath})
     '');
-  startScript = pkgs.writeShellScriptBin "gitlab-runner-start" ''
-    export CONFIG_FILE=${configPath}
-    exec gitlab-runner run --working-directory $HOME
-  '';
+  # Exec the current-system gitlab-runner (the nix-daemon launchd pattern),
+  # not the pinned store path, so a runner restarted in place comes back on
+  # the deployed version with no plist reload. A normal reload lands the new
+  # binary anyway, so this is transparent unless a caller turns
+  # restartIfChanged off and cycles the runner itself.
+  runnerExec = "/run/current-system/sw/bin/gitlab-runner";
+  startScript = pkgs.writeShellScriptBin "gitlab-runner-start" (
+    if cfg.gracefulTermination then ''
+      export CONFIG_FILE=${configPath}
+      # launchd only ever sends SIGTERM (a forceful abort to gitlab-runner)
+      # and cannot be told to send another signal, so catch it and forward
+      # SIGQUIT to drain the jobs first. wait returns the moment the trapped
+      # signal fires, so the wait that matters is the one in the handler,
+      # after the forward. The launchd analogue of the systemd unit's
+      # KillSignal = SIGQUIT.
+      ${runnerExec} run --working-directory "$HOME" &
+      runner=$!
+      trap 'kill -QUIT "$runner" 2>/dev/null; wait "$runner"; exit' TERM QUIT INT
+      wait "$runner"
+    '' else ''
+      export CONFIG_FILE=${configPath}
+      exec ${runnerExec} run --working-directory "$HOME"
+    ''
+  );
   # The service definition shared by both launchd placements; HOME (and
   # with it config.toml) comes from the daemon's dedicated user or from
   # the logged-in session user respectively.
@@ -134,8 +154,11 @@ let
     gnugrep
     gnused
   ] ++ cfg.extraPackages;
+  # exec into the runner so gitlab-runner is the launchd job's main process,
+  # not a child of the shell: launchctl kill / signals then reach it directly
+  # (a configure failure still short-circuits and lets KeepAlive retry).
   serviceScript = ''
-    ${configureScript}/bin/gitlab-runner-configure && ${startScript}/bin/gitlab-runner-start
+    ${configureScript}/bin/gitlab-runner-configure && exec ${startScript}/bin/gitlab-runner-start
   '';
   serviceConfigCommon = {
     ProcessType = "Interactive";
@@ -153,6 +176,14 @@ let
       "/etc/resolv.conf"
       "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
     ];
+  } // optionalAttrs cfg.gracefulTermination {
+    # Complete the graceful stop begun by the SIGQUIT-forwarding start script:
+    # AbandonProcessGroup keeps launchd from tearing down the in-flight job
+    # when the runner exits (the KillMode = process analogue), and ExitTimeOut
+    # = 0 lets the drain run instead of the default 20s cap (TimeoutStopSec;
+    # a shutdown is still bounded by macOS).
+    AbandonProcessGroup = true;
+    ExitTimeOut = 0;
   };
 in
 {
@@ -283,6 +314,14 @@ in
         Finish all remaining jobs before stopping.
         If not set gitlab-runner will stop immediatly without waiting
         for jobs to finish, which will lead to failed builds.
+
+        On darwin, where launchd always sends SIGTERM (a forceful abort to
+        gitlab-runner) and offers no way to change that signal, this runs the
+        runner under a SIGQUIT-forwarding start script plus
+        {var}`AbandonProcessGroup` and an unbounded {var}`ExitTimeOut`, so a
+        launchd-initiated stop drains its jobs first. The launchd analogue of
+        the systemd unit's KillSignal = SIGQUIT, KillMode = process and
+        TimeoutStopSec.
       '';
     };
     gracefulTimeout = mkOption {

--- a/modules/services/gitlab-runner.nix
+++ b/modules/services/gitlab-runner.nix
@@ -251,13 +251,20 @@ let
       "/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
     ];
   } // optionalAttrs cfg.gracefulTermination {
-    # Complete the graceful stop begun by the SIGQUIT-forwarding start script:
-    # AbandonProcessGroup keeps launchd from tearing down the in-flight job
-    # when the runner exits (the KillMode = process analogue), and ExitTimeOut
-    # = 0 lets the drain run instead of the default 20s cap (TimeoutStopSec;
-    # a shutdown is still bounded by macOS).
+    # Complete the graceful stop begun by the SIGQUIT-forwarding start script.
+    # AbandonProcessGroup keeps launchd from tearing down the in-flight job when the
+    # runner exits, the KillMode = process analogue.
+    #
+    # ExitTimeOut is how long launchd waits between SIGTERM and SIGKILL when it stops
+    # a job, the TimeoutStopSec analogue, and it holds the drain open. launchd.plist(5)
+    # says zero is read as infinity, but measured on macOS 26.5 it is an immediate
+    # kill: the job's SIGTERM handler never runs at all, so a stop, a bootout, or a
+    # system shutdown aborts the running build rather than draining it, which is the
+    # one thing this option exists to prevent. The value is a count of seconds with no
+    # literal for unbounded, so a year stands in for the gracefulTimeout default of
+    # "infinity": a ceiling no build reaches rather than a bound anyone means to hit.
     AbandonProcessGroup = true;
-    ExitTimeOut = 0;
+    ExitTimeOut = 31536000;
   };
 in
 {


### PR DESCRIPTION
## What

Extends `services.gitlab-runner` on darwin so a runner can host and deploy its own nix-darwin configuration, and generates config.toml directly.

- **`services.gitlab-runner.launchdType`** (`daemon` | `agent`): place the runner as a system LaunchDaemon (default, unchanged) or a LaunchAgent in `system.primaryUser`'s logged-in session. GitLab documents the user-session LaunchAgent as the only supported mode on macOS, for jobs that need the login keychain or an active GUI session.

- **`services.gitlab-runner.seamlessRestart`**: lets a runner deploy the host it runs on. The runner's launchd plist embeds the `/run/current-system` profile rather than pinned `/nix/store` paths (the pattern the launchd module's own `serviceConfig` example shows for `nix-daemon`), so it is byte-identical across closures. Activation never reloads it, so `darwin-rebuild switch` run *by* the runner does not tear it down mid-job; it picks up each new deployment on its own graceful restart, which the deploy triggers with `launchctl kill SIGQUIT`.

- **`gracefulTermination` now works on darwin** (it was previously inert there). launchd only ever sends SIGTERM, a forceful abort to gitlab-runner, and offers no `KillSignal` equivalent, so under `gracefulTermination` the runner runs under a SIGQUIT-forwarding start script plus `AbandonProcessGroup` and an unbounded `ExitTimeOut`: the launchd analogue of the systemd unit's `KillSignal = SIGQUIT`, `KillMode = process`, and `TimeoutStopSec`.

- **Direct config.toml generation.** The configure script writes config.toml with `tomlq` from the declared options, instead of registering each runner with a command-line flag per field and patching the result afterwards. The runner token, the one value not known at build time, is read from `registrationConfigFile` at runtime; `gitlab-runner run` runs whatever `[[runners]]` the file defines.

- **`registrationType`** (per service, default `authentication`): selects the token kind. `authentication` writes an authentication token (`glrt-`) directly, with no `register` step (from GitLab 18.0 the only supported token type). `registration`, for a pre-18.0 server, exchanges a deprecated registration token with a one-time `register`, names the runner over a hash of its server-side identity so a local change reloads config.toml while a server-side change re-registers, and unregisters runners it no longer produces.

## Why

An agent runner with `seamlessRestart = true` can run `darwin-rebuild switch` on the LaunchAgent it executes under: the switch leaves the running agent in place (an immutable plist has no change for activation to reload), the deploy drains and cycles it with `launchctl kill SIGQUIT`, and it returns on the new closure. Generating config.toml directly lets a shell-executor's toolchain be pinned per runner in `config.toml`'s `environment`, so it updates through the deploy rather than a flag-per-field re-register.

## Testing

- `darwinConfigurations.<host>.system.drvPath` evaluates clean for both `registrationType`s and with `seamlessRestart` on and off.
- On aarch64-darwin the configure and start scripts build (`writeShellScriptBin`'s `bash -n` checkPhase), the generated config.toml loads, and the runner verifies `valid` against a live GitLab instance.
- On a real Mac, an agent runner with `seamlessRestart = true` runs `darwin-rebuild switch` on itself without the switch aborting the deploy job, then drains and returns on the new closure via `launchctl kill SIGQUIT`.
