### PR TITLE
Add `system.defaults.loginwindow.HideUserAvatarAndName` option

### DIFF
--- a/modules/system/defaults/loginwindow.nix
+++ b/modules/system/defaults/loginwindow.nix
@@ -15,6 +15,16 @@ with lib;
       '';
     };
 
+    system.defaults.loginwindow.HideUserAvatarAndName = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Apple menu > System Settings > Lock Screen
+
+        Hides the username and photo on the login/lock screen, showing only a password prompt. Default is false.
+      '';
+    };
+
     system.defaults.loginwindow.autoLoginUser = mkOption {
       type = types.nullOr types.str;
       default = null;

--- a/modules/system/defaults/loginwindow.nix
+++ b/modules/system/defaults/loginwindow.nix
@@ -21,7 +21,7 @@ with lib;
       description = ''
         Apple menu > System Settings > Lock Screen
 
-        Hides the username and photo on the login/lock screen, showing only a password prompt. Default is false.
+        Hides the username and photo on the login screen, showing only a password prompt. Default is false.
       '';
     };
 


### PR DESCRIPTION
This adds support to declare the `Show username and photo` option in System Settings > Lock Screen.

I found this option by doing (on macOS 26.6):

```
sudo defaults read /Library/Preferences/com.apple.loginwindow > before

# toggle `Show username and photo` in settings

sudo defaults read /Library/Preferences/com.apple.loginwindow > after

diff before after
```

Output:

```
12c12
<     HideUserAvatarAndName = 0;
---
>     HideUserAvatarAndName = 1;
```