### PR TITLE
services.freenet-core: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -70,6 +70,7 @@
   ./services/dnscrypt-proxy.nix
   ./services/emacs.nix
   ./services/eternal-terminal.nix
+  ./services/freenet-core.nix
   ./services/github-runner
   ./services/gitlab-runner.nix
   ./services/hercules-ci-agent

--- a/modules/services/freenet-core.nix
+++ b/modules/services/freenet-core.nix
@@ -1,0 +1,133 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.freenet-core;
+
+  command = [
+    (lib.getExe cfg.package)
+    "network"
+    "--disable-auto-update"
+    "--network-address=${cfg.networkAddress}"
+    "--network-port=${toString cfg.networkPort}"
+    "--ws-api-address=${cfg.websocketAddress}"
+    "--ws-api-port=${toString cfg.websocketPort}"
+  ]
+  ++ lib.optional (cfg.configDir != null) "--config-dir=${cfg.configDir}"
+  ++ lib.optional (cfg.dataDir != null) "--data-dir=${cfg.dataDir}"
+  ++ lib.optional (cfg.logDir != null) "--log-dir=${cfg.logDir}"
+  ++ cfg.extraArgs;
+in
+{
+  options.services.freenet-core = {
+    enable = lib.mkEnableOption "Freenet node";
+
+    package = lib.mkPackageOption pkgs "freenet-core" { };
+
+    dataDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/Users/alice/Library/Application Support/Freenet";
+      description = ''
+        Directory used to store Freenet node data. When unset, Freenet uses its
+        platform-specific default for the primary user.
+      '';
+    };
+
+    configDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/Users/alice/Library/Application Support/Freenet/config";
+      description = ''
+        Directory used to store Freenet configuration. When unset, Freenet uses
+        its platform-specific default for the primary user.
+      '';
+    };
+
+    logDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/Users/alice/Library/Logs/Freenet";
+      description = ''
+        Directory used to store Freenet logs. When unset, Freenet uses its
+        platform-specific default for the primary user.
+      '';
+    };
+
+    networkAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "::";
+      example = "0.0.0.0";
+      description = "Address on which the Freenet peer-to-peer transport listens.";
+    };
+
+    networkPort = lib.mkOption {
+      type = lib.types.port;
+      default = 31337;
+      example = 31338;
+      description = "UDP port on which the Freenet peer-to-peer transport listens.";
+    };
+
+    websocketAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "::1";
+      description = "Address on which the Freenet HTTP and WebSocket API listens.";
+    };
+
+    websocketPort = lib.mkOption {
+      type = lib.types.port;
+      default = 7509;
+      example = 7510;
+      description = "TCP port on which the Freenet HTTP and WebSocket API listens.";
+    };
+
+    nice = lib.mkOption {
+      type = lib.types.ints.between (-20) 19;
+      default = 10;
+      example = 5;
+      description = "Nice level for the Freenet process.";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        RUST_LOG = "freenet=debug";
+      };
+      description = "Environment variables passed to the Freenet process.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--telemetry-enabled"
+        "--total-bandwidth-limit=10000000"
+      ];
+      description = "Additional command-line arguments passed to Freenet.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.user.agents.freenet-core = {
+      serviceConfig = {
+        ProgramArguments = command;
+        EnvironmentVariables = cfg.environment;
+        KeepAlive.SuccessfulExit = false;
+        RunAtLoad = true;
+        ProcessType = "Background";
+        Nice = cfg.nice;
+        ThrottleInterval = 10;
+        ExitTimeOut = 45;
+      };
+      managedBy = "services.freenet-core.enable";
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.LisaScheers or "LisaScheers" ];
+}

--- a/release.nix
+++ b/release.nix
@@ -114,6 +114,7 @@ in {
   tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
   tests.services-dnscrypt-proxy = makeTest ./tests/services-dnscrypt-proxy.nix;
   tests.services-eternal-terminal = makeTest ./tests/services-eternal-terminal.nix;
+  tests.services-freenet-core = makeTest ./tests/services-freenet-core.nix;
   tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
   tests.services-nix-optimise = makeTest ./tests/services-nix-optimise.nix;
   tests.services-nextdns = makeTest ./tests/services-nextdns.nix;

--- a/tests/services-freenet-core.nix
+++ b/tests/services-freenet-core.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  freenet = pkgs.writeShellScriptBin "freenet" "";
+  plist = "${config.out}/user/Library/LaunchAgents/org.nixos.freenet-core.plist";
+in
+{
+  system.primaryUser = "test-freenet-user";
+
+  services.freenet-core = {
+    enable = true;
+    package = freenet;
+    dataDir = "/var/lib/freenet-data";
+    configDir = "/var/lib/freenet-config";
+    logDir = "/var/log/freenet";
+    networkAddress = "192.0.2.1";
+    networkPort = 31338;
+    websocketAddress = "127.0.0.2";
+    websocketPort = 7510;
+    nice = 5;
+    environment.FREENET_TEST = "enabled";
+    extraArgs = [ "--telemetry-enabled" ];
+  };
+
+  test = ''
+    echo >&2 "checking Freenet service in ~/Library/LaunchAgents"
+    grep "org.nixos.freenet-core" ${plist}
+    grep "${freenet}/bin/freenet" ${plist}
+    grep -- "--disable-auto-update" ${plist}
+    grep -- "--data-dir=/var/lib/freenet-data" ${plist}
+    grep -- "--config-dir=/var/lib/freenet-config" ${plist}
+    grep -- "--log-dir=/var/log/freenet" ${plist}
+    grep -- "--network-address=192.0.2.1" ${plist}
+    grep -- "--network-port=31338" ${plist}
+    grep -- "--ws-api-address=127.0.0.2" ${plist}
+    grep -- "--ws-api-port=7510" ${plist}
+    grep -- "--telemetry-enabled" ${plist}
+    grep "FREENET_TEST" ${plist}
+    grep "enabled" ${plist}
+    grep "<integer>5</integer>" ${plist}
+    grep "<key>KeepAlive</key>" ${plist}
+    grep "<key>SuccessfulExit</key>" ${plist}
+    grep "<false/>" ${plist}
+    grep "<key>ExitTimeOut</key>" ${plist}
+    grep "<integer>45</integer>" ${plist}
+  '';
+}


### PR DESCRIPTION
## What

Add `services.freenet-core` as a per-user launchd agent for the Rust Freenet implementation.

The module exposes the package, platform-default or explicit state paths, P2P and HTTP/WebSocket listeners, process priority, environment variables, and extra arguments. It disables the upstream self-updater so upgrades remain managed by Nix.

The HTTP/WebSocket API defaults to loopback. launchd restarts unsuccessful exits, honors a 45-second graceful shutdown window, and leaves successful exits stopped. The `-core` suffix distinguishes this service from the Java project now known as Hyphanet.

## Dependency

The default `freenet-core` package is provided by [NixOS/nixpkgs#545814](https://github.com/NixOS/nixpkgs/pull/545814).

## Automation disclosure

This contribution was developed with assistance from OpenAI Codex (GPT-5). I reviewed the complete diff, and the commit includes the matching `Assisted-by:` trailer.

## Validation

- Nix formatter and parse checks
- `nix-build release.nix -A tests.services-freenet-core --no-out-link`
- generated LaunchAgent assertions for arguments, bind settings, environment, priority, restart policy, and shutdown timeout